### PR TITLE
Fix(Identifier-Editor): Improve identifier editor behavior for ISBNs

### DIFF
--- a/src/client/entity-editor/identifier-editor/identifier-row.tsx
+++ b/src/client/entity-editor/identifier-editor/identifier-row.tsx
@@ -29,7 +29,7 @@ import {
 	IdentifierType,
 	validateIdentifierValue
 } from '../validators/common';
-import {collapseWhiteSpaces, isbn10To13, isbn13To10} from '../../../common/helpers/utils';
+import {collapseWhiteSpaces, validateChkISBN} from '../../../common/helpers/utils';
 import type {Dispatch} from 'redux';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import Select from 'react-select';
@@ -148,18 +148,27 @@ function handleValueChange(
 		const result = new RegExp(guessedType.detectionRegex).exec(value);
 		value = result[1];
 		if (guessedType.id === 9) {
-			const isbn10Type:any = types.find((el) => el.id === 10);
-			const isbn10 = isbn13To10(value);
-			if (isbn10) {
-				dispatch(debouncedUpdateIdentifierValue(index + 1, isbn10, isbn10Type, false));
+			// verifying isbn13 check digit
+			if (!validateChkISBN(value)) {
+				return dispatch(debouncedUpdateIdentifierValue(index, value, null));
 			}
+			// disabling "add isbn row" feature temporary
+			// const isbn10Type:any = types.find((el) => el.id === 10);
+			// const isbn10 = isbn13To10(value);
+			// if (isbn10) {
+			// 	dispatch(debouncedUpdateIdentifierValue(index + 1, isbn10, isbn10Type, false));
+			// }
 		}
 		if (guessedType.id === 10) {
-			const isbn13Type:any = types.find((el) => el.id === 9);
-			const isbn13 = isbn10To13(value);
-			if (isbn13) {
-				dispatch(debouncedUpdateIdentifierValue(index + 1, isbn10To13(value), isbn13Type, false));
+			// verifying isbn10 check digit
+			if (!validateChkISBN(value, false)) {
+				return dispatch(debouncedUpdateIdentifierValue(index, value, null));
 			}
+			// const isbn13Type:any = types.find((el) => el.id === 9);
+			// const isbn13 = isbn10To13(value);
+			// if (isbn13) {
+			// 	dispatch(debouncedUpdateIdentifierValue(index + 1, isbn10To13(value), isbn13Type, false));
+			// }
 		}
 	}
 	return dispatch(debouncedUpdateIdentifierValue(index, value, guessedType));

--- a/src/client/entity-editor/identifier-editor/identifier-row.tsx
+++ b/src/client/entity-editor/identifier-editor/identifier-row.tsx
@@ -29,11 +29,11 @@ import {
 	IdentifierType,
 	validateIdentifierValue
 } from '../validators/common';
-import {collapseWhiteSpaces, validateChkISBN} from '../../../common/helpers/utils';
 import type {Dispatch} from 'redux';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import Select from 'react-select';
 import ValueField from './value-field';
+import {collapseWhiteSpaces} from '../../../common/helpers/utils';
 import {connect} from 'react-redux';
 import {faTimes} from '@fortawesome/free-solid-svg-icons';
 
@@ -147,29 +147,21 @@ function handleValueChange(
 	if (guessedType) {
 		const result = new RegExp(guessedType.detectionRegex).exec(value);
 		value = result[1];
-		if (guessedType.id === 9) {
-			// verifying isbn13 check digit
-			if (!validateChkISBN(value)) {
-				return dispatch(debouncedUpdateIdentifierValue(index, value, null));
-			}
-			// disabling "add isbn row" feature temporary
-			// const isbn10Type:any = types.find((el) => el.id === 10);
-			// const isbn10 = isbn13To10(value);
-			// if (isbn10) {
-			// 	dispatch(debouncedUpdateIdentifierValue(index + 1, isbn10, isbn10Type, false));
-			// }
-		}
-		if (guessedType.id === 10) {
-			// verifying isbn10 check digit
-			if (!validateChkISBN(value, false)) {
-				return dispatch(debouncedUpdateIdentifierValue(index, value, null));
-			}
-			// const isbn13Type:any = types.find((el) => el.id === 9);
-			// const isbn13 = isbn10To13(value);
-			// if (isbn13) {
-			// 	dispatch(debouncedUpdateIdentifierValue(index + 1, isbn10To13(value), isbn13Type, false));
-			// }
-		}
+		// 	disabling "add isbn row" feature temporary
+		// if (guessedType.id === 9) {
+		// 	const isbn10Type:any = types.find((el) => el.id === 10);
+		// 	const isbn10 = isbn13To10(value);
+		// 	if (isbn10) {
+		// 		dispatch(debouncedUpdateIdentifierValue(index + 1, isbn10, isbn10Type, false));
+		// 	}
+		// }
+		// if (guessedType.id === 10) {
+		// 	const isbn13Type:any = types.find((el) => el.id === 9);
+		// 	const isbn13 = isbn10To13(value);
+		// 	if (isbn13) {
+		// 		dispatch(debouncedUpdateIdentifierValue(index + 1, isbn10To13(value), isbn13Type, false));
+		// 	}
+		// }
 	}
 	return dispatch(debouncedUpdateIdentifierValue(index, value, guessedType));
 }

--- a/src/client/entity-editor/identifier-editor/reducer.ts
+++ b/src/client/entity-editor/identifier-editor/reducer.ts
@@ -43,7 +43,8 @@ function reducer(
 			const updatedValue = state.setIn(
 				[payload.rowId, 'value'], payload.value
 			);
-			if (payload.suggestedType) {
+			// don't switch type if user already selected it
+			if (payload.suggestedType && !state.getIn([payload.rowId, 'type'])) {
 				return updatedValue.setIn(
 					[payload.rowId, 'type'], payload.suggestedType.id
 				);

--- a/src/client/entity-editor/validators/common.ts
+++ b/src/client/entity-editor/validators/common.ts
@@ -25,6 +25,7 @@ import {
 
 import {Iterable} from 'immutable';
 import _ from 'lodash';
+import {validateChkISBN} from '../../../common/helpers/utils';
 
 
 export function validateMultiple(
@@ -93,6 +94,11 @@ export function validateIdentifierValue(
 	const selectedType = _.find(types, (type) => type.id === typeId);
 
 	if (selectedType) {
+		// also verify the last digit of ISBNs
+		if (typeId === 9 && !validateChkISBN(value) || typeId === 10 && !validateChkISBN(value, false)) {
+			return false;
+		}
+
 		return new RegExp(selectedType.validationRegex).test(value);
 	}
 

--- a/src/client/entity-editor/validators/common.ts
+++ b/src/client/entity-editor/validators/common.ts
@@ -25,7 +25,6 @@ import {
 
 import {Iterable} from 'immutable';
 import _ from 'lodash';
-import {validateChkISBN} from '../../../common/helpers/utils';
 
 
 export function validateMultiple(
@@ -94,11 +93,6 @@ export function validateIdentifierValue(
 	const selectedType = _.find(types, (type) => type.id === typeId);
 
 	if (selectedType) {
-		// also verify the last digit of ISBNs
-		if (typeId === 9 && !validateChkISBN(value) || typeId === 10 && !validateChkISBN(value, false)) {
-			return false;
-		}
-
 		return new RegExp(selectedType.validationRegex).test(value);
 	}
 

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -1,7 +1,6 @@
 import {Relationship, RelationshipForDisplay} from '../../client/entity-editor/relationship-editor/types';
 
-import {isString, kebabCase} from 'lodash';
-import {validateAlias} from '../../client/entity-editor/validators/common';
+import {isString, kebabCase, toString} from 'lodash';
 
 /**
  * Regular expression for valid BookBrainz UUIDs (bbid)
@@ -190,10 +189,10 @@ export function getNextEnabledAndResultsArray(array, size) {
 /**
  * Calculate check digit for isbn10
  * @param {string} isbn ISBN-10
- * @returns {string|number} check digit
+ * @returns {string} check digit
  */
 
-export function calIsbn10Chk(isbn) {
+export function calIsbn10Chk(isbn:string):string {
 	let digits = [];
 	let sum = 0;
 	let chkDigit;
@@ -216,36 +215,22 @@ export function calIsbn10Chk(isbn) {
 			chkDigit = chkTmp;
 			break;
 	}
-	return chkDigit;
+	return toString(chkDigit);
 }
 
 /**
  * Calculate check digit for isbn13
  * @param {string} isbn ISBN-13
- * @returns {string|number} check digit
+ * @returns {string} check digit
  */
-export function calIsbn13Chk(isbn) {
+export function calIsbn13Chk(isbn:string):string {
 	let totalSum = 0;
 	for (let i = 0; i < 12; i++) {
 		totalSum += Number(isbn.charAt(i)) * ((i % 2) === 0 ? 1 : 3);
 	}
 
 	const lastDigit = (10 - (totalSum % 10)) % 10;
-	return lastDigit;
-}
-
-/**
- * Match the check digit for isbn
- * @param {string} value ISBN value
- * @param {boolean} isISBN13 validate for isbn13?
- * @returns {boolean} check digit
- */
-export function validateChkISBN(value:string, isISBN13 = true) {
-	if (isISBN13) {
-		return calIsbn13Chk(value.replaceAll('-', '')) === Number(value.at(-1));
-	}
-
-	return calIsbn10Chk(value.replaceAll('-', '')) === value.at(-1);
+	return toString(lastDigit);
 }
 
 /**

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -1,6 +1,7 @@
 import {Relationship, RelationshipForDisplay} from '../../client/entity-editor/relationship-editor/types';
 
 import {isString, kebabCase} from 'lodash';
+import {validateAlias} from '../../client/entity-editor/validators/common';
 
 /**
  * Regular expression for valid BookBrainz UUIDs (bbid)
@@ -187,46 +188,17 @@ export function getNextEnabledAndResultsArray(array, size) {
 }
 
 /**
- * Convert ISBN-10 to ISBN-13
- * @param {string} isbn10 valid ISBN-10
- * @returns {string} ISBN-13
+ * Calculate check digit for isbn10
+ * @param {string} isbn ISBN-10
+ * @returns {string|number} check digit
  */
 
-export function isbn10To13(isbn10:string):string | null {
-	const isbn10Regex = RegExp(/^(?=[0-9X]{10}$|(?=(?:[0-9]+[- ]){3})[- 0-9X]{13}$)[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]$/);
-	if (!isbn10Regex.test(isbn10)) {
-		return null;
-	}
-	const tempISBN10 = `${isbn10}`.replaceAll('-', '');
-	let totalSum = 0;
-
-	const isbn13 = `978${tempISBN10.substring(0, 9)}`;
-
-	for (let i = 0; i < 12; i++) {
-		totalSum += Number(isbn13.charAt(i)) * ((i % 2) === 0 ? 1 : 3);
-	}
-
-	const lastDigit = (10 - (totalSum % 10)) % 10;
-	return isbn13 + lastDigit;
-}
-
-/**
- * Convert ISBN-13 to ISBN-10
- * @param {string} isbn13 valid ISBN-13
- * @returns {string} ISBN-10
- */
-
-export function isbn13To10(isbn13:string):string | null {
-	const isbn13Regex = RegExp(/^(?=[0-9]{13}$|(?=(?:[0-9]+[- ]){1,4})[- 0-9]{14,17}$)978[- ]?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9]$/);
-	if (!isbn13Regex.test(isbn13)) {
-		return null;
-	}
-	const tempISBN13 = isbn13.replaceAll('-', '');
+export function calIsbn10Chk(isbn) {
 	let digits = [];
 	let sum = 0;
 	let chkDigit;
 
-	digits = `${tempISBN13}`.substring(3, 12).split('');
+	digits = `${isbn}`.substring(0, 9).split('');
 
 	for (let i = 0; i < 9; i++) {
 		sum += digits[i] * (10 - i);
@@ -244,7 +216,71 @@ export function isbn13To10(isbn13:string):string | null {
 			chkDigit = chkTmp;
 			break;
 	}
-	digits.push(chkDigit);
+	return chkDigit;
+}
+
+/**
+ * Calculate check digit for isbn13
+ * @param {string} isbn ISBN-13
+ * @returns {string|number} check digit
+ */
+export function calIsbn13Chk(isbn) {
+	let totalSum = 0;
+	for (let i = 0; i < 12; i++) {
+		totalSum += Number(isbn.charAt(i)) * ((i % 2) === 0 ? 1 : 3);
+	}
+
+	const lastDigit = (10 - (totalSum % 10)) % 10;
+	return lastDigit;
+}
+
+/**
+ * Match the check digit for isbn
+ * @param {string} value ISBN value
+ * @param {boolean} isISBN13 validate for isbn13?
+ * @returns {boolean} check digit
+ */
+export function validateChkISBN(value:string, isISBN13 = true) {
+	if (isISBN13) {
+		return calIsbn13Chk(value.replaceAll('-', '')) === Number(value.at(-1));
+	}
+
+	return calIsbn10Chk(value.replaceAll('-', '')) === value.at(-1);
+}
+
+/**
+ * Convert ISBN-10 to ISBN-13
+ * @param {string} isbn10 valid ISBN-10
+ * @returns {string} ISBN-13
+ */
+
+export function isbn10To13(isbn10:string):string | null {
+	const isbn10Regex = RegExp(/^(?=[0-9X]{10}$|(?=(?:[0-9]+[- ]){3})[- 0-9X]{13}$)[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]$/);
+	if (!isbn10Regex.test(isbn10)) {
+		return null;
+	}
+	const tempISBN10 = `${isbn10}`.replaceAll('-', '');
+
+	const isbn13 = `978${tempISBN10.substring(0, 9)}`;
+
+	const lastDigit = calIsbn13Chk(isbn13);
+	return isbn13 + lastDigit;
+}
+
+/**
+ * Convert ISBN-13 to ISBN-10
+ * @param {string} isbn13 valid ISBN-13
+ * @returns {string} ISBN-10
+ */
+
+export function isbn13To10(isbn13:string):string | null {
+	const isbn13Regex = RegExp(/^(?=[0-9]{13}$|(?=(?:[0-9]+[- ]){1,4})[- 0-9]{14,17}$)978[- ]?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9]$/);
+	if (!isbn13Regex.test(isbn13)) {
+		return null;
+	}
+	const tempISBN13 = isbn13.replaceAll('-', '');
+	const digits = tempISBN13.substring(3, 12).split('');
+	digits.push(calIsbn10Chk(digits.join('')));
 
 	return digits.join('');
 }


### PR DESCRIPTION
In this PR, I am making ISBN detection more strict by verifying its check digit, disabling switching type after user manually selected it and disabling new ISBN row addition(temporary).

