### PR TITLE
fix(merging): Default to empty relationships array in middleware

### DIFF
--- a/src/server/routes/merge.ts
+++ b/src/server/routes/merge.ts
@@ -164,6 +164,9 @@ function entitiesToFormState(entities: any[]) {
 function loadEntityRelationships(entity, orm, transacting): Promise<any> {
 	const {RelationshipSet} = orm;
 
+	// Default to empty array, its presence is expected down the line
+	entity.relationships = [];
+	
 	if (!entity.relationshipSetId) {
 		return null;
 	}
@@ -180,8 +183,9 @@ function loadEntityRelationships(entity, orm, transacting): Promise<any> {
 			]
 		})
 		.then((relationshipSet) => {
-			entity.relationships = relationshipSet ?
-				relationshipSet.related('relationships').toJSON() : [];
+			if(relationshipSet){
+				entity.relationships = relationshipSet.related('relationships').toJSON();
+			}
 
 			attachAttributes(entity.relationships);
 


### PR DESCRIPTION
In this middleware we exit early if the entity doesn't have a relationshipSet ID.

As a consequence, entity.relationships is not set to an empty array, as is expected by some code down the line, for example here: https://github.com/metabrainz/bookbrainz-site/blob/38e083e90c6592e3f4f5597a1a2a2a5b355759b4/src/client/entity-editor/series-section/series-section-merge.tsx#L86

Trying to spread `undefined` results in an error thrown which currently crashes the server — which is a separate issue.