### PR TITLE
fix(CollectionPage): Added Horizontal rule in CollectionPage

### DIFF
--- a/src/client/components/pages/collection.js
+++ b/src/client/components/pages/collection.js
@@ -232,6 +232,7 @@ class CollectionPage extends React.Component {
 					</Col>
 					<Col md={10}>
 						<h1>{this.props.collection.name}</h1>
+						<hr/>
 						<CollectionAttributes collection={this.props.collection}/>
 					</Col>
 				</Row>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
The Collection Page Name Section does not have a horizontal rule between Collection Title and Collection Attributes. This makes the design of the page appear somewhat inconsistent.
Here's how the Collection Page looks like: 




![Screenshot from 2022-01-03 21-38-20](https://user-images.githubusercontent.com/56965261/147955219-305ba930-0e9b-40bf-8041-4c6e8e403cc1.png)

Here's how other entities look like: 



![Screenshot from 2022-01-03 21-57-22](https://user-images.githubusercontent.com/56965261/147955152-d8e1b4c5-de45-4051-a569-268da4ce99d6.png)

Here's how the Collection Page should look like:


![Screenshot from 2022-01-03 21-57-17](https://user-images.githubusercontent.com/56965261/147955206-02fdf986-ab25-4212-98d5-6e43b4ca3b05.png)





### Solution
Added a Horizontal Rule between the title and attributes of the Collection in collection page



