### PR TITLE
Add useful columns to entity views

### DIFF
--- a/sql/migrations/2022-06-28-views/down.sql
+++ b/sql/migrations/2022-06-28-views/down.sql
@@ -1,0 +1,87 @@
+-- Views --
+BEGIN;
+
+DROP VIEW bookbrainz.author;
+DROP VIEW bookbrainz.edition;
+DROP VIEW bookbrainz.edition_group;
+DROP VIEW bookbrainz.publisher;
+DROP VIEW bookbrainz.work;
+DROP VIEW bookbrainz.series;
+
+CREATE VIEW bookbrainz.author AS
+	SELECT
+		e.bbid, cd.id AS data_id, cr.id AS revision_id, (cr.id = c.master_revision_id) AS master, cd.annotation_id, cd.disambiguation_id,
+		als.default_alias_id, cd.begin_year, cd.begin_month, cd.begin_day, cd.begin_area_id,
+		cd.end_year, cd.end_month, cd.end_day, cd.end_area_id, cd.ended, cd.area_id,
+		cd.gender_id, cd.type_id, cd.alias_set_id, cd.identifier_set_id, cd.relationship_set_id, e.type
+	FROM bookbrainz.author_revision cr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = cr.bbid
+	LEFT JOIN bookbrainz.author_header c ON c.bbid = e.bbid
+	LEFT JOIN bookbrainz.author_data cd ON cr.data_id = cd.id
+	LEFT JOIN bookbrainz.alias_set als ON cd.alias_set_id = als.id
+	WHERE e.type = 'Author';
+
+CREATE VIEW bookbrainz.edition AS
+	SELECT
+		e.bbid, edd.id AS data_id, edr.id AS revision_id, (edr.id = ed.master_revision_id) AS master, edd.annotation_id, edd.disambiguation_id,
+		als.default_alias_id, edd.edition_group_bbid, edd.author_credit_id, edd.width, edd.height,
+		edd.depth, edd.weight, edd.pages, edd.format_id, edd.status_id,
+		edd.alias_set_id, edd.identifier_set_id, edd.relationship_set_id, e.type,
+		edd.language_set_id, edd.release_event_set_id, edd.publisher_set_id
+	FROM bookbrainz.edition_revision edr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = edr.bbid
+	LEFT JOIN bookbrainz.edition_header ed ON ed.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_data edd ON edr.data_id = edd.id
+	LEFT JOIN bookbrainz.alias_set als ON edd.alias_set_id = als.id
+	WHERE e.type = 'Edition';
+
+CREATE VIEW bookbrainz.work AS
+	SELECT
+		e.bbid, wd.id AS data_id, wr.id AS revision_id, (wr.id = w.master_revision_id) AS master, wd.annotation_id, wd.disambiguation_id,
+		als.default_alias_id, wd.type_id, wd.alias_set_id, wd.identifier_set_id,
+		wd.relationship_set_id, e.type, wd.language_set_id
+	FROM bookbrainz.work_revision wr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = wr.bbid
+	LEFT JOIN bookbrainz.work_header w ON w.bbid = e.bbid
+	LEFT JOIN bookbrainz.work_data wd ON wr.data_id = wd.id
+	LEFT JOIN bookbrainz.alias_set als ON wd.alias_set_id = als.id
+	WHERE e.type = 'Work';
+
+CREATE VIEW bookbrainz.publisher AS
+	SELECT
+		e.bbid, psd.id AS data_id, psr.id AS revision_id, (psr.id = ps.master_revision_id) AS master, psd.annotation_id, psd.disambiguation_id,
+		als.default_alias_id, psd.begin_year, psd.begin_month, psd.begin_day,
+		psd.end_year, psd.end_month, psd.end_day, psd.ended, psd.area_id,
+		psd.type_id, psd.alias_set_id, psd.identifier_set_id, psd.relationship_set_id, e.type
+	FROM bookbrainz.publisher_revision psr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = psr.bbid
+	LEFT JOIN bookbrainz.publisher_header ps ON ps.bbid = e.bbid
+	LEFT JOIN bookbrainz.publisher_data psd ON psr.data_id = psd.id
+	LEFT JOIN bookbrainz.alias_set als ON psd.alias_set_id = als.id
+	WHERE e.type = 'Publisher';
+
+CREATE VIEW bookbrainz.edition_group AS
+	SELECT
+		e.bbid, pcd.id AS data_id, pcr.id AS revision_id, (pcr.id = pc.master_revision_id) AS master, pcd.annotation_id, pcd.disambiguation_id,
+		als.default_alias_id, pcd.type_id, pcd.author_credit_id, pcd.alias_set_id, pcd.identifier_set_id,
+		pcd.relationship_set_id, e.type
+	FROM bookbrainz.edition_group_revision pcr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = pcr.bbid
+	LEFT JOIN bookbrainz.edition_group_header pc ON pc.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_group_data pcd ON pcr.data_id = pcd.id
+	LEFT JOIN bookbrainz.alias_set als ON pcd.alias_set_id = als.id
+	WHERE e.type = 'EditionGroup';
+
+CREATE VIEW bookbrainz.series AS
+	SELECT
+		e.bbid, sd.id AS data_id, sr.id AS revision_id, (sr.id = s.master_revision_id) AS master, sd.entity_type, sd.annotation_id, sd.disambiguation_id,
+		als.default_alias_id, sd.ordering_type_id, sd.alias_set_id, sd.identifier_set_id,
+		sd.relationship_set_id, e.type
+	FROM bookbrainz.series_revision sr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = sr.bbid
+	LEFT JOIN bookbrainz.series_header s ON s.bbid = e.bbid
+	LEFT JOIN bookbrainz.series_data sd ON sr.data_id = sd.id
+	LEFT JOIN bookbrainz.alias_set als ON sd.alias_set_id = als.id
+	WHERE e.type = 'Series';
+	
+COMMIT;

--- a/sql/migrations/2022-06-28-views/up.sql
+++ b/sql/migrations/2022-06-28-views/up.sql
@@ -1,3 +1,7 @@
+-- IMPORTANT ! --
+-- Do not forget to run the sql/scripts/create_triggers.sql script
+-- since we are dropping the and recreating the views --
+
 -- Views --
 BEGIN;
 
@@ -10,30 +14,30 @@ DROP VIEW bookbrainz.series;
 
 CREATE OR REPLACE VIEW bookbrainz.author AS
 	SELECT
-		e.bbid, cd.id AS data_id, cr.id AS revision_id, (cr.id = c.master_revision_id) AS master, cd.annotation_id, dis.comment,
-		als.default_alias_id, al."name", al.sort_name, cd.begin_year, cd.begin_month, cd.begin_day, cd.begin_area_id,
-		cd.end_year, cd.end_month, cd.end_day, cd.end_area_id, cd.ended, cd.area_id,
-		cd.gender_id, cd.type_id, atype.label as author_type, cd.alias_set_id, cd.identifier_set_id, cd.relationship_set_id, e.type
-	FROM bookbrainz.author_revision cr
-	LEFT JOIN bookbrainz.entity e ON e.bbid = cr.bbid
-	LEFT JOIN bookbrainz.author_header c ON c.bbid = e.bbid
-	LEFT JOIN bookbrainz.author_data cd ON cr.data_id = cd.id
-	LEFT JOIN bookbrainz.alias_set als ON cd.alias_set_id = als.id
+		e.bbid, ad.id AS data_id, ar.id AS revision_id, (ar.id = ah.master_revision_id) AS master, ad.annotation_id, ad.disambiguation_id, dis.comment disambiguation,
+		als.default_alias_id, al."name", al.sort_name, ad.begin_year, ad.begin_month, ad.begin_day, ad.begin_area_id,
+		ad.end_year, ad.end_month, ad.end_day, ad.end_area_id, ad.ended, ad.area_id,
+		ad.gender_id, ad.type_id, atype.label as author_type, ad.alias_set_id, ad.identifier_set_id, ad.relationship_set_id, e.type
+	FROM bookbrainz.author_revision ar
+	LEFT JOIN bookbrainz.entity e ON e.bbid = ar.bbid
+	LEFT JOIN bookbrainz.author_header ah ON ah.bbid = e.bbid
+	LEFT JOIN bookbrainz.author_data ad ON ar.data_id = ad.id
+	LEFT JOIN bookbrainz.alias_set als ON ad.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
-	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = cd.disambiguation_id
-	LEFT JOIN bookbrainz.author_type atype ON atype.id = cd.type_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = ad.disambiguation_id
+	LEFT JOIN bookbrainz.author_type atype ON atype.id = ad.type_id
 	WHERE e.type = 'Author';
 
 CREATE OR REPLACE VIEW bookbrainz.edition AS
 	SELECT
-		e.bbid, edd.id AS data_id, edr.id AS revision_id, (edr.id = ed.master_revision_id) AS master, edd.annotation_id, dis.comment,
+		e.bbid, edd.id AS data_id, edr.id AS revision_id, (edr.id = edh.master_revision_id) AS master, edd.annotation_id, edd.disambiguation_id, dis.comment disambiguation,
 		als.default_alias_id, al."name", al.sort_name, edd.edition_group_bbid, edd.author_credit_id, edd.width, edd.height,
 		edd.depth, edd.weight, edd.pages, edd.format_id, edd.status_id,
-		edd.alias_set_id, edd.identifier_set_id, edd.relationship_set_id, e.type,
-		edd.language_set_id, edd.release_event_set_id, edd.publisher_set_id
+		edd.alias_set_id, edd.identifier_set_id, edd.relationship_set_id,
+		edd.language_set_id, edd.release_event_set_id, edd.publisher_set_id, e.type
 	FROM bookbrainz.edition_revision edr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = edr.bbid
-	LEFT JOIN bookbrainz.edition_header ed ON ed.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_header edh ON edh.bbid = e.bbid
 	LEFT JOIN bookbrainz.edition_data edd ON edr.data_id = edd.id
 	LEFT JOIN bookbrainz.alias_set als ON edd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
@@ -42,58 +46,58 @@ CREATE OR REPLACE VIEW bookbrainz.edition AS
 
 CREATE OR REPLACE VIEW bookbrainz.work AS
 	SELECT
-		e.bbid, wd.id AS data_id, wr.id AS revision_id, (wr.id = w.master_revision_id) AS master, wd.annotation_id, dis.comment,
+		e.bbid, wd.id AS data_id, wr.id AS revision_id, ( wr.id = wh.master_revision_id) AS master, wd.annotation_id, wd.disambiguation_id, dis.comment disambiguation,
 		als.default_alias_id, al."name", al.sort_name, wd.type_id, worktype.label as work_type, wd.alias_set_id, wd.identifier_set_id,
-		wd.relationship_set_id, e.type, wd.language_set_id
+		wd.relationship_set_id, wd.language_set_id, e.type
 	FROM bookbrainz.work_revision wr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = wr.bbid
-	LEFT JOIN bookbrainz.work_header w ON w.bbid = e.bbid
+	LEFT JOIN bookbrainz.work_header wh ON wh.bbid = e.bbid
 	LEFT JOIN bookbrainz.work_data wd ON wr.data_id = wd.id
 	LEFT JOIN bookbrainz.alias_set als ON wd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
 	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = wd.disambiguation_id
-	LEFT JOIN bookbrainz.publisher_type worktype ON worktype.id = wd.type_id
+	LEFT JOIN bookbrainz.work_type worktype ON worktype.id = wd.type_id
 	WHERE e.type = 'Work';
 
 CREATE OR REPLACE VIEW bookbrainz.publisher AS
 	SELECT
-		e.bbid, psd.id AS data_id, psr.id AS revision_id, (psr.id = ps.master_revision_id) AS master, psd.annotation_id, dis.comment,
-		als.default_alias_id, al."name", al.sort_name, psd.begin_year, psd.begin_month, psd.begin_day,
-		psd.end_year, psd.end_month, psd.end_day, psd.ended, psd.area_id,
-		psd.type_id, pubtype.label as publisher_type, psd.alias_set_id, psd.identifier_set_id, psd.relationship_set_id, e.type
+		e.bbid, pubd.id AS data_id, psr.id AS revision_id, (psr.id = pubh.master_revision_id) AS master, pubd.annotation_id, pubd.disambiguation_id, dis.comment disambiguation,
+		als.default_alias_id, al."name", al.sort_name, pubd.begin_year, pubd.begin_month, pubd.begin_day,
+		pubd.end_year, pubd.end_month, pubd.end_day, pubd.ended, pubd.area_id,
+		pubd.type_id, pubtype.label as publisher_type, pubd.alias_set_id, pubd.identifier_set_id, pubd.relationship_set_id, e.type
 	FROM bookbrainz.publisher_revision psr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = psr.bbid
-	LEFT JOIN bookbrainz.publisher_header ps ON ps.bbid = e.bbid
-	LEFT JOIN bookbrainz.publisher_data psd ON psr.data_id = psd.id
-	LEFT JOIN bookbrainz.alias_set als ON psd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.publisher_header pubh ON pubh.bbid = e.bbid
+	LEFT JOIN bookbrainz.publisher_data pubd ON psr.data_id = pubd.id
+	LEFT JOIN bookbrainz.alias_set als ON pubd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
-	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = psd.disambiguation_id
-	LEFT JOIN bookbrainz.publisher_type pubtype ON pubtype.id = psd.type_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = pubd.disambiguation_id
+	LEFT JOIN bookbrainz.publisher_type pubtype ON pubtype.id = pubd.type_id
 	WHERE e.type = 'Publisher';
 
 CREATE OR REPLACE VIEW bookbrainz.edition_group AS
 	SELECT
-		e.bbid, pcd.id AS data_id, pcr.id AS revision_id, (pcr.id = pc.master_revision_id) AS master, pcd.annotation_id, dis.comment,
-		als.default_alias_id, al."name", al.sort_name, pcd.type_id, egtype.label as edition_group_type, pcd.author_credit_id, pcd.alias_set_id, pcd.identifier_set_id,
-		pcd.relationship_set_id, e.type
+		e.bbid, egd.id AS data_id, pcr.id AS revision_id, (pcr.id = egh.master_revision_id) AS master, egd.annotation_id, egd.disambiguation_id, dis.comment disambiguation,
+		als.default_alias_id, al."name", al.sort_name, egd.type_id, egtype.label as edition_group_type, egd.author_credit_id, egd.alias_set_id, egd.identifier_set_id,
+		egd.relationship_set_id, e.type
 	FROM bookbrainz.edition_group_revision pcr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = pcr.bbid
-	LEFT JOIN bookbrainz.edition_group_header pc ON pc.bbid = e.bbid
-	LEFT JOIN bookbrainz.edition_group_data pcd ON pcr.data_id = pcd.id
-	LEFT JOIN bookbrainz.alias_set als ON pcd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.edition_group_header egh ON egh.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_group_data egd ON pcr.data_id = egd.id
+	LEFT JOIN bookbrainz.alias_set als ON egd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
-	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = pcd.disambiguation_id
-	LEFT JOIN bookbrainz.edition_group_type egtype ON egtype.id = pcd.type_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = egd.disambiguation_id
+	LEFT JOIN bookbrainz.edition_group_type egtype ON egtype.id = egd.type_id
 	WHERE e.type = 'EditionGroup';
 
 CREATE OR REPLACE VIEW bookbrainz.series AS
 	SELECT
-		e.bbid, sd.id AS data_id, sr.id AS revision_id, (sr.id = s.master_revision_id) AS master, sd.entity_type, sd.annotation_id, dis.comment,
+		e.bbid, sd.id AS data_id, sr.id AS revision_id, (sr.id = sh.master_revision_id) AS master, sd.entity_type, sd.annotation_id, sd.disambiguation_id, dis.comment disambiguation,
 		als.default_alias_id, al."name", al.sort_name, sd.ordering_type_id, sd.alias_set_id, sd.identifier_set_id,
 		sd.relationship_set_id, e.type
 	FROM bookbrainz.series_revision sr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = sr.bbid
-	LEFT JOIN bookbrainz.series_header s ON s.bbid = e.bbid
+	LEFT JOIN bookbrainz.series_header sh ON sh.bbid = e.bbid
 	LEFT JOIN bookbrainz.series_data sd ON sr.data_id = sd.id
 	LEFT JOIN bookbrainz.alias_set als ON sd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id

--- a/sql/migrations/2022-06-28-views/up.sql
+++ b/sql/migrations/2022-06-28-views/up.sql
@@ -1,0 +1,104 @@
+-- Views --
+BEGIN;
+
+DROP VIEW bookbrainz.author;
+DROP VIEW bookbrainz.edition;
+DROP VIEW bookbrainz.edition_group;
+DROP VIEW bookbrainz.publisher;
+DROP VIEW bookbrainz.work;
+DROP VIEW bookbrainz.series;
+
+CREATE OR REPLACE VIEW bookbrainz.author AS
+	SELECT
+		e.bbid, cd.id AS data_id, cr.id AS revision_id, (cr.id = c.master_revision_id) AS master, cd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, cd.begin_year, cd.begin_month, cd.begin_day, cd.begin_area_id,
+		cd.end_year, cd.end_month, cd.end_day, cd.end_area_id, cd.ended, cd.area_id,
+		cd.gender_id, cd.type_id, atype.label as author_type, cd.alias_set_id, cd.identifier_set_id, cd.relationship_set_id, e.type
+	FROM bookbrainz.author_revision cr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = cr.bbid
+	LEFT JOIN bookbrainz.author_header c ON c.bbid = e.bbid
+	LEFT JOIN bookbrainz.author_data cd ON cr.data_id = cd.id
+	LEFT JOIN bookbrainz.alias_set als ON cd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = cd.disambiguation_id
+	LEFT JOIN bookbrainz.author_type atype ON atype.id = cd.type_id
+	WHERE e.type = 'Author';
+
+CREATE OR REPLACE VIEW bookbrainz.edition AS
+	SELECT
+		e.bbid, edd.id AS data_id, edr.id AS revision_id, (edr.id = ed.master_revision_id) AS master, edd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, edd.edition_group_bbid, edd.author_credit_id, edd.width, edd.height,
+		edd.depth, edd.weight, edd.pages, edd.format_id, edd.status_id,
+		edd.alias_set_id, edd.identifier_set_id, edd.relationship_set_id, e.type,
+		edd.language_set_id, edd.release_event_set_id, edd.publisher_set_id
+	FROM bookbrainz.edition_revision edr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = edr.bbid
+	LEFT JOIN bookbrainz.edition_header ed ON ed.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_data edd ON edr.data_id = edd.id
+	LEFT JOIN bookbrainz.alias_set als ON edd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = edd.disambiguation_id
+	WHERE e.type = 'Edition';
+
+CREATE OR REPLACE VIEW bookbrainz.work AS
+	SELECT
+		e.bbid, wd.id AS data_id, wr.id AS revision_id, (wr.id = w.master_revision_id) AS master, wd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, wd.type_id, worktype.label as work_type, wd.alias_set_id, wd.identifier_set_id,
+		wd.relationship_set_id, e.type, wd.language_set_id
+	FROM bookbrainz.work_revision wr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = wr.bbid
+	LEFT JOIN bookbrainz.work_header w ON w.bbid = e.bbid
+	LEFT JOIN bookbrainz.work_data wd ON wr.data_id = wd.id
+	LEFT JOIN bookbrainz.alias_set als ON wd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = wd.disambiguation_id
+	LEFT JOIN bookbrainz.publisher_type worktype ON worktype.id = wd.type_id
+	WHERE e.type = 'Work';
+
+CREATE OR REPLACE VIEW bookbrainz.publisher AS
+	SELECT
+		e.bbid, psd.id AS data_id, psr.id AS revision_id, (psr.id = ps.master_revision_id) AS master, psd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, psd.begin_year, psd.begin_month, psd.begin_day,
+		psd.end_year, psd.end_month, psd.end_day, psd.ended, psd.area_id,
+		psd.type_id, pubtype.label as publisher_type, psd.alias_set_id, psd.identifier_set_id, psd.relationship_set_id, e.type
+	FROM bookbrainz.publisher_revision psr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = psr.bbid
+	LEFT JOIN bookbrainz.publisher_header ps ON ps.bbid = e.bbid
+	LEFT JOIN bookbrainz.publisher_data psd ON psr.data_id = psd.id
+	LEFT JOIN bookbrainz.alias_set als ON psd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = psd.disambiguation_id
+	LEFT JOIN bookbrainz.publisher_type pubtype ON pubtype.id = psd.type_id
+	WHERE e.type = 'Publisher';
+
+CREATE OR REPLACE VIEW bookbrainz.edition_group AS
+	SELECT
+		e.bbid, pcd.id AS data_id, pcr.id AS revision_id, (pcr.id = pc.master_revision_id) AS master, pcd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, pcd.type_id, egtype.label as edition_group_type, pcd.author_credit_id, pcd.alias_set_id, pcd.identifier_set_id,
+		pcd.relationship_set_id, e.type
+	FROM bookbrainz.edition_group_revision pcr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = pcr.bbid
+	LEFT JOIN bookbrainz.edition_group_header pc ON pc.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_group_data pcd ON pcr.data_id = pcd.id
+	LEFT JOIN bookbrainz.alias_set als ON pcd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = pcd.disambiguation_id
+	LEFT JOIN bookbrainz.edition_group_type egtype ON egtype.id = pcd.type_id
+	WHERE e.type = 'EditionGroup';
+
+CREATE OR REPLACE VIEW bookbrainz.series AS
+	SELECT
+		e.bbid, sd.id AS data_id, sr.id AS revision_id, (sr.id = s.master_revision_id) AS master, sd.entity_type, sd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, sd.ordering_type_id, sd.alias_set_id, sd.identifier_set_id,
+		sd.relationship_set_id, e.type
+	FROM bookbrainz.series_revision sr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = sr.bbid
+	LEFT JOIN bookbrainz.series_header s ON s.bbid = e.bbid
+	LEFT JOIN bookbrainz.series_data sd ON sr.data_id = sd.id
+	LEFT JOIN bookbrainz.alias_set als ON sd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = sd.disambiguation_id
+	WHERE e.type = 'Series';
+
+COMMIT;
+

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -560,7 +560,7 @@ ALTER TABLE bookbrainz.relationship ADD FOREIGN KEY (target_bbid) REFERENCES boo
 -- Relationship Attributes
 
 CREATE TABLE bookbrainz.relationship_attribute_set (
-	id SERIAL PRIMARY KEY 
+	id SERIAL PRIMARY KEY
 );
 
 ALTER TABLE bookbrainz.relationship ADD COLUMN attribute_set_id INTEGER;
@@ -585,7 +585,7 @@ CREATE TABLE bookbrainz.relationship_type__attribute_type (
 );
 
 CREATE TABLE bookbrainz.relationship_attribute (
-  id SERIAL PRIMARY KEY, 
+  id SERIAL PRIMARY KEY,
   attribute_type INT NOT NULL REFERENCES bookbrainz.relationship_attribute_type(id)
 );
 
@@ -598,7 +598,7 @@ CREATE TABLE bookbrainz.relationship_attribute_set__relationship_attribute (
 	set_id INTEGER REFERENCES bookbrainz.relationship_attribute_set (id),
 	attribute_id INTEGER REFERENCES bookbrainz.relationship_attribute (id),
   PRIMARY KEY (
-    set_id, 
+    set_id,
     attribute_id
   )
 );
@@ -810,30 +810,30 @@ ALTER TABLE bookbrainz.user_collection_collaborator ADD FOREIGN KEY (collaborato
 
 CREATE VIEW bookbrainz.author AS
 	SELECT
-		e.bbid, cd.id AS data_id, cr.id AS revision_id, (cr.id = c.master_revision_id) AS master, cd.annotation_id, dis.comment,
-		als.default_alias_id, al."name", al.sort_name, cd.begin_year, cd.begin_month, cd.begin_day, cd.begin_area_id,
-		cd.end_year, cd.end_month, cd.end_day, cd.end_area_id, cd.ended, cd.area_id,
-		cd.gender_id, cd.type_id, atype.label as author_type, cd.alias_set_id, cd.identifier_set_id, cd.relationship_set_id, e.type
-	FROM bookbrainz.author_revision cr
-	LEFT JOIN bookbrainz.entity e ON e.bbid = cr.bbid
-	LEFT JOIN bookbrainz.author_header c ON c.bbid = e.bbid
-	LEFT JOIN bookbrainz.author_data cd ON cr.data_id = cd.id
-	LEFT JOIN bookbrainz.alias_set als ON cd.alias_set_id = als.id
+		e.bbid, ad.id AS data_id, ar.id AS revision_id, (ar.id = ah.master_revision_id) AS master, ad.annotation_id, ad.disambiguation_id, dis.comment disambiguation,
+		als.default_alias_id, al."name", al.sort_name, ad.begin_year, ad.begin_month, ad.begin_day, ad.begin_area_id,
+		ad.end_year, ad.end_month, ad.end_day, ad.end_area_id, ad.ended, ad.area_id,
+		ad.gender_id, ad.type_id, atype.label as author_type, ad.alias_set_id, ad.identifier_set_id, ad.relationship_set_id, e.type
+	FROM bookbrainz.author_revision ar
+	LEFT JOIN bookbrainz.entity e ON e.bbid = ar.bbid
+	LEFT JOIN bookbrainz.author_header ah ON ah.bbid = e.bbid
+	LEFT JOIN bookbrainz.author_data ad ON ar.data_id = ad.id
+	LEFT JOIN bookbrainz.alias_set als ON ad.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
-	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = cd.disambiguation_id
-	LEFT JOIN bookbrainz.author_type atype ON atype.id = cd.type_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = ad.disambiguation_id
+	LEFT JOIN bookbrainz.author_type atype ON atype.id = ad.type_id
 	WHERE e.type = 'Author';
 
 CREATE VIEW bookbrainz.edition AS
 	SELECT
-		e.bbid, edd.id AS data_id, edr.id AS revision_id, (edr.id = ed.master_revision_id) AS master, edd.annotation_id, dis.comment,
+		e.bbid, edd.id AS data_id, edr.id AS revision_id, (edr.id = edh.master_revision_id) AS master, edd.annotation_id, edd.disambiguation_id, dis.comment disambiguation,
 		als.default_alias_id, al."name", al.sort_name, edd.edition_group_bbid, edd.author_credit_id, edd.width, edd.height,
 		edd.depth, edd.weight, edd.pages, edd.format_id, edd.status_id,
-		edd.alias_set_id, edd.identifier_set_id, edd.relationship_set_id, e.type,
-		edd.language_set_id, edd.release_event_set_id, edd.publisher_set_id
+		edd.alias_set_id, edd.identifier_set_id, edd.relationship_set_id,
+		edd.language_set_id, edd.release_event_set_id, edd.publisher_set_id, e.type
 	FROM bookbrainz.edition_revision edr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = edr.bbid
-	LEFT JOIN bookbrainz.edition_header ed ON ed.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_header edh ON edh.bbid = e.bbid
 	LEFT JOIN bookbrainz.edition_data edd ON edr.data_id = edd.id
 	LEFT JOIN bookbrainz.alias_set als ON edd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
@@ -842,58 +842,58 @@ CREATE VIEW bookbrainz.edition AS
 
 CREATE VIEW bookbrainz.work AS
 	SELECT
-		e.bbid, wd.id AS data_id, wr.id AS revision_id, (wr.id = w.master_revision_id) AS master, wd.annotation_id, dis.comment,
+		e.bbid, wd.id AS data_id, wr.id AS revision_id, ( wr.id = wh.master_revision_id) AS master, wd.annotation_id, wd.disambiguation_id, dis.comment disambiguation,
 		als.default_alias_id, al."name", al.sort_name, wd.type_id, worktype.label as work_type, wd.alias_set_id, wd.identifier_set_id,
-		wd.relationship_set_id, e.type, wd.language_set_id
+		wd.relationship_set_id, wd.language_set_id, e.type
 	FROM bookbrainz.work_revision wr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = wr.bbid
-	LEFT JOIN bookbrainz.work_header w ON w.bbid = e.bbid
+	LEFT JOIN bookbrainz.work_header wh ON wh.bbid = e.bbid
 	LEFT JOIN bookbrainz.work_data wd ON wr.data_id = wd.id
 	LEFT JOIN bookbrainz.alias_set als ON wd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
 	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = wd.disambiguation_id
-	LEFT JOIN bookbrainz.publisher_type worktype ON worktype.id = wd.type_id
+	LEFT JOIN bookbrainz.work_type worktype ON worktype.id = wd.type_id
 	WHERE e.type = 'Work';
 
 CREATE VIEW bookbrainz.publisher AS
 	SELECT
-		e.bbid, psd.id AS data_id, psr.id AS revision_id, (psr.id = ps.master_revision_id) AS master, psd.annotation_id, dis.comment,
-		als.default_alias_id, al."name", al.sort_name, psd.begin_year, psd.begin_month, psd.begin_day,
-		psd.end_year, psd.end_month, psd.end_day, psd.ended, psd.area_id,
-		psd.type_id, pubtype.label as publisher_type, psd.alias_set_id, psd.identifier_set_id, psd.relationship_set_id, e.type
+		e.bbid, pubd.id AS data_id, psr.id AS revision_id, (psr.id = pubh.master_revision_id) AS master, pubd.annotation_id, pubd.disambiguation_id, dis.comment disambiguation,
+		als.default_alias_id, al."name", al.sort_name, pubd.begin_year, pubd.begin_month, pubd.begin_day,
+		pubd.end_year, pubd.end_month, pubd.end_day, pubd.ended, pubd.area_id,
+		pubd.type_id, pubtype.label as publisher_type, pubd.alias_set_id, pubd.identifier_set_id, pubd.relationship_set_id, e.type
 	FROM bookbrainz.publisher_revision psr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = psr.bbid
-	LEFT JOIN bookbrainz.publisher_header ps ON ps.bbid = e.bbid
-	LEFT JOIN bookbrainz.publisher_data psd ON psr.data_id = psd.id
-	LEFT JOIN bookbrainz.alias_set als ON psd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.publisher_header pubh ON pubh.bbid = e.bbid
+	LEFT JOIN bookbrainz.publisher_data pubd ON psr.data_id = pubd.id
+	LEFT JOIN bookbrainz.alias_set als ON pubd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
-	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = psd.disambiguation_id
-	LEFT JOIN bookbrainz.publisher_type pubtype ON pubtype.id = psd.type_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = pubd.disambiguation_id
+	LEFT JOIN bookbrainz.publisher_type pubtype ON pubtype.id = pubd.type_id
 	WHERE e.type = 'Publisher';
 
 CREATE VIEW bookbrainz.edition_group AS
 	SELECT
-		e.bbid, pcd.id AS data_id, pcr.id AS revision_id, (pcr.id = pc.master_revision_id) AS master, pcd.annotation_id, dis.comment,
-		als.default_alias_id, al."name", al.sort_name, pcd.type_id, egtype.label as edition_group_type, pcd.author_credit_id, pcd.alias_set_id, pcd.identifier_set_id,
-		pcd.relationship_set_id, e.type
+		e.bbid, egd.id AS data_id, pcr.id AS revision_id, (pcr.id = egh.master_revision_id) AS master, egd.annotation_id, egd.disambiguation_id, dis.comment disambiguation,
+		als.default_alias_id, al."name", al.sort_name, egd.type_id, egtype.label as edition_group_type, egd.author_credit_id, egd.alias_set_id, egd.identifier_set_id,
+		egd.relationship_set_id, e.type
 	FROM bookbrainz.edition_group_revision pcr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = pcr.bbid
-	LEFT JOIN bookbrainz.edition_group_header pc ON pc.bbid = e.bbid
-	LEFT JOIN bookbrainz.edition_group_data pcd ON pcr.data_id = pcd.id
-	LEFT JOIN bookbrainz.alias_set als ON pcd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.edition_group_header egh ON egh.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_group_data egd ON pcr.data_id = egd.id
+	LEFT JOIN bookbrainz.alias_set als ON egd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
-	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = pcd.disambiguation_id
-	LEFT JOIN bookbrainz.edition_group_type egtype ON egtype.id = pcd.type_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = egd.disambiguation_id
+	LEFT JOIN bookbrainz.edition_group_type egtype ON egtype.id = egd.type_id
 	WHERE e.type = 'EditionGroup';
 
 CREATE VIEW bookbrainz.series AS
 	SELECT
-		e.bbid, sd.id AS data_id, sr.id AS revision_id, (sr.id = s.master_revision_id) AS master, sd.entity_type, sd.annotation_id, dis.comment,
+		e.bbid, sd.id AS data_id, sr.id AS revision_id, (sr.id = sh.master_revision_id) AS master, sd.entity_type, sd.annotation_id, sd.disambiguation_id, dis.comment disambiguation,
 		als.default_alias_id, al."name", al.sort_name, sd.ordering_type_id, sd.alias_set_id, sd.identifier_set_id,
 		sd.relationship_set_id, e.type
 	FROM bookbrainz.series_revision sr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = sr.bbid
-	LEFT JOIN bookbrainz.series_header s ON s.bbid = e.bbid
+	LEFT JOIN bookbrainz.series_header sh ON sh.bbid = e.bbid
 	LEFT JOIN bookbrainz.series_data sd ON sr.data_id = sd.id
 	LEFT JOIN bookbrainz.alias_set als ON sd.alias_set_id = als.id
 	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -810,21 +810,24 @@ ALTER TABLE bookbrainz.user_collection_collaborator ADD FOREIGN KEY (collaborato
 
 CREATE VIEW bookbrainz.author AS
 	SELECT
-		e.bbid, cd.id AS data_id, cr.id AS revision_id, (cr.id = c.master_revision_id) AS master, cd.annotation_id, cd.disambiguation_id,
-		als.default_alias_id, cd.begin_year, cd.begin_month, cd.begin_day, cd.begin_area_id,
+		e.bbid, cd.id AS data_id, cr.id AS revision_id, (cr.id = c.master_revision_id) AS master, cd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, cd.begin_year, cd.begin_month, cd.begin_day, cd.begin_area_id,
 		cd.end_year, cd.end_month, cd.end_day, cd.end_area_id, cd.ended, cd.area_id,
-		cd.gender_id, cd.type_id, cd.alias_set_id, cd.identifier_set_id, cd.relationship_set_id, e.type
+		cd.gender_id, cd.type_id, atype.label as author_type, cd.alias_set_id, cd.identifier_set_id, cd.relationship_set_id, e.type
 	FROM bookbrainz.author_revision cr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = cr.bbid
 	LEFT JOIN bookbrainz.author_header c ON c.bbid = e.bbid
 	LEFT JOIN bookbrainz.author_data cd ON cr.data_id = cd.id
 	LEFT JOIN bookbrainz.alias_set als ON cd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = cd.disambiguation_id
+	LEFT JOIN bookbrainz.author_type atype ON atype.id = cd.type_id
 	WHERE e.type = 'Author';
 
 CREATE VIEW bookbrainz.edition AS
 	SELECT
-		e.bbid, edd.id AS data_id, edr.id AS revision_id, (edr.id = ed.master_revision_id) AS master, edd.annotation_id, edd.disambiguation_id,
-		als.default_alias_id, edd.edition_group_bbid, edd.author_credit_id, edd.width, edd.height,
+		e.bbid, edd.id AS data_id, edr.id AS revision_id, (edr.id = ed.master_revision_id) AS master, edd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, edd.edition_group_bbid, edd.author_credit_id, edd.width, edd.height,
 		edd.depth, edd.weight, edd.pages, edd.format_id, edd.status_id,
 		edd.alias_set_id, edd.identifier_set_id, edd.relationship_set_id, e.type,
 		edd.language_set_id, edd.release_event_set_id, edd.publisher_set_id
@@ -833,57 +836,71 @@ CREATE VIEW bookbrainz.edition AS
 	LEFT JOIN bookbrainz.edition_header ed ON ed.bbid = e.bbid
 	LEFT JOIN bookbrainz.edition_data edd ON edr.data_id = edd.id
 	LEFT JOIN bookbrainz.alias_set als ON edd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = edd.disambiguation_id
 	WHERE e.type = 'Edition';
 
 CREATE VIEW bookbrainz.work AS
 	SELECT
-		e.bbid, wd.id AS data_id, wr.id AS revision_id, (wr.id = w.master_revision_id) AS master, wd.annotation_id, wd.disambiguation_id,
-		als.default_alias_id, wd.type_id, wd.alias_set_id, wd.identifier_set_id,
+		e.bbid, wd.id AS data_id, wr.id AS revision_id, (wr.id = w.master_revision_id) AS master, wd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, wd.type_id, worktype.label as work_type, wd.alias_set_id, wd.identifier_set_id,
 		wd.relationship_set_id, e.type, wd.language_set_id
 	FROM bookbrainz.work_revision wr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = wr.bbid
 	LEFT JOIN bookbrainz.work_header w ON w.bbid = e.bbid
 	LEFT JOIN bookbrainz.work_data wd ON wr.data_id = wd.id
 	LEFT JOIN bookbrainz.alias_set als ON wd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = wd.disambiguation_id
+	LEFT JOIN bookbrainz.publisher_type worktype ON worktype.id = wd.type_id
 	WHERE e.type = 'Work';
 
 CREATE VIEW bookbrainz.publisher AS
 	SELECT
-		e.bbid, psd.id AS data_id, psr.id AS revision_id, (psr.id = ps.master_revision_id) AS master, psd.annotation_id, psd.disambiguation_id,
-		als.default_alias_id, psd.begin_year, psd.begin_month, psd.begin_day,
+		e.bbid, psd.id AS data_id, psr.id AS revision_id, (psr.id = ps.master_revision_id) AS master, psd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, psd.begin_year, psd.begin_month, psd.begin_day,
 		psd.end_year, psd.end_month, psd.end_day, psd.ended, psd.area_id,
-		psd.type_id, psd.alias_set_id, psd.identifier_set_id, psd.relationship_set_id, e.type
+		psd.type_id, pubtype.label as publisher_type, psd.alias_set_id, psd.identifier_set_id, psd.relationship_set_id, e.type
 	FROM bookbrainz.publisher_revision psr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = psr.bbid
 	LEFT JOIN bookbrainz.publisher_header ps ON ps.bbid = e.bbid
 	LEFT JOIN bookbrainz.publisher_data psd ON psr.data_id = psd.id
 	LEFT JOIN bookbrainz.alias_set als ON psd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = psd.disambiguation_id
+	LEFT JOIN bookbrainz.publisher_type pubtype ON pubtype.id = psd.type_id
 	WHERE e.type = 'Publisher';
 
 CREATE VIEW bookbrainz.edition_group AS
 	SELECT
-		e.bbid, pcd.id AS data_id, pcr.id AS revision_id, (pcr.id = pc.master_revision_id) AS master, pcd.annotation_id, pcd.disambiguation_id,
-		als.default_alias_id, pcd.type_id, pcd.author_credit_id, pcd.alias_set_id, pcd.identifier_set_id,
+		e.bbid, pcd.id AS data_id, pcr.id AS revision_id, (pcr.id = pc.master_revision_id) AS master, pcd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, pcd.type_id, egtype.label as edition_group_type, pcd.author_credit_id, pcd.alias_set_id, pcd.identifier_set_id,
 		pcd.relationship_set_id, e.type
 	FROM bookbrainz.edition_group_revision pcr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = pcr.bbid
 	LEFT JOIN bookbrainz.edition_group_header pc ON pc.bbid = e.bbid
 	LEFT JOIN bookbrainz.edition_group_data pcd ON pcr.data_id = pcd.id
 	LEFT JOIN bookbrainz.alias_set als ON pcd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = pcd.disambiguation_id
+	LEFT JOIN bookbrainz.edition_group_type egtype ON egtype.id = pcd.type_id
 	WHERE e.type = 'EditionGroup';
 
 CREATE VIEW bookbrainz.series AS
 	SELECT
-		e.bbid, sd.id AS data_id, sr.id AS revision_id, (sr.id = s.master_revision_id) AS master, sd.entity_type, sd.annotation_id, sd.disambiguation_id,
-		als.default_alias_id, sd.ordering_type_id, sd.alias_set_id, sd.identifier_set_id,
+		e.bbid, sd.id AS data_id, sr.id AS revision_id, (sr.id = s.master_revision_id) AS master, sd.entity_type, sd.annotation_id, dis.comment,
+		als.default_alias_id, al."name", al.sort_name, sd.ordering_type_id, sd.alias_set_id, sd.identifier_set_id,
 		sd.relationship_set_id, e.type
 	FROM bookbrainz.series_revision sr
 	LEFT JOIN bookbrainz.entity e ON e.bbid = sr.bbid
 	LEFT JOIN bookbrainz.series_header s ON s.bbid = e.bbid
 	LEFT JOIN bookbrainz.series_data sd ON sr.data_id = sd.id
 	LEFT JOIN bookbrainz.alias_set als ON sd.alias_set_id = als.id
+	LEFT JOIN bookbrainz.alias al ON al.id = als.default_alias_id
+	LEFT JOIN bookbrainz.disambiguation dis ON dis.id = sd.disambiguation_id
 	WHERE e.type = 'Series';
 
+-- Imported entities views --
 CREATE VIEW bookbrainz.author_import AS
 	SELECT
 		import.id AS import_id,


### PR DESCRIPTION
This is tied to the CritiqueBrainz-BookBrainz integration project.
Using the views is particularly helpful in the CB codebase since  it is in python and they cannot use our JS ORM.
So we are adding some columns to the views for each entity (alias name and sort name, disambiguation content, entity type labels, etc.)
