### PR TITLE
Fix Dockerfile certificate dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ ARG BUILD_DEPS=" \
     build-essential \
     python-dev \
     libpq5 \
-    libpq-dev \
-    ca-certificates"
+    libpq-dev"
 
 ARG RUN_DEPS=" \
     bzip2 \
     git \
-    rsync"
+    rsync \
+    ca-certificates"
 
 
 RUN apt-get update && \


### PR DESCRIPTION
The ca-certificates package is needed at runtime so should be in RUN_DEPS rather than the BUILD_DEPS that get remove.
Mistake introduced in #709 