### PR TITLE
fix(entity-editor): Edition: search for EditionGroups with same name

### DIFF
--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -202,7 +202,7 @@ function EditionSection({
 
 	const {isValid: isValidReleaseDate, errorMessage: dateErrorMessage} = validateEditionSectionReleaseDate(releaseDateValue);
 
-	const hasmatchingNameEditionGroups = Array.isArray(matchingNameEditionGroups) && matchingNameEditionGroups.length > 0;
+	const hasmatchingNameEditionGroups = matchingNameEditionGroups?.length;
 
 	const showAutoCreateEditionGroupMessage =
 		!editionGroupValue &&
@@ -456,7 +456,7 @@ EditionSection.displayName = 'EditionSection';
 type RootState = Map<string, Map<string, any>>;
 function mapStateToProps(rootState: RootState): StateProps {
 	const state: Map<string, any> = rootState.get('editionSection');
-	const matchingNameEditionGroups = state.get('matchingNameEditionGroups');
+	const matchingNameEditionGroups = state.get('matchingNameEditionGroups')?.toJS();
 
 	return {
 		depthValue: state.get('depth'),

--- a/src/client/entity-editor/edition-section/reducer.ts
+++ b/src/client/entity-editor/edition-section/reducer.ts
@@ -85,9 +85,9 @@ function reducer(
 			return state.set('depth', payload);
 		case UPDATE_WARN_IF_EDITION_GROUP_EXISTS:
 			if (!Array.isArray(payload) || !payload.length) {
-				return state.set('matchingNameEditionGroups', []);
+				return state.set('matchingNameEditionGroups', Immutable.List());
 			}
-			return state.set('matchingNameEditionGroups', payload);
+			return state.set('matchingNameEditionGroups', Immutable.List(payload));
 		// no default
 	}
 	return state;

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -204,7 +204,8 @@ router.get(
 			if (initialState.nameSection.name) {
 				// Initial search for existing Edition Group with same name
 				// Otherwise the search for matching EG is only triggered when user modifies the name
-				initialState.editionSection.matchingNameEditionGroups = props.editionGroup ?? await search.autocomplete(req.app.locals.orm, req.query.name, 'EditionGroup');
+				initialState.editionSection.matchingNameEditionGroups = props.editionGroup ??
+					await search.autocomplete(req.app.locals.orm, req.query.name, 'EditionGroup');
 			}
 
 			const editorMarkup = entityEditorMarkup(props);

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -20,8 +20,8 @@
 import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
-import * as utils from '../../helpers/utils';
 import * as search from '../../../common/helpers/search';
+import * as utils from '../../helpers/utils';
 
 import {
 	addInitialRelationship,

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -204,7 +204,7 @@ router.get(
 			if (initialState.nameSection.name) {
 				// Initial search for existing Edition Group with same name
 				// Otherwise the search for matching EG is only triggered when user modifies the name
-				initialState.editionSection.matchingNameEditionGroups = await search.autocomplete(req.app.locals.orm, req.query.name, 'EditionGroup');
+				initialState.editionSection.matchingNameEditionGroups = props.editionGroup ?? await search.autocomplete(req.app.locals.orm, req.query.name, 'EditionGroup');
 			}
 
 			const editorMarkup = entityEditorMarkup(props);

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -171,9 +171,7 @@ router.get(
 			let relationshipTypeId;
 			let initialRelationshipIndex = 0;
 
-			if (props.publisher || props.editionGroup || props.work) {
-				initialState.editionSection = {};
-			}
+			initialState.editionSection = initialState.editionSection ?? {};
 
 			if (props.publisher) {
 				initialState.editionSection.publisher = props.publisher;

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -21,6 +21,7 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
+import * as search from '../../../common/helpers/search';
 
 import {
 	addInitialRelationship,
@@ -157,7 +158,7 @@ router.get(
 					.then((data) => data && utils.entityToOption(data.toJSON()));
 		}
 
-		function render(props) {
+		async function render(props) {
 			const {initialState} = props;
 			initialState.nameSection = {
 				disambiguation: '',
@@ -194,6 +195,13 @@ router.get(
 				relationshipTypeId = RelationshipTypes.EditionContainsWork;
 				addInitialRelationship(props, relationshipTypeId, initialRelationshipIndex++, props.work);
 			}
+
+			if (req.query?.name) {
+				// Initial search for existing Edition Group with same name
+				// Otherwise the search for matching EG is only triggered when user modifies the name
+				initialState.editionSection.matchingNameEditionGroups = await search.autocomplete(req.app.locals.orm, req.query.name, 'EditionGroup');
+			}
+
 			const editorMarkup = entityEditorMarkup(props);
 			const {markup} = editorMarkup;
 			const updatedProps = editorMarkup.props;

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -182,6 +182,8 @@ router.get(
 
 			if (props.editionGroup) {
 				initialState.editionSection.editionGroup = props.editionGroup;
+				// Default to same name as Edition Group
+				initialState.nameSection = getInitialNameSection(props.editionGroup);
 				// add initial raltionship with relationshipTypeId = 3 (<New Edition> is an edition of <EditionGroup>)
 				relationshipTypeId = RelationshipTypes.EditionIsAnEditionOfEditionGroup;
 				addInitialRelationship(props, relationshipTypeId, initialRelationshipIndex++, props.editionGroup);

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -181,22 +181,27 @@ router.get(
 			}
 
 			if (props.editionGroup) {
+				if (!initialState.nameSection.name) {
+					// If a name hasn't been passed in query parameters, default to same name as the Edition Group
+					initialState.nameSection = getInitialNameSection(props.editionGroup);
+				}
 				initialState.editionSection.editionGroup = props.editionGroup;
-				// Default to same name as Edition Group
-				initialState.nameSection = getInitialNameSection(props.editionGroup);
 				// add initial raltionship with relationshipTypeId = 3 (<New Edition> is an edition of <EditionGroup>)
 				relationshipTypeId = RelationshipTypes.EditionIsAnEditionOfEditionGroup;
 				addInitialRelationship(props, relationshipTypeId, initialRelationshipIndex++, props.editionGroup);
 			}
 
 			if (props.work) {
-				initialState.nameSection = getInitialNameSection(props.work);
+				if (!initialState.nameSection.name) {
+					// If a name hasn't been passed in query parameters, default to same name as the Work
+					initialState.nameSection = getInitialNameSection(props.work);
+				}
 				// add initial raltionship with relationshipTypeId = 10 (<New Edition> Contains <Work>)
 				relationshipTypeId = RelationshipTypes.EditionContainsWork;
 				addInitialRelationship(props, relationshipTypeId, initialRelationshipIndex++, props.work);
 			}
 
-			if (req.query?.name) {
+			if (initialState.nameSection.name) {
 				// Initial search for existing Edition Group with same name
 				// Otherwise the search for matching EG is only triggered when user modifies the name
 				initialState.editionSection.matchingNameEditionGroups = await search.autocomplete(req.app.locals.orm, req.query.name, 'EditionGroup');


### PR DESCRIPTION
As [reported on the forums](https://community.metabrainz.org/t/more-serious-bug-concerning-edition-groups/575369/4), when a user creates an Edition with the name pre-filled (for example using the search page call to action), the search for an Edition Group with the same name is not performed automatically, and the user would have to modify the name to trigger it.

With this PR, we perform the search for matching Edition Group server-side and add the results to the initial state before sending the rendered page.


In a separate PR, I will add the same sort of mechanism to search for duplicates when pre-filling the name