### PR TITLE
fix(bs4): Place tooltips to the right in modal header

### DIFF
--- a/src/client/components/forms/deletion.js
+++ b/src/client/components/forms/deletion.js
@@ -185,6 +185,7 @@ class EntityDeletionForm extends React.Component {
 											<OverlayTrigger
 												delay={50}
 												overlay={deletionTooltip}
+												placement="right"
 											>
 												<FontAwesomeIcon
 													className="margin-left-0-5"

--- a/src/client/entity-editor/alias-editor/alias-editor.js
+++ b/src/client/entity-editor/alias-editor/alias-editor.js
@@ -67,6 +67,7 @@ const AliasEditor = ({
 		<OverlayTrigger
 			delay={50}
 			overlay={<Tooltip id="alias-editor-tooltip">{helpText}</Tooltip>}
+			placement="right"
 		>
 			<FontAwesomeIcon
 				className="fa-sm"

--- a/src/client/entity-editor/identifier-editor/identifier-editor.js
+++ b/src/client/entity-editor/identifier-editor/identifier-editor.js
@@ -64,6 +64,7 @@ const IdentifierEditor = ({
 		<OverlayTrigger
 			delay={50}
 			overlay={<Tooltip id="identifier-editor-tooltip">{helpText}</Tooltip>}
+			placement="right"
 		>
 			<FontAwesomeIcon
 				className="fa-sm"


### PR DESCRIPTION
### Problem
Tooltips are rendered by default on top of their OverlayTrigger, and for modal headers the tooltips appear mostly off-screen:
![image](https://user-images.githubusercontent.com/6179856/156216863-f6e8761c-d4bf-40f2-8026-f654db960ba6.png)



### Solution
Adds `placement="right"` property to OverlayTrigger components that appear in modal headers.
Other OverlayTriggers remain untouched as we don't have the issue mentioned above.

![image](https://user-images.githubusercontent.com/6179856/156217015-a1d8f2e6-f81b-4970-a19f-433a1f37b364.png)


### Areas of Impact
```
src/client/components/forms/deletion.js
src/client/entity-editor/alias-editor/alias-editor.js
src/client/entity-editor/identifier-editor/identifier-editor.js
```