### PR TITLE
Fix permissions issue in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,10 +87,8 @@ ADD ./docker/crontab /etc/cron.d/bookbrainz
 RUN chmod 0644 /etc/cron.d/bookbrainz && crontab -u bookbrainz /etc/cron.d/bookbrainz
 
 # Build JS project and assets
-USER bookbrainz
 RUN ["npm", "run", "build"]
 RUN ["npm", "prune", "--production"]
-USER root
 
 # API target
 FROM bookbrainz-base as bookbrainz-webservice
@@ -107,7 +105,5 @@ RUN chmod 755 /etc/service/webserver/run
 RUN touch /etc/service/webserver/down
 
 # Build API JS
-USER bookbrainz
 RUN ["npm", "run", "build-api-js"]
 RUN ["npm", "prune", "--production"]
-USER root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       dockerfile: Dockerfile
       target: bookbrainz-dev
     restart: unless-stopped
+    user: bookbrainz
     ports:
       - "9099:9099"
     depends_on:


### PR DESCRIPTION
I've been hitting an issue (and same issue reported by other users, see [here for example](https://community.metabrainz.org/t/error-eacces-permission-denied-scandir-root-npm-logs/552031)) with permissions inside the docker container.

In short, in dev setup we should be running the container with the user set to `bookbrainz`.