### PR TITLE
[BB-662]: URLs are turned into malformed links

### DIFF
--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -177,10 +177,10 @@ export function dateObjectToISOString(value: DateObject) {
  * @returns {JSX} returns a JSX Element
  */
 export function stringToHTMLWithLinks(string: string) {
-	const addHttpRegex = /(^(|\b))www\./igm;
+	const addHttpRegex = /(\b(?<!https?:\/\/)w{3}\.\S+\.)/gmi;
 	// eslint-disable-next-line max-len, no-useless-escape
 	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
-	let content = string.replace(addHttpRegex, '$1https://www.');
+	let content = string.replace(addHttpRegex, 'https://$1');
 	content = content.replace(
 		urlRegex,
 		'<a href="$1" target="_blank">$1</a>'

--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -173,25 +173,19 @@ export function dateObjectToISOString(value: DateObject) {
  * Convert any string url that has a prefix http|https|ftp|ftps to a clickable link
  * and then rendered the HTML string as real HTML.
  * @function stringToHTMLWithLinks
- * @param {string} text - Can be either revision notes or annotation content etc...
+ * @param {string} string - Can be either revision notes or annotation content etc...
  * @returns {JSX} returns a JSX Element
  */
-export function stringToHTMLWithLinks(text: string) {
-	let urlRegex = /(?:http|\S+\.\S).+?(?=[.,;:?!-]?(?:\s|$))/g;
-	const matches = text.match(urlRegex)
-	if (!matches) return text;
-	const contentString = []
-	matches.forEach(x => {
-		const [t1, ...t2] = text.split(x)
-		contentString.push(t1)
-		text = t2.join(x)
-		const y = (!(x.match(/(http(s?)):\/\//)) ? 'https://' : '') + x;
-		contentString.push('<a href="' + y + '" target="_blank">' + y + '</a>');
-	})
-	contentString.push(text);
-	const finalText = contentString.join('');
-
-	const sanitizedHtml = DOMPurify.sanitize(finalText);
+export function stringToHTMLWithLinks(string: string) {
+	const addHttpRegex = /(^(|\b))www\./igm;
+	// eslint-disable-next-line max-len, no-useless-escape
+	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
+	let content = string.replace(addHttpRegex, '$1https://www.');
+	content = content.replace(
+		urlRegex,
+		'<a href="$1" target="_blank">$1</a>'
+	);
+	const sanitizedHtml = DOMPurify.sanitize(content);
 	// eslint-disable-next-line react/no-danger
 	return <span dangerouslySetInnerHTML={{__html: sanitizedHtml}}/>;
 }

--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -173,20 +173,25 @@ export function dateObjectToISOString(value: DateObject) {
  * Convert any string url that has a prefix http|https|ftp|ftps to a clickable link
  * and then rendered the HTML string as real HTML.
  * @function stringToHTMLWithLinks
- * @param {string} string - Can be either revision notes or annotation content etc...
+ * @param {string} text - Can be either revision notes or annotation content etc...
  * @returns {JSX} returns a JSX Element
  */
-export function stringToHTMLWithLinks(string: string) {
-	let urlRegex = /(((https?:\/\/)|(www\.))[^\s]+)/g;
-	let contentString = string.replace(urlRegex, (url) => {
-		let hyperlink = url;
-		if (!hyperlink.match('^https?:')) {
-			hyperlink = `http://${hyperlink}`;
-		}
-		return `<a href="${hyperlink}" target="_blank">${url}</a>`;
-	});
+export function stringToHTMLWithLinks(text: string) {
+	let urlRegex = /(?:http|\S+\.\S).+?(?=[.,;:?!-]?(?:\s|$))/g;
+	const matches = text.match(urlRegex)
+	if (!matches) return text;
+	const contentString = []
+	matches.forEach(x => {
+		const [t1, ...t2] = text.split(x)
+		contentString.push(t1)
+		text = t2.join(x)
+		const y = (!(x.match(/(http(s?)):\/\//)) ? 'https://' : '') + x;
+		contentString.push('<a href="' + y + '" target="_blank">' + y + '</a>');
+	})
+	contentString.push(text);
+	const finalText = contentString.join('');
 
-	const sanitizedHtml = DOMPurify.sanitize(contentString);
+	const sanitizedHtml = DOMPurify.sanitize(finalText);
 	// eslint-disable-next-line react/no-danger
 	return <span dangerouslySetInnerHTML={{__html: sanitizedHtml}}/>;
 }

--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -180,7 +180,7 @@ export function stringToHTMLWithLinks(string: string) {
 	const addHttpRegex = /(^|\b)www\./ig;
 	// eslint-disable-next-line max-len, no-useless-escape
 	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
-	let content = string.replace(addHttpRegex, '$1https://www.');
+	let content = string.replace(addHttpRegex, '$1www.');
 	content = content.replace(
 		urlRegex,
 		'<a href="$1" target="_blank">$1</a>'

--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -177,15 +177,16 @@ export function dateObjectToISOString(value: DateObject) {
  * @returns {JSX} returns a JSX Element
  */
 export function stringToHTMLWithLinks(string: string) {
-	const addHttpRegex = /(^|\b)www\./ig;
-	// eslint-disable-next-line max-len, no-useless-escape
-	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
-	let content = string.replace(addHttpRegex, '$1www.');
-	content = content.replace(
-		urlRegex,
-		'<a href="$1" target="_blank">$1</a>'
-	);
-	const sanitizedHtml = DOMPurify.sanitize(content);
+	let urlRegex = /(((https?:\/\/)|(www\.))[^\s]+)/g;
+	let contentString = string.replace(urlRegex, (url) => {
+		let hyperlink = url;
+		if (!hyperlink.match('^https?:')) {
+			hyperlink = `http://${hyperlink}`;
+		}
+		return `<a href="${hyperlink}" target="_blank">${url}</a>`;
+	});
+
+	const sanitizedHtml = DOMPurify.sanitize(contentString);
 	// eslint-disable-next-line react/no-danger
 	return <span dangerouslySetInnerHTML={{__html: sanitizedHtml}}/>;
 }


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
This PR addresses ticket BB-662.

### Solution
<!-- What does this PR do to fix the problem? -->
Initially, we were adding an `https://` even if it was already present in the string, now I have added a check.
I have also improved the regex we were using, as I feel it was a bit insufficient and antiquated. I took help from [this](https://stackoverflow.com/a/71734086), and I think it works a lot better and is somewhat cleaner also.

