### PR TITLE
Fix(BB-643): Setting initialState in correct place

### DIFF
--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -159,7 +159,14 @@ router.get(
 
 		function render(props) {
 			const {initialState} = props;
-
+			initialState.nameSection = {
+				disambiguation: '',
+				exactMatches: null,
+				language: null,
+				name: req.query?.name ?? '',
+				searchResults: null,
+				sortName: ''
+			};
 			let relationshipTypeId;
 			let initialRelationshipIndex = 0;
 
@@ -187,14 +194,6 @@ router.get(
 				relationshipTypeId = RelationshipTypes.EditionContainsWork;
 				addInitialRelationship(props, relationshipTypeId, initialRelationshipIndex++, props.work);
 			}
-			props.initialState.nameSection = {
-				disambiguation: '',
-				exactMatches: null,
-				language: null,
-				name: req.query?.name ?? '',
-				searchResults: null,
-				sortName: ''
-			};
 			const editorMarkup = entityEditorMarkup(props);
 			const {markup} = editorMarkup;
 			const updatedProps = editorMarkup.props;


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
BB-643: Beta: "Add edition" is not pre-populated from work.

### Solution
<!-- What does this PR do to fix the problem? -->
setting initialState in correct place

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/server/routes/entity/edition.js