### PR TITLE
Fix(languages): Sort language options after fast filter

### DIFF
--- a/src/client/entity-editor/alias-editor/alias-editor.js
+++ b/src/client/entity-editor/alias-editor/alias-editor.js
@@ -54,6 +54,7 @@ const AliasEditor = ({
 	show
 }) => {
 	const languageOptionsForDisplay = languageOptions.map((language) => ({
+		frequency: language.frequency,
 		label: language.name,
 		value: language.id
 	}));

--- a/src/client/entity-editor/common/language-field.tsx
+++ b/src/client/entity-editor/common/language-field.tsx
@@ -24,6 +24,7 @@ import ValidationLabel from './validation-label';
 import VirtualizedSelect from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
 import {faQuestionCircle} from '@fortawesome/free-solid-svg-icons';
+import {isNumber} from 'lodash';
 
 
 type Props = {
@@ -64,7 +65,7 @@ function LanguageField({
 	const sortFilterOptions = (opts, input, selectOptions) => {
 		const newOptions = filterOptions(opts, input, selectOptions);
 		const sortLang = (a, b) => {
-			if (a.frequency !== b.frequency) {
+			if (isNumber(a.frequency) && isNumber(b.frequency) && a.frequency !== b.frequency) {
 				return b.frequency - a.frequency;
 			}
 			return a.label.localeCompare(b.label);

--- a/src/client/entity-editor/common/language-field.tsx
+++ b/src/client/entity-editor/common/language-field.tsx
@@ -61,6 +61,17 @@ function LanguageField({
 	const filterOptions = createFilterOptions({
 		options
 	});
+	const sortFilterOptions = (opts, input, selectOptions) => {
+		const newOptions = filterOptions(opts, input, selectOptions);
+		const sortLang = (a, b) => {
+			if (a.frequency !== b.frequency) {
+				return b.frequency - a.frequency;
+			}
+			return a.label.localeCompare(b.label);
+		};
+		newOptions.sort(sortLang);
+		return newOptions;
+	};
 	return (
 		<Form.Group>
 			<Form.Label>
@@ -72,7 +83,7 @@ function LanguageField({
 					/>
 				</OverlayTrigger>
 			</Form.Label>
-			<VirtualizedSelect filterOptions={filterOptions} {...rest}/>
+			<VirtualizedSelect filterOptions={sortFilterOptions} {...rest}/>
 		</Form.Group>
 	);
 }

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -76,6 +76,7 @@ type EditionStatus = {
 };
 
 type LanguageOption = {
+	frequency: number,
 	name: string,
 	id: number
 };
@@ -186,6 +187,7 @@ function EditionSection({
 	widthValue
 }: Props) {
 	const languageOptionsForDisplay = languageOptions.map((language) => ({
+		frequency: language.frequency,
 		label: language.name,
 		value: language.id
 	}));

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -143,6 +143,7 @@ class NameSection extends React.Component {
 		} = this.props;
 
 		const languageOptionsForDisplay = languageOptions.map((language) => ({
+			frequency: language.frequency,
 			label: language.name,
 			value: language.id
 		}));

--- a/src/client/entity-editor/work-section/work-section-merge.tsx
+++ b/src/client/entity-editor/work-section/work-section-merge.tsx
@@ -34,6 +34,7 @@ import {convertMapToObject} from '../../helpers/utils';
 
 
 type LanguageOption = {
+	frequency: number,
 	name: string,
 	id: number
 };

--- a/src/client/entity-editor/work-section/work-section.tsx
+++ b/src/client/entity-editor/work-section/work-section.tsx
@@ -44,6 +44,7 @@ type WorkType = {
 };
 
 type LanguageOption = {
+	frequency: number,
 	name: string,
 	id: number
 };
@@ -92,6 +93,7 @@ function WorkSection({
 	onTypeChange
 }: Props) {
 	const languageOptionsForDisplay = languageOptions.map((language) => ({
+		frequency: language.frequency,
 		label: language.name,
 		value: language.id
 	}));


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Languages are not sorted according to frequency after using fast-filter

### Solution
<!-- What does this PR do to fix the problem? -->
Sort options manually after filtering

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
language-field