### PR TITLE
feat(call-to-action): Replace Edition Group with Series

### DIFF
--- a/src/client/components/pages/parts/call-to-action.js
+++ b/src/client/components/pages/parts/call-to-action.js
@@ -68,11 +68,11 @@ function CallToAction(props) {
 					</Button>
 					<Button
 						className="padding-bottom-1 padding-sides-2 padding-top-1"
-						href={`/edition-group/create${nameQueryParameter}`}
+						href={`/series/create${nameQueryParameter}`}
 						variant="secondary"
 					>
-						{genEntityIconHTMLElement('EditionGroup', '3x', false)}
-						<div className="margin-top-d4">Edition Group</div>
+						{genEntityIconHTMLElement('Series', '3x', false)}
+						<div className="margin-top-d4">Series</div>
 					</Button>
 					<Button
 						className="padding-bottom-1 padding-sides-2 padding-top-1"

--- a/src/server/routes/entity/series.js
+++ b/src/server/routes/entity/series.js
@@ -92,6 +92,15 @@ router.get(
 			'series', req, res, {}
 		));
 
+		props.initialState.nameSection = {
+			disambiguation: '',
+			exactMatches: null,
+			language: null,
+			name: req.query?.name ?? '',
+			searchResults: null,
+			sortName: ''
+		};
+
 		return res.send(target({
 			markup,
 			props: escapeProps(props),


### PR DESCRIPTION
Suggested in https://tickets.metabrainz.org/browse/BB-513

Edition Groups are created automatically when creating an Edition, so there is less point in having this shorcut in the call to action.
However the new Series entity was completely missing.