### PR TITLE
[BB-569]: Add an author for a work from the WorkTable

### DIFF
--- a/src/client/components/pages/entities/work-table.js
+++ b/src/client/components/pages/entities/work-table.js
@@ -64,7 +64,19 @@ function WorkTableRow({showAddedAtColumn, work, showCheckboxes, selectedEntities
 				<a href={`/work/${work.bbid}`}>{name}</a>
 				{disambiguation}
 			</td>
-			{authorData && <td>{authorData.length ? renderAuthors(authorData) : '?'}</td>}
+			{authorData &&
+			<td>
+				{authorData.length ? renderAuthors(authorData) :
+					<a
+						href={`/author/create?work=${work.bbid}`}
+						title="Add Author"
+						variant="link"
+					>
+						?
+					</a>
+				}
+			</td>
+			}
 			<td>{languages}</td>
 			<td>{workType}</td>
 			{showAddedAtColumn ? <td>{addedAt}</td> : null}


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
In the WorkTable component which displays the works in an Edition, if the author of a work is not present, it is displayed as a "?". We should be able to directly add an author from here for this work (Similar to the Add ${entity} button which is displayed on the entity pages)

### Solution
<!-- What does this PR do to fix the problem? -->
Now the "?" is clickable
![EditionWorkTable](https://user-images.githubusercontent.com/56965261/161557804-ecad1741-0476-4ba4-a6b3-529f53be3d78.png)

On clicking "?", it will take you to add Author page

![AddAuthorLink](https://user-images.githubusercontent.com/56965261/161557826-5e46cef8-b6e3-46c6-967b-218a2e408c04.png)

The editor will have the relationship with the work already attached
![AuthorWithWorkRelationship](https://user-images.githubusercontent.com/56965261/161557820-4c220b57-a2bb-4610-9d99-14fcf80ffb5c.png)





