### PR TITLE
feat(BB-564): Make revision notes links clickable

### DIFF
--- a/src/client/components/pages/revision.js
+++ b/src/client/components/pages/revision.js
@@ -32,7 +32,7 @@ import {transformISODateForDisplay} from '../../helpers/entity';
 
 
 const {Badge, Button, Col, Form, ListGroup, Row} = bootstrap;
-const {formatDate} = utilsHelper;
+const {formatDate, stringToHTMLWithLinks} = utilsHelper;
 
 class RevisionPage extends React.Component {
 	static formatValueList(list, isChangeADate) {
@@ -210,7 +210,9 @@ class RevisionPage extends React.Component {
 					key={note.id}
 				>
 					<div className="revision-note">
-						<p className="note-content">{note.content}</p>
+						<p className="note-content">
+							{stringToHTMLWithLinks(note.content)}
+						</p>
 						<p className="text-right">
 							—&nbsp;
 							<a


### PR DESCRIPTION
In the revision page (for a single revision), URLs in notes are not made into real clickable URLs as is the case with the revision history page (history of revisions for an entity) (See #572)
<img width="563" alt="image" src="https://user-images.githubusercontent.com/6179856/158435166-43844910-9c92-4895-8f68-ecbf4d0f1a3f.png">