### PR TITLE
fix[BB-637]: Fixing typo in variable name?

### DIFF
--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -313,7 +313,7 @@ function editionToFormState(edition) {
 		(identifier) => { identifierEditor[identifier.id] = identifier; }
 	);
 
-	const physicalVisible = !(
+	const physicalEnable = !(
 		_.isNull(edition.depth) && _.isNull(edition.height) &&
 		_.isNull(edition.pages) && _.isNull(edition.weight) &&
 		_.isNull(edition.width)
@@ -341,7 +341,7 @@ function editionToFormState(edition) {
 			({id, name}) => ({label: name, value: id})
 		) : [],
 		pages: edition.pages,
-		physicalVisible,
+		physicalEnable,
 		publisher,
 		releaseDate,
 		status: edition.editionStatus && edition.editionStatus.id,


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
BB-637: When editing edition width, height, depth, and weight fields are locked

### Solution
<!-- What does this PR do to fix the problem? -->
I suppose there was typo in variable name  so renamed physicalVisible -> physicalEnable

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/server/routes/entity/edition.js