### PR TITLE
Fix(BB-636): displaying show more button only when necessary

### DIFF
--- a/src/client/components/pages/entities/annotation.js
+++ b/src/client/components/pages/entities/annotation.js
@@ -25,10 +25,24 @@ import React from 'react';
 class EntityAnnotation extends React.Component {
 	constructor(props) {
 	  super(props);
-
+	  this.preRef = React.createRef();
 	  this.state = {
-			open: false
+			open: false,
+			show: true
 	  };
+	}
+
+
+	componentDidMount() {
+		const {annotation} = this.props.entity;
+		if (!annotation || !annotation.content) {
+			return;
+		}
+		const spanElement = document.querySelector('pre span');
+		if (spanElement.offsetHeight < this.preRef.current.offsetHeight) {
+			// eslint-disable-next-line react/no-did-mount-set-state
+			this.setState({open: false, show: false});
+		}
 	}
 
 	handleToggleCollapse = () => {
@@ -46,11 +60,12 @@ class EntityAnnotation extends React.Component {
 				<Col md={12}>
 					<h2>Annotation</h2>
 					<Collapse in={this.state.open}>
-						<pre className="annotation-content">{stringToHTMLWithLinks(annotation.content)}</pre>
+						<pre className="annotation-content" ref={this.preRef} >{stringToHTMLWithLinks(annotation.content)}</pre>
 					</Collapse>
+					{this.state.show &&
 					<Button bsStyle="link" onClick={this.handleToggleCollapse}>
 						Show {this.state.open ? 'less' : 'more…'}
-					</Button>
+					</Button>}
 					<p className="text-muted">Last modified: <span title={formatDate(lastModifiedDate, true)}>{formatDate(lastModifiedDate)}</span>
 						<span className="small"> (revision <a href={`/revision/${annotation.lastRevisionId}`}>#{annotation.lastRevisionId}</a>)</span>
 					</p>

--- a/src/client/components/pages/entities/annotation.js
+++ b/src/client/components/pages/entities/annotation.js
@@ -41,7 +41,7 @@ class EntityAnnotation extends React.Component {
 		const spanElement = document.querySelector('.annotation-content span');
 		if (spanElement.offsetHeight < this.annotationContentRef.current.offsetHeight) {
 			// eslint-disable-next-line react/no-did-mount-set-state
-			this.setState({open: false, showButton: false});
+			this.setState({open: true, showButton: false});
 		}
 	}
 

--- a/src/client/components/pages/entities/annotation.js
+++ b/src/client/components/pages/entities/annotation.js
@@ -25,10 +25,10 @@ import React from 'react';
 class EntityAnnotation extends React.Component {
 	constructor(props) {
 	  super(props);
-	  this.preRef = React.createRef();
+	  this.annotationContentRef = React.createRef();
 	  this.state = {
 			open: false,
-			show: true
+			showButton: true
 	  };
 	}
 
@@ -38,10 +38,10 @@ class EntityAnnotation extends React.Component {
 		if (!annotation || !annotation.content) {
 			return;
 		}
-		const spanElement = document.querySelector('pre span');
-		if (spanElement.offsetHeight < this.preRef.current.offsetHeight) {
+		const spanElement = document.querySelector('.annotation-content span');
+		if (spanElement.offsetHeight < this.annotationContentRef.current.offsetHeight) {
 			// eslint-disable-next-line react/no-did-mount-set-state
-			this.setState({open: false, show: false});
+			this.setState({open: false, showButton: false});
 		}
 	}
 
@@ -60,9 +60,9 @@ class EntityAnnotation extends React.Component {
 				<Col md={12}>
 					<h2>Annotation</h2>
 					<Collapse in={this.state.open}>
-						<pre className="annotation-content" ref={this.preRef} >{stringToHTMLWithLinks(annotation.content)}</pre>
+						<pre className="annotation-content" ref={this.annotationContentRef} >{stringToHTMLWithLinks(annotation.content)}</pre>
 					</Collapse>
-					{this.state.show &&
+					{this.state.showButton &&
 					<Button bsStyle="link" onClick={this.handleToggleCollapse}>
 						Show {this.state.open ? 'less' : 'more…'}
 					</Button>}


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
BB-636: Show more link should be hidden in small annotations.

### Solution
<!-- What does this PR do to fix the problem? -->
Compare span height with parent container for toggling show more button.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
1. src/client/components/pages/entities/annotation.js