### PR TITLE
fix(bs4): Make exactMatches ListGroupItems links

### DIFF
--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -185,6 +185,7 @@ class NameSection extends React.Component {
 									{exactMatches.map((match) =>
 										(
 											<ListGroup.Item
+												action
 												href={`/${_.kebabCase(entityType)}/${match.bbid}`}
 												key={`${match.bbid}`}
 												rel="noopener noreferrer" target="_blank"


### PR DESCRIPTION
### Problem
As reported [in the forums](https://community.metabrainz.org/t/bug-after-changes/575062) the possible duplicate entities are not clickable anymore.
![image](https://user-images.githubusercontent.com/6179856/156626223-e948112e-2329-475c-9a46-611b9ff490cb.png)

introduced in the Bootstrap v4 migration: 30518cacd058d63f09d54d1b5fff625c254ce294


### Solution
Simply adding the `action` boolean prop turns the list group item into an anchor tag.
From [react-bootstrap docs](https://react-bootstrap-v4.netlify.app/components/list-group/):
>Toggle the action prop to create actionable list group items, with disabled, hover and active styles. List item actions will render a <button> or <a> (depending on the presence of an href) by default 

This component is the only ListGroup.Item that has an `href` and that we use as a link.

### Areas of Impact
src/client/entity-editor/name-section/name-section.js
