### PR TITLE
Fix autocomplete search endpoint

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -31,7 +31,6 @@ import appCleanup from '../common/helpers/appCleanup';
 import compression from 'compression';
 import config from '../common/helpers/config';
 import {createClient} from 'redis';
-import {decodeUrlQueryParams} from './helpers/middleware';
 import express from 'express';
 import favicon from 'serve-favicon';
 import initInflux from './influx';
@@ -67,7 +66,6 @@ app.use(express.urlencoded({
 	extended: false
 }));
 app.use(compression());
-app.use(decodeUrlQueryParams);
 
 // Set up serving of static assets
 if (process.env.NODE_ENV === 'development') {

--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -97,6 +97,7 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadGenders, middleware.loadLanguages,
 	middleware.loadAuthorTypes, middleware.loadRelationshipTypes,
+	middleware.decodeUrlQueryParams,
 	async (req, res) => {
 		const markupProps = generateEntityProps(
 			'author', req, res, {

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -93,7 +93,8 @@ const router = express.Router();
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadEditionGroupTypes,
-	middleware.loadRelationshipTypes, async (req, res) => {
+	middleware.loadRelationshipTypes, middleware.decodeUrlQueryParams,
+	 async (req, res) => {
 		const markupProps = generateEntityProps(
 			'editionGroup', req, res, {}
 		);

--- a/src/server/routes/entity/edition.ts
+++ b/src/server/routes/entity/edition.ts
@@ -143,6 +143,7 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadEditionStatuses, middleware.loadEditionFormats,
 	middleware.loadLanguages, middleware.loadRelationshipTypes,
+	middleware.decodeUrlQueryParams,
 	(req:PassportRequest, res, next) => {
 		const {EditionGroup, Publisher, Work} = req.app.locals.orm;
 		const propsPromise = generateEntityProps(

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -93,7 +93,7 @@ const router = express.Router();
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublisherTypes,
-	middleware.loadRelationshipTypes,
+	middleware.loadRelationshipTypes, middleware.decodeUrlQueryParams,
 	async (req, res) => {
 		const markupProps = generateEntityProps(
 			'publisher', req, res, {}

--- a/src/server/routes/entity/series.js
+++ b/src/server/routes/entity/series.js
@@ -90,6 +90,7 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages,
 	middleware.loadRelationshipTypes, middleware.loadSeriesOrderingTypes,
+	middleware.decodeUrlQueryParams,
 	async (req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'series', req, res, {}

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -91,7 +91,7 @@ const router = express.Router();
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadWorkTypes,
-	middleware.loadRelationshipTypes,
+	middleware.loadRelationshipTypes, middleware.decodeUrlQueryParams,
 	(req, res, next) => {
 		const {Author, Edition} = req.app.locals.orm;
 		let relationshipTypeId;


### PR DESCRIPTION
The middleware `decodeUrlQueryParams` was introduced in #819 to fix an issue with encoding of names passed to an entity create route (see [BB-646](https://tickets.metabrainz.org/browse/BB-646)).
We didn't realize at the time before deploying to beta that the entity search component (used for example in the relationship editor) stopped working.
This is because the search endpoint is called with multiple type arguments of the same name (`…&type=author&type=work`) which was previously parsed as an array by ExpressJS.
The `decodeUrlQueryParams`  middleware changed that to a string or comma separated values ("author,work") instead of the expected array.

To fix this, let's apply the decodeUrlQueryParams middleware only for required `/$entityType/create` routes
