### PR TITLE
Feat[BB-607] : display total number of entity present in a particular collection

### DIFF
--- a/src/client/components/pages/entities/author-table.js
+++ b/src/client/components/pages/entities/author-table.js
@@ -116,12 +116,12 @@ function AuthorTable({authors, showAddedAtColumn, showCheckboxes, selectedEntiti
 	}
 	return (
 		<div>
-			<Row> 
+			<Row>
 				<Col xs={6}>
 					<h2>Authors</h2>
 				</Col>
 				<Col xs={6}>
-					<h2 className="pull-right"> Total : {authors.length}</h2> 
+					<h2 className="pull-right"> Total : {authors.length}</h2>
 				</Col>
 			</Row>
 			{tableContent}

--- a/src/client/components/pages/entities/author-table.js
+++ b/src/client/components/pages/entities/author-table.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 
-const {Table} = bootstrap;
+const {Table, Row, Col} = bootstrap;
 const {transformISODateForDisplay, extractAttribute, getEntityDisambiguation, getEntityLabel} = entityHelper;
 
 function AuthorTableRow({author, showAddedAtColumn, showCheckboxes, selectedEntities, onToggleRow}) {
@@ -116,7 +116,14 @@ function AuthorTable({authors, showAddedAtColumn, showCheckboxes, selectedEntiti
 	}
 	return (
 		<div>
-			<h2>Authors</h2>
+			<Row> 
+				<Col xs={6}>
+					<h2>Authors</h2>
+				</Col>
+				<Col xs={6}>
+					<h2 className="pull-right"> Total : {authors.length}</h2> 
+				</Col>
+			</Row>
 			{tableContent}
 		</div>
 	);

--- a/src/client/components/pages/entities/edition-table.js
+++ b/src/client/components/pages/entities/edition-table.js
@@ -168,12 +168,12 @@ function EditionTable({editions, entity, showAddedAtColumn, showAdd, showCheckbo
 	}
 	return (
 		<div>
-			<Row> 
+			<Row>
 				<Col xs={6}>
 					<h2>Editions</h2>
 				</Col>
 				<Col xs={6}>
-					<h2 className="pull-right"> Total : {editions.length}</h2> 
+					<h2 className="pull-right"> Total : {editions.length}</h2>
 				</Col>
 			</Row>
 			{tableContent}

--- a/src/client/components/pages/entities/edition-table.js
+++ b/src/client/components/pages/entities/edition-table.js
@@ -32,7 +32,7 @@ const {
 	getEditionReleaseDate, getEntityLabel, getEntityDisambiguation,
 	getISBNOfEdition, getEditionFormat
 } = entityHelper;
-const {Button, Table} = bootstrap;
+const {Button, Table, Row, Col} = bootstrap;
 
 function EditionTableRow({edition, showAddedAtColumn, showCheckboxes, selectedEntities, onToggleRow}) {
 	const name = getEntityLabel(edition);
@@ -168,7 +168,14 @@ function EditionTable({editions, entity, showAddedAtColumn, showAdd, showCheckbo
 	}
 	return (
 		<div>
-			<h2>Editions</h2>
+			<Row> 
+				<Col xs={6}>
+					<h2>Editions</h2>
+				</Col>
+				<Col xs={6}>
+					<h2 className="pull-right"> Total : {editions.length}</h2> 
+				</Col>
+			</Row>
 			{tableContent}
 		</div>
 	);

--- a/src/client/components/pages/entities/editionGroup-table.js
+++ b/src/client/components/pages/entities/editionGroup-table.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 
-const {Table} = bootstrap;
+const {Table, Row, Col} = bootstrap;
 
 const {getEntityDisambiguation, getEntityLabel} = entityHelper;
 
@@ -108,7 +108,14 @@ function EditionGroupTable({editionGroups, showAddedAtColumn, showCheckboxes, se
 	}
 	return (
 		<div>
-			<h2>Edition Groups</h2>
+			<Row> 
+				<Col xs={6}>
+					<h2>Edition Groups</h2>
+				</Col>
+				<Col xs={6}>
+					<h2 className="pull-right"> Total : {editionGroups.length}</h2> 
+				</Col>
+			</Row>
 			{tableContent}
 		</div>
 	);

--- a/src/client/components/pages/entities/editionGroup-table.js
+++ b/src/client/components/pages/entities/editionGroup-table.js
@@ -108,12 +108,12 @@ function EditionGroupTable({editionGroups, showAddedAtColumn, showCheckboxes, se
 	}
 	return (
 		<div>
-			<Row> 
+			<Row>
 				<Col xs={6}>
 					<h2>Edition Groups</h2>
 				</Col>
 				<Col xs={6}>
-					<h2 className="pull-right"> Total : {editionGroups.length}</h2> 
+					<h2 className="pull-right"> Total : {editionGroups.length}</h2>
 				</Col>
 			</Row>
 			{tableContent}

--- a/src/client/components/pages/entities/publisher-table.js
+++ b/src/client/components/pages/entities/publisher-table.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 
-const {Table} = bootstrap;
+const {Table, Row, Col} = bootstrap;
 const {transformISODateForDisplay, extractAttribute, getEntityDisambiguation, getEntityLabel} = entityHelper;
 
 function PublisherTableRow({showAddedAtColumn, publisher, showCheckboxes, selectedEntities, onToggleRow}) {
@@ -116,7 +116,14 @@ function PublisherTable({showAddedAtColumn, publishers, showCheckboxes, selected
 	}
 	return (
 		<div>
-			<h2>Publishers</h2>
+			<Row> 
+				<Col xs={6}>
+					<h2>Publishers</h2>
+				</Col>
+				<Col xs={6}>
+					<h2 className="pull-right"> Total : {publishers.length}</h2> 
+				</Col>
+			</Row>
 			{tableContent}
 		</div>
 	);

--- a/src/client/components/pages/entities/publisher-table.js
+++ b/src/client/components/pages/entities/publisher-table.js
@@ -116,12 +116,12 @@ function PublisherTable({showAddedAtColumn, publishers, showCheckboxes, selected
 	}
 	return (
 		<div>
-			<Row> 
+			<Row>
 				<Col xs={6}>
 					<h2>Publishers</h2>
 				</Col>
 				<Col xs={6}>
-					<h2 className="pull-right"> Total : {publishers.length}</h2> 
+					<h2 className="pull-right"> Total : {publishers.length}</h2>
 				</Col>
 			</Row>
 			{tableContent}

--- a/src/client/components/pages/entities/work-table.js
+++ b/src/client/components/pages/entities/work-table.js
@@ -150,12 +150,12 @@ function WorkTable({entity, showAddedAtColumn, works, showAdd, showCheckboxes, s
 	}
 	return (
 		<div>
-			<Row> 
+			<Row>
 				<Col xs={6}>
 					<h2>Works</h2>
 				</Col>
 				<Col xs={6}>
-					<h2 className="pull-right"> Total : {works.length}</h2> 
+					<h2 className="pull-right"> Total : {works.length}</h2>
 				</Col>
 			</Row>
 			{tableContent}

--- a/src/client/components/pages/entities/work-table.js
+++ b/src/client/components/pages/entities/work-table.js
@@ -29,7 +29,7 @@ import React from 'react';
 import {kebabCase as _kebabCase} from 'lodash';
 
 
-const {Button, Table} = bootstrap;
+const {Button, Table, Row, Col} = bootstrap;
 
 const {getEntityDisambiguation, getLanguageAttribute, getEntityLabel} = entityHelper;
 
@@ -150,7 +150,14 @@ function WorkTable({entity, showAddedAtColumn, works, showAdd, showCheckboxes, s
 	}
 	return (
 		<div>
-			<h2>Works</h2>
+			<Row> 
+				<Col xs={6}>
+					<h2>Works</h2>
+				</Col>
+				<Col xs={6}>
+					<h2 className="pull-right"> Total : {works.length}</h2> 
+				</Col>
+			</Row>
 			{tableContent}
 		</div>
 	);


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/browse/BB-607



### Solution
Added indication for Total number of entities present in the given collection.

![rec-tab](https://user-images.githubusercontent.com/43696525/113527880-8f08e280-95dc-11eb-8241-a39a6661fa2e.gif)

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->

src/client/components/pages/entities/author-table.js
src/client/components/pages/entities/edition-table.js
src/client/components/pages/entities/editionGroup-table.js
src/client/components/pages/entities/publisher-table.js
src/client/components/pages/entities/work-table.js