### PR TITLE
Feat(EG):  Copy Edition name to Edition Group

### DIFF
--- a/src/client/entity-editor/name-section/actions.ts
+++ b/src/client/entity-editor/name-section/actions.ts
@@ -26,7 +26,7 @@ export const UPDATE_NAME_FIELD = 'UPDATE_NAME_FIELD';
 export const UPDATE_SORT_NAME_FIELD = 'UPDATE_SORT_NAME_FIELD';
 export const UPDATE_WARN_IF_EXISTS = 'UPDATE_WARN_IF_EXISTS';
 export const UPDATE_SEARCH_RESULTS = 'UPDATE_SEARCH_RESULTS';
-
+export const UPDATE_COPY_CHECKBOX = 'UPDATE_COPY_CHECKBOX';
 export type Action = {
 	type: string,
 	payload?: unknown,
@@ -201,5 +201,19 @@ export function searchName(
 					type: UPDATE_SEARCH_RESULTS
 				});
 			});
+	};
+}
+
+/**
+ * Produces an action indicating that the checkbox
+ * should be updated with the provided value.
+ *
+ * @param {boolean} isCheck - The new value to be used for the checkbox.
+ * @returns {Action} The resulting UPDATE_COPY_CHECKBOX action.
+ */
+export function updateCheckbox(isCheck:boolean): Action {
+	return {
+		payload: isCheck,
+		type: UPDATE_COPY_CHECKBOX
 	};
 }

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -16,13 +16,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {Alert, Col, ListGroup, Row} from 'react-bootstrap';
+import {Alert, Col, Form, ListGroup, Row} from 'react-bootstrap';
 import {
 	checkIfNameExists,
 	debouncedUpdateDisambiguationField,
 	debouncedUpdateNameField,
 	debouncedUpdateSortNameField,
 	searchName,
+	updateCheckbox,
 	updateLanguageField
 } from './actions';
 import {isAliasEmpty, isRequiredDisambiguationEmpty} from '../helpers';
@@ -63,6 +64,7 @@ import {getEntityDisambiguation} from '../../helpers/entity';
  * @param {string} props.nameValue - The name currently set for this entity.
  * @param {string} props.sortNameValue - The sort name currently set for this
  *        entity.
+ * @param {Function} props.onCheckboxToggle - A function to be called when toggle copy name to EG checkbox
  * @param {Function} props.onLanguageChange - A function to be called when a
  *        different language type is selected.
  * @param {Function} props.onNameChange - A function to be called when the name
@@ -129,6 +131,7 @@ class NameSection extends React.Component {
 
 	render() {
 		const {
+			action,
 			disambiguationDefaultValue,
 			entityType,
 			exactMatches,
@@ -136,6 +139,7 @@ class NameSection extends React.Component {
 			languageValue,
 			nameValue,
 			sortNameValue,
+			onCheckboxToggle,
 			onLanguageChange,
 			onSortNameChange,
 			onDisambiguationChange,
@@ -172,6 +176,17 @@ class NameSection extends React.Component {
 							onChange={this.handleNameChange}
 						/>
 					</Col>
+					{action === 'edit' && entityType === 'edition' &&
+					<Col className="md-2" lg={{offset: 3, span: 6}}>
+						<Form.Check
+							className="margin-bottom-d8"
+							id="name"
+							label="Copy the edition name to edition-group"
+							type="checkbox"
+							onChange={onCheckboxToggle}
+						/>
+					</Col>
+					}
 					<Col lg={{offset: 3, span: 6}}>
 						{isRequiredDisambiguationEmpty(
 							warnIfExists,
@@ -271,6 +286,7 @@ NameSection.propTypes = {
 	languageOptions: PropTypes.array.isRequired,
 	languageValue: PropTypes.number,
 	nameValue: PropTypes.string.isRequired,
+	onCheckboxToggle: PropTypes.func.isRequired,
 	onDisambiguationChange: PropTypes.func.isRequired,
 	onLanguageChange: PropTypes.func.isRequired,
 	onNameChange: PropTypes.func.isRequired,
@@ -314,6 +330,7 @@ function mapStateToProps(rootState) {
 function mapDispatchToProps(dispatch, {entity, entityType}) {
 	const entityBBID = entity && entity.bbid;
 	return {
+		onCheckboxToggle: (event) => dispatch(updateCheckbox(event.target.checked)),
 		onDisambiguationChange: (event) =>
 			dispatch(debouncedUpdateDisambiguationField(event.target.value)),
 		onLanguageChange: (value) =>

--- a/src/client/entity-editor/name-section/reducer.js
+++ b/src/client/entity-editor/name-section/reducer.js
@@ -17,14 +17,15 @@
  */
 
 import {
-	UPDATE_DISAMBIGUATION_FIELD, UPDATE_LANGUAGE_FIELD, UPDATE_NAME_FIELD,
-	UPDATE_SEARCH_RESULTS, UPDATE_SORT_NAME_FIELD, UPDATE_WARN_IF_EXISTS
+	UPDATE_COPY_CHECKBOX, UPDATE_DISAMBIGUATION_FIELD, UPDATE_LANGUAGE_FIELD,
+	UPDATE_NAME_FIELD, UPDATE_SEARCH_RESULTS, UPDATE_SORT_NAME_FIELD, UPDATE_WARN_IF_EXISTS
 } from './actions';
 import Immutable from 'immutable';
 
 
 function reducer(
 	state = Immutable.Map({
+		copyToEG: false,
 		disambiguation: '',
 		exactMatches: [],
 		language: null,
@@ -48,6 +49,8 @@ function reducer(
 			return state.set('searchResults', payload);
 		case UPDATE_WARN_IF_EXISTS:
 			return state.set('exactMatches', payload);
+		case UPDATE_COPY_CHECKBOX:
+			return state.set('copyToEG', payload);
 		// no default
 	}
 	return state;

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -73,6 +73,7 @@ function transformNewForm(data) {
 	return {
 		aliases,
 		annotation: data.annotationSection.content,
+		copyToEG: data.nameSection.copyToEG ?? false,
 		depth: data.editionSection.depth &&
 			parseInt(data.editionSection.depth, 10),
 		disambiguation: data.nameSection.disambiguation,


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
BB-663: Add option to copy Edition name to Edition Group

### Solution
<!-- What does this PR do to fix the problem? -->
Added checkbox for copying edition name to edition-group

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
nameSection component, createOrEditEnity function