### PR TITLE
Bootstrap4 migration tweaks

### DIFF
--- a/src/client/stylesheets/style.scss
+++ b/src/client/stylesheets/style.scss
@@ -38,9 +38,15 @@ $disabled-color: lighten($disabled-bg,15%);
 	background: rgba(255, 255, 255, 1);
 	margin-bottom: 0px;
 	padding-right: 0px;
-	.navbar-nav > .disabled > a {
-		color: $disabled-color;
-		background: $disabled-bg;
+	.navbar-nav {
+		// The following prevents menu items from wrapping to two lines (icon on top text on the bottom)
+		// in browsers sizes between collapsed menu and enough horizontal space for all menu items
+		white-space: nowrap;
+		
+		& > .disabled > a {
+			color: $disabled-color;
+			background: $disabled-bg;
+		}
 	}
 }
 

--- a/src/client/stylesheets/style.scss
+++ b/src/client/stylesheets/style.scss
@@ -301,9 +301,7 @@ a.contact-text:visited {
 /* react-datepicker styling */
 .form-group {
 	.responsive-date-field{
-		width: 100%;
-		display: flex;
-		flex-wrap: wrap;
+		width: 18em;
 		.year-field{
 			width:4em;
 		}


### PR DESCRIPTION
### Problem
A couple of minor things changed with the migration to Bootstrap4 in #769 

- the date inputs have become much larger (the date input component now fills available space)
![image](https://user-images.githubusercontent.com/6179856/151997605-736da44b-ff3e-479d-813a-b944a61232a9.png)

- behavior of the navbar items when there isn't enough horizontal space (in very specific conditions: screen width > 992px and < 1091px, on pages other than index)
![image](https://user-images.githubusercontent.com/6179856/151997014-63d606b0-8533-4158-83f2-df1688ba5be4.png)


### Solution
Just a couple of CSS tweaks did the trick:

- limit date input component width (copied size from pre-migration CSS)
![image](https://user-images.githubusercontent.com/6179856/151997890-bcf94911-6b34-4264-b057-e8caaad360ce.png)

- `white-space: nowrap;` on the menu items
![image](https://user-images.githubusercontent.com/6179856/151998092-297b355e-88cf-4396-98e7-781c389d69e3.png)
With flexbox, search input will take less space if there is a lack of space instead of the menu item wrapping.

### Areas of Impact
src/client/stylesheets/style.scss
