### PR TITLE
Remove hyphen from isbns

### DIFF
--- a/sql/migrations/alias/up.sql
+++ b/sql/migrations/alias/up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE bookbrainz.alias ADD area_id INTEGER;
+ALTER TABLE bookbrainz.alias ADD CONSTRAINT alias_area_id_fkey FOREIGN KEY (area_id) REFERENCES musicbrainz.area(id);
+
+COMMIT ;

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -1201,8 +1201,19 @@ export function constructIdentifiers(
 ) {
 	return _.map(
 		identifierEditor,
-		({type: typeId, value}: IdentifierEditorT, id: string) =>
-			({id, typeId, value})
+		({type: typeId, value}: IdentifierEditorT, id: string) =>{
+			if(typeId===9 || typeId===10){
+				let val=value.split('');
+				value=val.reduce((acc,n)=>{
+				  if(n!=='-'){
+					acc+=n;
+				  }
+				  return acc;
+				})
+			  }
+			  
+			  return {id,typeId,value}
+		}
 	);
 }
 

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -1203,7 +1203,7 @@ export function constructIdentifiers(
 		identifierEditor,
 		({type: typeId, value}: IdentifierEditorT, id: string) =>{
 			if(typeId===9 || typeId===10){
-				let val=value.split('');
+				let val=value.split('-');
 				value=val.reduce((acc,n)=>{
 				  if(n!=='-'){
 					acc+=n;


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
When an ISBN is added to an edition, it can be stored with or without hyphens. This creates inconsistency across editions. It also creates problems when searching by ISBN; if the ISBN was added with hyphens and you search without hyphens in the proper positions, you won't find the edition. The best way is most likely to remove the hyphens when the identifier is validated and automatically remove them when searching.


### Solution
Remove `-`(hyphens) from ISBN identifier when constructing identifiers


### Areas of Impact
Store ISBN without hyphens to maintain consistency and ease  in search
