### PR TITLE
BB-432: move duplicate entity warning below sort name

### DIFF
--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -171,7 +171,22 @@ class NameSection extends React.Component {
 							onChange={this.handleNameChange}
 						/>
 					</Col>
+				</Row>
+				<Row>
 					<Col md={6} mdOffset={3}>
+						<SortNameField
+							defaultValue={sortNameValue}
+							empty={isAliasEmpty(
+								nameValue, sortNameValue, languageValue
+							)}
+							error={!validateNameSectionSortName(sortNameValue)}
+							storedNameValue={nameValue}
+							onChange={onSortNameChange}
+						/>
+					</Col>
+				</Row>
+				<Row>
+				    <Col md={6} mdOffset={3}>
 						{isRequiredDisambiguationEmpty(
 							warnIfExists,
 							disambiguationDefaultValue
@@ -212,19 +227,6 @@ class NameSection extends React.Component {
 							</Col>
 						</Row>
 				}
-				<Row>
-					<Col md={6} mdOffset={3}>
-						<SortNameField
-							defaultValue={sortNameValue}
-							empty={isAliasEmpty(
-								nameValue, sortNameValue, languageValue
-							)}
-							error={!validateNameSectionSortName(sortNameValue)}
-							storedNameValue={nameValue}
-							onChange={onSortNameChange}
-						/>
-					</Col>
-				</Row>
 				<Row>
 					<Col md={6} mdOffset={3}>
 						<LanguageField

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -186,7 +186,7 @@ class NameSection extends React.Component {
 					</Col>
 				</Row>
 				<Row>
-				    <Col md={6} mdOffset={3}>
+					<Col md={6} mdOffset={3}>
 						{isRequiredDisambiguationEmpty(
 							warnIfExists,
 							disambiguationDefaultValue


### PR DESCRIPTION
Signed-off-by: Akash Gupta <akashgp9@gmail.com>

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
This PR Fixes: [BB-432](https://tickets.metabrainz.org/browse/BB-432)


### Solution
<!-- What does this PR do to fix the problem? -->
Moved Duplicate Entity Warning below sort name

![Screenshot from 2021-05-05 16-46-43](https://user-images.githubusercontent.com/55311336/117133421-d47a2480-adc1-11eb-81e7-a6d6546466d3.png)



### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->

- [name-section.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/entity-editor/name-section/name-section.js)
