### PR TITLE
fix(entity-editor): Fix WorkTable HTML structure

### DIFF
--- a/src/client/components/pages/entities/work-table.js
+++ b/src/client/components/pages/entities/work-table.js
@@ -34,7 +34,7 @@ const {Button, Table} = bootstrap;
 const {getEntityDisambiguation, getLanguageAttribute, getEntityLabel} = entityHelper;
 
 function renderAuthors(authorData) {
-	return authorData.map(author => <tr key={author.authorbbid}><a href={`/author/${author.authorbbid}`}>{author.authoralias}</a></tr>);
+	return authorData.map(author => <div key={author.authorbbid}><a href={`/author/${author.authorbbid}`}>{author.authoralias}</a></div>);
 }
 
 function WorkTableRow({showAddedAtColumn, work, showCheckboxes, selectedEntities, onToggleRow}) {


### PR DESCRIPTION
We were using `<tr>` elements inside `<td>`s to show a list of authors ([in `renderAuthors` method](https://github.com/metabrainz/bookbrainz-site/blob/b919b95596ab5526a06831f351036278f3254dfb/src/client/components/pages/entities/work-table.js#L37)), but that breaks the HTML table structure and weird stuff happens to the page structure (see https://community.metabrainz.org/t/bug-with-adding-a-work-to-an-edition)

Using `<div>`s instead allows us to keep each author on a separate line but does not break the page structure.