### PR TITLE
fix(language-select): Fix filtering of language select options

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react-hot-loader": "^4.13.0",
     "react-redux": "^7.2.6",
     "react-select": "^1.1.0",
+    "react-select-fast-filter-options": "^0.2.3",
     "react-sortable-hoc": "^2.0.0",
     "react-sticky": "^6.0.1",
     "react-virtualized-select": "^3.0.1",

--- a/src/client/entity-editor/common/language-field.tsx
+++ b/src/client/entity-editor/common/language-field.tsx
@@ -22,6 +22,7 @@ import {Form, OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import ValidationLabel from './validation-label';
 import VirtualizedSelect from 'react-virtualized-select';
+import createFilterOptions from 'react-select-fast-filter-options';
 import {faQuestionCircle} from '@fortawesome/free-solid-svg-icons';
 
 
@@ -56,7 +57,10 @@ function LanguageField({
 	;
 
 	const tooltip = <Tooltip>{tooltipText}</Tooltip>;
-
+	const {options} = rest;
+	const filterOptions = createFilterOptions({
+		options
+	});
 	return (
 		<Form.Group>
 			<Form.Label>
@@ -68,7 +72,7 @@ function LanguageField({
 					/>
 				</OverlayTrigger>
 			</Form.Label>
-			<VirtualizedSelect {...rest}/>
+			<VirtualizedSelect filterOptions={filterOptions} {...rest}/>
 		</Form.Group>
 	);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4994,6 +4994,11 @@ jest-worker@^27.0.6, jest-worker@^27.3.1:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+js-search@^1.3.1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/js-search/-/js-search-1.4.3.tgz#23a86d7e064ca53a473930edc48615b6b1c1954a"
+  integrity sha512-Sny5pf00kX1sM1KzvUC9nGYWXOvBfy30rmvZWeRktpg+esQKedIXrXNee/I2CAnsouCyaTjitZpRflDACx4toA==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6685,6 +6690,13 @@ react-redux@^7.2.6:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^17.0.2"
+
+react-select-fast-filter-options@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/react-select-fast-filter-options/-/react-select-fast-filter-options-0.2.3.tgz#d9f667ab1fe7bcc2dd8bfd74277e56c771e9e518"
+  integrity sha512-rTMMRhd73MI1z2eWpes8sGoR4nBYM1IGjsYPvay2DF/kylHUmXFFIGsZJZQcXdBZnAXExKyw2kYKCGiYi4ls4Q==
+  dependencies:
+    js-search "^1.3.1"
 
 react-select@^1.0.0-rc.2, react-select@^1.1.0:
   version "1.3.0"


### PR DESCRIPTION
### Problem
The select is crazy slow on older browsers due to issues with filtering the gigantic list of options.
The default filtering of react-select is inefficient

### Solution
Using the library react-select-fast-filter-options fixes the issue.
It uses js-search under the hood which is more efficient.


### Areas of Impact
src/client/entity-editor/common/language-field.tsx
package.json and yarn lockfile
