### PR TITLE
Graph date fix

### DIFF
--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -230,17 +230,19 @@ export async function getEditorActivity(editorId, startDate, Revision, endDate =
 		(revision) => format(new Date(revision.createdAt), 'LLL-yy')
 	);
 	const revisionsCount = _.countBy(revisionDates);
-
+	// eslint-disable-next-line no-console
+	console.log(revisionJSON.size);
+	const temp = revisionJSON.length ? revisionJSON[0].createdAt : Date.now();
+	const temp2 = startDate > temp ? temp : startDate;
 	const allMonthsInInterval = eachMonthOfInterval({
 		end: endDate,
-		start: startDate
+		start: temp2
 	})
 		.map(month => format(new Date(month), 'LLL-yy'))
 		.reduce((accumulator, month) => {
 			accumulator[month] = 0;
 			return accumulator;
 		}, {});
-
 	return {...allMonthsInInterval, ...revisionsCount};
 }
 

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -230,19 +230,19 @@ export async function getEditorActivity(editorId, startDate, Revision, endDate =
 		(revision) => format(new Date(revision.createdAt), 'LLL-yy')
 	);
 	const revisionsCount = _.countBy(revisionDates);
-	// eslint-disable-next-line no-console
-	console.log(revisionJSON.size);
-	const temp = revisionJSON.length ? revisionJSON[0].createdAt : Date.now();
-	const temp2 = startDate > temp ? temp : startDate;
+
+	const firstRevisionDate = revisionJSON.length ? revisionJSON[0].createdAt : Date.now();
+	const activityStart = startDate > firstRevisionDate ? firstRevisionDate : startDate;
 	const allMonthsInInterval = eachMonthOfInterval({
 		end: endDate,
-		start: temp2
+		start: activityStart
 	})
 		.map(month => format(new Date(month), 'LLL-yy'))
 		.reduce((accumulator, month) => {
 			accumulator[month] = 0;
 			return accumulator;
 		}, {});
+
 	return {...allMonthsInInterval, ...revisionsCount};
 }
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/browse/BB-551


### Solution
In user activity graph of editor Monkey, after the current month revisions the graph was showing revisions of year 2015 and 2016  i.e., dates in graph starts from the day of joining but because there were some revisions that were of before the joining date hence dates in graph were not sorted
To make sure the dates are in correct order I changed the start condition of the graph. 
condition is: if the joining date of the editor is greater than the first revision then graph will start from date of first revision otherwise it will start from the joining date.


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
