### PR TITLE
feat(entity-editor): search for duplicates when pre-filling name

### DIFF
--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -43,9 +43,9 @@ import SortNameField from '../common/sort-name-field';
 import {UPDATE_WARN_IF_EDITION_GROUP_EXISTS} from '../edition-section/actions';
 import _ from 'lodash';
 import {connect} from 'react-redux';
+import {convertMapToObject} from '../../helpers/utils';
 import {entityTypeProperty} from '../../helpers/react-validators';
 import {getEntityDisambiguation} from '../../helpers/entity';
-
 
 /**
  * Container component. The NameSection component contains input fields for
@@ -284,10 +284,10 @@ NameSection.propTypes = {
 NameSection.defaultProps = {
 	action: 'create',
 	disambiguationDefaultValue: null,
-	exactMatches: null,
+	exactMatches: [],
 	languageValue: null,
 	searchForExistingEditionGroup: true,
-	searchResults: null
+	searchResults: []
 };
 
 
@@ -301,11 +301,11 @@ function mapStateToProps(rootState) {
 	);
 	return {
 		disambiguationDefaultValue: state.get('disambiguation'),
-		exactMatches: state.get('exactMatches'),
+		exactMatches: convertMapToObject(state.get('exactMatches')),
 		languageValue: state.get('language'),
 		nameValue: state.get('name'),
 		searchForExistingEditionGroup,
-		searchResults: state.get('searchResults'),
+		searchResults: convertMapToObject(state.get('searchResults')),
 		sortNameValue: state.get('sortName')
 	};
 }

--- a/src/client/entity-editor/name-section/reducer.js
+++ b/src/client/entity-editor/name-section/reducer.js
@@ -26,10 +26,10 @@ import Immutable from 'immutable';
 function reducer(
 	state = Immutable.Map({
 		disambiguation: '',
-		exactMatches: null,
+		exactMatches: [],
 		language: null,
 		name: '',
-		searchResults: null,
+		searchResults: [],
 		sortName: ''
 	}),
 	action

--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -20,6 +20,7 @@
 import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
+import * as search from '../../../common/helpers/search';
 import * as utils from '../../helpers/utils';
 
 import {
@@ -32,8 +33,8 @@ import {ConflictError} from '../../../common/helpers/error';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
+import log from 'log';
 import target from '../../templates/target';
-
 
 /** ****************************
 *********** Helpers ************
@@ -96,13 +97,13 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadGenders, middleware.loadLanguages,
 	middleware.loadAuthorTypes, middleware.loadRelationshipTypes,
-	(req, res) => {
+	async (req, res) => {
 		const markupProps = generateEntityProps(
 			'author', req, res, {
 				genderOptions: res.locals.genders
 			}
 		);
-		markupProps.initialState.nameSection = {
+		const nameSection = {
 			disambiguation: '',
 			exactMatches: null,
 			language: null,
@@ -110,6 +111,17 @@ router.get(
 			searchResults: null,
 			sortName: ''
 		};
+		if (nameSection.name) {
+			try {
+				nameSection.searchResults = await search.autocomplete(req.app.locals.orm, nameSection.name, 'Author');
+				nameSection.exactMatches = await search.checkIfExists(req.app.locals.orm, nameSection.name, 'Author');
+			}
+			catch (err) {
+				log.debug(err);
+			}
+		}
+
+		markupProps.initialState.nameSection = nameSection;
 		const {markup, props} = entityEditorMarkup(markupProps);
 
 		return res.send(target({

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -20,6 +20,7 @@
 import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
+import * as search from '../../../common/helpers/search';
 import * as utils from '../../helpers/utils';
 
 import {
@@ -32,6 +33,7 @@ import {ConflictError} from '../../../common/helpers/error';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
+import log from 'log';
 import target from '../../templates/target';
 
 /** ****************************
@@ -81,11 +83,11 @@ const router = express.Router();
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadEditionGroupTypes,
-	middleware.loadRelationshipTypes, (req, res) => {
+	middleware.loadRelationshipTypes, async (req, res) => {
 		const markupProps = generateEntityProps(
 			'editionGroup', req, res, {}
 		);
-		markupProps.initialState.nameSection = {
+		const nameSection = {
 			disambiguation: '',
 			exactMatches: null,
 			language: null,
@@ -93,6 +95,17 @@ router.get(
 			searchResults: null,
 			sortName: ''
 		};
+		if (nameSection.name) {
+			try {
+				nameSection.searchResults = await search.autocomplete(req.app.locals.orm, nameSection.name, 'EditionGroup');
+				nameSection.exactMatches = await search.checkIfExists(req.app.locals.orm, nameSection.name, 'EditionGroup');
+			}
+			catch (err) {
+				log.debug(err);
+			}
+		}
+
+		markupProps.initialState.nameSection = nameSection;
 		const {markup, props} = entityEditorMarkup(markupProps);
 
 		return res.send(target({

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -214,6 +214,7 @@ router.get(
 				catch (err) {
 					log.debug(err);
 				}
+			}
 
 			const editorMarkup = entityEditorMarkup(props);
 			const {markup} = editorMarkup;

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -20,6 +20,7 @@
 import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
+import * as search from '../../../common/helpers/search';
 import * as utils from '../../helpers/utils';
 
 import {
@@ -32,6 +33,7 @@ import {ConflictError} from '../../../common/helpers/error';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
+import log from 'log';
 import target from '../../templates/target';
 
 
@@ -92,11 +94,11 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublisherTypes,
 	middleware.loadRelationshipTypes,
-	(req, res) => {
+	async (req, res) => {
 		const markupProps = generateEntityProps(
 			'publisher', req, res, {}
 		);
-		markupProps.initialState.nameSection = {
+		const nameSection = {
 			disambiguation: '',
 			exactMatches: null,
 			language: null,
@@ -104,6 +106,17 @@ router.get(
 			searchResults: null,
 			sortName: ''
 		};
+		if (nameSection.name) {
+			try {
+				nameSection.searchResults = await search.autocomplete(req.app.locals.orm, nameSection.name, 'Publisher');
+				nameSection.exactMatches = await search.checkIfExists(req.app.locals.orm, nameSection.name, 'Publisher');
+			}
+			catch (err) {
+				log.debug(err);
+			}
+		}
+
+		markupProps.initialState.nameSection = nameSection;
 		const {markup, props} = entityEditorMarkup(markupProps);
 
 		return res.send(target({

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -20,6 +20,7 @@
 import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
+import * as search from '../../../common/helpers/search';
 import * as utils from '../../helpers/utils';
 
 import {
@@ -34,6 +35,7 @@ import {RelationshipTypes} from '../../../client/entity-editor/relationship-edit
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
+import log from 'log';
 import {makePromiseFromObject} from '../../../common/helpers/utils';
 import target from '../../templates/target';
 
@@ -112,7 +114,7 @@ router.get(
 					.then((data) => data && utils.entityToOption(data.toJSON()));
 		}
 
-		function render(props) {
+		async function render(props) {
 			if (props.author) {
 				// add initial ralationship with relationshipTypeId = 8 (<Work> is written by <Author>)
 				relationshipTypeId = RelationshipTypes.AuthorWroteWork;
@@ -124,7 +126,7 @@ router.get(
 				relationshipTypeId = RelationshipTypes.EditionContainsWork;
 				addInitialRelationship(props, relationshipTypeId, initialRelationshipIndex++, props.edition);
 			}
-			props.initialState.nameSection = {
+			const nameSection = {
 				disambiguation: '',
 				exactMatches: null,
 				language: null,
@@ -132,6 +134,16 @@ router.get(
 				searchResults: null,
 				sortName: ''
 			};
+			if (nameSection.name) {
+				try {
+					nameSection.searchResults = await search.autocomplete(req.app.locals.orm, nameSection.name, 'Work');
+					nameSection.exactMatches = await search.checkIfExists(req.app.locals.orm, nameSection.name, 'Work');
+				}
+				catch (err) {
+					log.debug(err);
+				}
+			}
+			props.initialState.nameSection = nameSection;
 			const editorMarkup = entityEditorMarkup(props);
 			const {markup} = editorMarkup;
 			const updatedProps = editorMarkup.props;


### PR DESCRIPTION
While working on #800 I realized we have the same issue with the duplicate search:
When creating a new entity, the search for possible duplicates is only triggered when when user types in the name input.
When using query parameters to pre-fill the name of a new entity, that doesn't happen, leading to possible dupes.

With this PR we trigger a search for possible duplicates when we render the props to send to the user.