### PR TITLE
fix(entity-editor): [BB-661] Remove slow deserialization in redux state

### DIFF
--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -202,14 +202,14 @@ function EditionSection({
 
 	const {isValid: isValidReleaseDate, errorMessage: dateErrorMessage} = validateEditionSectionReleaseDate(releaseDateValue);
 
-	const hasmatchingNameEditionGroups = matchingNameEditionGroups?.length;
+	const hasmatchingNameEditionGroups = Boolean(matchingNameEditionGroups?.length);
 
 	const showAutoCreateEditionGroupMessage =
 		!editionGroupValue &&
 		!editionGroupVisible &&
 		!editionGroupRequired;
 
-	const showMatchingEditionGroups = hasmatchingNameEditionGroups && !editionGroupValue;
+	const showMatchingEditionGroups = Boolean(hasmatchingNameEditionGroups && !editionGroupValue);
 
 	const getEditionGroupSearchSelect = () => (
 		<React.Fragment>
@@ -456,7 +456,6 @@ EditionSection.displayName = 'EditionSection';
 type RootState = Map<string, Map<string, any>>;
 function mapStateToProps(rootState: RootState): StateProps {
 	const state: Map<string, any> = rootState.get('editionSection');
-	const matchingNameEditionGroups = state.get('matchingNameEditionGroups')?.toJS();
 
 	return {
 		depthValue: state.get('depth'),
@@ -466,7 +465,7 @@ function mapStateToProps(rootState: RootState): StateProps {
 		formatValue: state.get('format'),
 		heightValue: state.get('height'),
 		languageValues: state.get('languages'),
-		matchingNameEditionGroups,
+		matchingNameEditionGroups: state.get('matchingNameEditionGroups'),
 		pagesValue: state.get('pages'),
 		physicalEnable: state.get('physicalEnable'),
 		publisherValue: state.get('publisher'),

--- a/src/client/entity-editor/edition-section/reducer.ts
+++ b/src/client/entity-editor/edition-section/reducer.ts
@@ -45,7 +45,7 @@ function reducer(
 	state: State = Immutable.Map({
 		format: null,
 		languages: Immutable.List([]),
-		matchingNameEditionGroups: Immutable.List([]),
+		matchingNameEditionGroups: [],
 		physicalEnable: true,
 		publisher: null,
 		releaseDate: '',
@@ -85,9 +85,9 @@ function reducer(
 			return state.set('depth', payload);
 		case UPDATE_WARN_IF_EDITION_GROUP_EXISTS:
 			if (!Array.isArray(payload) || !payload.length) {
-				return state.set('matchingNameEditionGroups', Immutable.List());
+				return state.set('matchingNameEditionGroups', []);
 			}
-			return state.set('matchingNameEditionGroups', Immutable.List(payload));
+			return state.set('matchingNameEditionGroups', payload);
 		// no default
 	}
 	return state;


### PR DESCRIPTION
https://community.metabrainz.org/t/lag-between-typing-and-appearance-of-information-in-annotation-section-of-editions/579426

Introduced in commit 7d02163, using an Immutable.List instead of a plain array to store `matchingNameEditionGroups` in the redux state introduced a  huge slowness in state deserializing which impacted the whole entity editor (when creating/editing Editions only).
The page slows down to a crawl if you trigger lots of state updates, for example writing text in the annotation textarea.
Reverting these changes to fix the issue.
