### PR TITLE
Move common code to /common folder

### DIFF
--- a/src/client/components/pages/parts/pager.js
+++ b/src/client/components/pages/parts/pager.js
@@ -17,10 +17,10 @@
  */
 
 import * as bootstrap from 'react-bootstrap';
-import * as utils from '../../../../server/helpers/utils';
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import {getNextEnabledAndResultsArray} from '../../../../common/helpers/utils';
 import {isFunction} from 'lodash';
 import request from 'superagent';
 
@@ -106,7 +106,7 @@ class PagerElement extends React.Component {
 		request.get(`${this.props.paginationUrl}?${searchParams.toString()}`)
 			.then((res) => JSON.parse(res.text))
 			.then((data) => {
-				const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(data, newSize);
+				const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(data, newSize);
 				this.setState({
 					from: newFrom,
 					nextEnabled,

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -37,7 +37,7 @@ import {
 } from './actions';
 
 import {Alert, Button, Col, ListGroup, Row} from 'react-bootstrap';
-import {DateObject, isNullDate} from '../../helpers/utils';
+import {DateObject, entityToOption, isNullDate} from '../../helpers/utils';
 import type {List, Map} from 'immutable';
 import {faClone, faExternalLinkAlt, faSearch} from '@fortawesome/free-solid-svg-icons';
 import {
@@ -60,7 +60,6 @@ import NumericField from '../common/numeric-field';
 import Select from 'react-select';
 import _ from 'lodash';
 import {connect} from 'react-redux';
-import {entityToOption} from '../../../server/helpers/utils';
 import makeImmutable from '../common/make-immutable';
 
 

--- a/src/client/entity-editor/entity-merge.tsx
+++ b/src/client/entity-editor/entity-merge.tsx
@@ -32,7 +32,7 @@ import SubmissionSection from './submission-section/submission-section';
 import _ from 'lodash';
 import {connect} from 'react-redux';
 import {faAngleDoubleLeft} from '@fortawesome/free-solid-svg-icons';
-import {getEntityLink} from '../../server/helpers/utils';
+import {getEntityLink} from '../../common/helpers/utils';
 import {submit} from './submission-section/actions';
 
 

--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -45,7 +45,7 @@ import {NumberAttribute} from './attributes';
 import ReactSelect from 'react-select';
 import Relationship from './relationship';
 import _ from 'lodash';
-import {getEntityLink} from '../../../server/helpers/utils';
+import {getEntityLink} from '../../../common/helpers/utils';
 
 
 function isValidRelationship(relationship: _Relationship) {

--- a/src/client/entity-editor/relationship-editor/relationship.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship.tsx
@@ -23,7 +23,7 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import Entity from '../common/entity';
 import RelationshipAttribute from './relationship-attribute';
 import _ from 'lodash';
-import {getEntityLink} from '../../../server/helpers/utils';
+import {getEntityLink} from '../../../common/helpers/utils';
 
 
 function getEntityObjectForDisplay(entity: _Entity, makeLink: boolean) {

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -93,6 +93,17 @@ export function sortRelationshipOrdinal(sortByProperty: string) {
 }
 
 
+/**
+ * Returns an API path for interacting with the given Bookshelf entity model
+ *
+ * @param {object} entity - Entity object
+ * @returns {string} - URL path to interact with entity
+ */
+export function getEntityLink(entity: {type: string, bbid: string}): string {
+	return `/${_.kebabCase(entity.type)}/${entity.bbid}`;
+}
+
+
 export function getNextEnabledAndResultsArray(array, size) {
 	if (array.length > size) {
 		while (array.length > size) {

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -1,5 +1,7 @@
 import {Relationship, RelationshipForDisplay} from '../../client/entity-editor/relationship-editor/types';
 
+import {kebabCase} from 'lodash';
+
 /**
  * Regular expression for valid BookBrainz UUIDs (bbid)
  *
@@ -100,7 +102,7 @@ export function sortRelationshipOrdinal(sortByProperty: string) {
  * @returns {string} - URL path to interact with entity
  */
 export function getEntityLink(entity: {type: string, bbid: string}): string {
-	return `/${_.kebabCase(entity.type)}/${entity.bbid}`;
+	return `/${kebabCase(entity.type)}/${entity.bbid}`;
 }
 
 

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -91,3 +91,20 @@ export function sortRelationshipOrdinal(sortByProperty: string) {
 		return value1.localeCompare(value2, undefined, {numeric: true});
 	};
 }
+
+
+export function getNextEnabledAndResultsArray(array, size) {
+	if (array.length > size) {
+		while (array.length > size) {
+			array.pop();
+		}
+		return {
+			newResultsArray: array,
+			nextEnabled: true
+		};
+	}
+	return {
+		newResultsArray: array,
+		nextEnabled: false
+	};
+}

--- a/src/server/helpers/render.ts
+++ b/src/server/helpers/render.ts
@@ -18,9 +18,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as utils from './utils';
-
 import {ENTITY_TYPE_ICONS} from '../../client/helpers/entity';
+import {getEntityLink} from '../../common/helpers/utils';
 import _ from 'lodash';
 
 
@@ -88,7 +87,7 @@ function renderRelationship(relationship: Relationship) {
 			// Linkify source and target based on default alias
 			const name = _.get(entity, 'defaultAlias.name', '(unnamed)');
 			const entityIcon = `<i class="fa fa-${ENTITY_TYPE_ICONS[entity.type]} margin-right-0-5"></i>`;
-			return `${entityIcon}<a href="${utils.getEntityLink(entity)}">${name}</a>`;
+			return `${entityIcon}<a href="${getEntityLink(entity)}">${name}</a>`;
 		})
 	};
 

--- a/src/server/helpers/render.ts
+++ b/src/server/helpers/render.ts
@@ -18,9 +18,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import {get, isString} from 'lodash';
+
 import {ENTITY_TYPE_ICONS} from '../../client/helpers/entity';
 import {getEntityLink} from '../../common/helpers/utils';
-import _ from 'lodash';
 
 
 type EntityInRelationship = {
@@ -63,7 +64,7 @@ type Relationship = {
 function renderRelationship(relationship: Relationship) {
 	const inputsInvalid =
 		!relationship.source || !relationship.target ||
-		!_.isString(_.get(relationship, 'type.linkPhrase'));
+		!isString(get(relationship, 'type.linkPhrase'));
 	if (inputsInvalid) {
 		throw new TypeError(
 			`Invalid inputs to renderRelationship:\n${
@@ -85,7 +86,7 @@ function renderRelationship(relationship: Relationship) {
 			relationship.target
 		].map((entity) => {
 			// Linkify source and target based on default alias
-			const name = _.get(entity, 'defaultAlias.name', '(unnamed)');
+			const name = get(entity, 'defaultAlias.name', '(unnamed)');
 			const entityIcon = `<i class="fa fa-${ENTITY_TYPE_ICONS[entity.type]} margin-right-0-5"></i>`;
 			return `${entityIcon}<a href="${getEntityLink(entity)}">${name}</a>`;
 		})

--- a/src/server/helpers/utils.ts
+++ b/src/server/helpers/utils.ts
@@ -170,21 +170,6 @@ export function getAdditionalRelations(modelType) {
 	return [];
 }
 
-export function getNextEnabledAndResultsArray(array, size) {
-	if (array.length > size) {
-		while (array.length > size) {
-			array.pop();
-		}
-		return {
-			newResultsArray: array,
-			nextEnabled: true
-		};
-	}
-	return {
-		newResultsArray: array,
-		nextEnabled: false
-	};
-}
 
 /**
  * Takes an entity and converts it to a format acceptable to react-select.

--- a/src/server/helpers/utils.ts
+++ b/src/server/helpers/utils.ts
@@ -22,16 +22,6 @@
 import _ from 'lodash';
 
 
-/**
- * Returns an API path for interacting with the given Bookshelf entity model
- *
- * @param {object} entity - Entity object
- * @returns {string} - URL path to interact with entity
- */
-export function getEntityLink(entity: {type: string, bbid: string}): string {
-	return `/${_.kebabCase(entity.type)}/${entity.bbid}`;
-}
-
 export function getDateBeforeDays(days) {
 	const date = new Date();
 	date.setDate(date.getDate() - days);

--- a/src/server/routes/collection.js
+++ b/src/server/routes/collection.js
@@ -33,6 +33,7 @@ import UserCollectionForm from '../../client/components/forms/userCollection';
 import {collectionCreateOrEditHandler} from '../helpers/collectionRouteUtils';
 import express from 'express';
 import {getCollectionItems} from '../helpers/collections';
+import {getNextEnabledAndResultsArray} from '../../common/helpers/utils';
 import log from 'log';
 import target from '../templates/target';
 
@@ -126,7 +127,7 @@ router.get('/:collectionId', auth.isAuthenticatedForCollectionView, async (req, 
 		// fetch 1 more bbid to check next enabled for pagination
 		const items = await getCollectionItems(collection.id, from, size + 1, orm);
 		// get next enabled for pagination
-		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(items, size);
+		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(items, size);
 		// load entities from bbids
 		const entitiesPromise = newResultsArray.map(async item => ({
 			addedAt: item.added_at,

--- a/src/server/routes/collection.js
+++ b/src/server/routes/collection.js
@@ -23,7 +23,6 @@ import * as handler from '../helpers/handler';
 import * as middleware from '../helpers/middleware';
 import * as propHelpers from '../../client/helpers/props';
 import * as search from '../../common/helpers/search';
-import * as utils from '../helpers/utils';
 import {escapeProps, generateProps} from '../helpers/props';
 import CollectionPage from '../../client/components/pages/collection';
 import Layout from '../../client/containers/layout';

--- a/src/server/routes/collections.js
+++ b/src/server/routes/collections.js
@@ -18,7 +18,6 @@
 import * as commonUtils from '../../common/helpers/utils';
 import * as error from '../../common/helpers/error';
 import * as propHelpers from '../../client/helpers/props';
-import * as utils from '../helpers/utils';
 import {escapeProps, generateProps} from '../helpers/props';
 import CollectionsPage from '../../client/components/pages/collections';
 import Layout from '../../client/containers/layout';

--- a/src/server/routes/collections.js
+++ b/src/server/routes/collections.js
@@ -47,7 +47,7 @@ router.get('/', async (req, res, next) => {
 		const {user} = req;
 		// fetch 1 more collections than required to check nextEnabled
 		const orderedRevisions = await getOrderedPublicCollections(from, size + 1, type, orm);
-		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(orderedRevisions, size);
+		const {newResultsArray, nextEnabled} = commonUtils.getNextEnabledAndResultsArray(orderedRevisions, size);
 
 		const props = generateProps(req, res, {
 			entityTypes,

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -23,7 +23,6 @@ import * as error from '../../common/helpers/error';
 import * as handler from '../helpers/handler';
 import * as propHelpers from '../../client/helpers/props';
 import * as search from '../../common/helpers/search';
-import * as utils from '../helpers/utils';
 import {eachMonthOfInterval, format, isAfter, isValid} from 'date-fns';
 import {escapeProps, generateProps} from '../helpers/props';
 import AchievementsTab from '../../client/components/pages/parts/editor-achievements';

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -331,7 +331,7 @@ router.get('/:id/revisions', async (req, res, next) => {
 			await Promise.all([orderedRevisionsPromise, editorJSONPromise]);
 
 		const {newResultsArray, nextEnabled} =
-			utils.getNextEnabledAndResultsArray(orderedRevisions, size);
+			commonUtils.getNextEnabledAndResultsArray(orderedRevisions, size);
 
 		const props = generateProps(req, res, {
 			editor: editorJSON,
@@ -522,7 +522,7 @@ router.get('/:id/collections', async (req, res, next) => {
 
 		// fetch 1 more collections than required to check nextEnabled
 		const orderedCollections = await getOrderedCollectionsForEditorPage(from, size + 1, type, req);
-		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(orderedCollections, size);
+		const {newResultsArray, nextEnabled} = commonUtils.getNextEnabledAndResultsArray(orderedCollections, size);
 		const editor = await new Editor({id: req.params.id}).fetch();
 		const editorJSON = await getEditorTitleJSON(editor.toJSON(), TitleUnlock);
 

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -200,7 +200,7 @@ export async function displayRevisions(
 	try {
 		// get 1 more revision than required to check nextEnabled
 		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, from, size + 1, RevisionModel, bbid);
-		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(orderedRevisions, size);
+		const {newResultsArray, nextEnabled} = commonUtils.getNextEnabledAndResultsArray(orderedRevisions, size);
 		const props = generateProps(req, res, {
 			from,
 			nextEnabled,

--- a/src/server/routes/revisions.js
+++ b/src/server/routes/revisions.js
@@ -17,7 +17,6 @@
  */
 
 import * as propHelpers from '../../client/helpers/props';
-import * as utils from '../helpers/utils';
 import {escapeProps, generateProps} from '../helpers/props';
 import Layout from '../../client/containers/layout';
 import React from 'react';

--- a/src/server/routes/revisions.js
+++ b/src/server/routes/revisions.js
@@ -24,6 +24,7 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import RevisionsPage from '../../client/components/pages/revisions';
 import express from 'express';
+import {getNextEnabledAndResultsArray} from '../../common/helpers/utils';
 import {getOrderedRevisions} from '../helpers/revisions';
 import target from '../templates/target';
 
@@ -67,7 +68,7 @@ router.get('/', async (req, res, next) => {
 	try {
 		// fetch 1 more revision than required to check nextEnabled
 		const orderedRevisions = await getOrderedRevisions(from, size + 1, orm);
-		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(orderedRevisions, size);
+		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(orderedRevisions, size);
 		return render(newResultsArray, nextEnabled);
 	}
 	catch (err) {

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -23,7 +23,6 @@ import * as error from '../../common/helpers/error';
 import * as handler from '../helpers/handler';
 import * as propHelpers from '../../client/helpers/props';
 import * as search from '../../common/helpers/search';
-import * as utils from '../helpers/utils';
 
 import {keys as _keys, snakeCase as _snakeCase, isNil} from 'lodash';
 import {escapeProps, generateProps} from '../helpers/props';

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -56,7 +56,7 @@ router.get('/', (req, res, next) => {
 		}))
 		.then((searchResults) => {
 			const entityTypes = _keys(commonUtils.getEntityModels(orm));
-			const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(searchResults.initialResults, size);
+			const {newResultsArray, nextEnabled} = commonUtils.getNextEnabledAndResultsArray(searchResults.initialResults, size);
 			searchResults.initialResults = newResultsArray;
 
 			const props = generateProps(req, res, {

--- a/test/src/server/helpers/utils.js
+++ b/test/src/server/helpers/utils.js
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import {getNextEnabledAndResultsArray} from '../../../../src/server/helpers/utils';
+import {getNextEnabledAndResultsArray} from '../../../../src/common/helpers/utils';
 
 
 const {expect} = chai;


### PR DESCRIPTION
There are some instance in the codebase where from the client-side code we are importing code from the server-side code folder (instead of the existing /common folder).

This can create some issues with Webpack 5 (with [removal of auto-injected NodeJS polyfills](https://github.com/webpack/changelog-v5#automatic-nodejs-polyfills-removed)), and shouldn't be done anyway.
Exhibit A: https://pastebin.com/hymEgHgB
Along the lines of:
```
Module not found: Error: Can't resolve 'assert' in '/Users/Lenore/Work/Brainz/BookBrainz/bookbrainz-site-api/node_modules/@elastic/elasticsearch/api'
 
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.
 
If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "assert": require.resolve("assert/") }'
	- install 'assert'
```

This PR moves common utility functions to the src/common folder so it can be imported into src/client as well as src/server.