### PR TITLE
Feat(route): Edit exisiting entity through unified form POST route

### DIFF
--- a/src/server/helpers/entityRouteUtils.tsx
+++ b/src/server/helpers/entityRouteUtils.tsx
@@ -35,6 +35,7 @@ import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
 import {createStore} from 'redux';
 import {generateProps} from './props';
+import {isValidBBID} from '../../common/helpers/utils';
 
 
 const {createRootReducer, getEntitySection, getEntitySectionMerge, getValidator} = entityEditorHelpers;
@@ -328,6 +329,12 @@ function validateUnifiedForm(body:Record<string, any>):boolean {
 		if (Object.prototype.hasOwnProperty.call(body, entityKey)) {
 			const entityForm = body[entityKey];
 			const entityType = _.camelCase(entityForm.type);
+			const isNew = _.get(entityForm, '__isNew__', true);
+			const bbid = _.get(entityForm, 'id', null);
+			// for existing entity, it must have id attribute set to its bbid
+			if (!isNew && (!bbid || !isValidBBID(bbid))) {
+				return false;
+			}
 			if (!entityType || !validEntityTypes.includes(entityType)) {
 				return false;
 			}

--- a/src/server/helpers/entityRouteUtils.tsx
+++ b/src/server/helpers/entityRouteUtils.tsx
@@ -339,7 +339,7 @@ function validateUnifiedForm(body:Record<string, any>):boolean {
 				return false;
 			}
 			const validator = getValidator(entityType);
-			if (!validator(entityForm)) {
+			if (isNew && !validator(entityForm)) {
 				return false;
 			}
 		}
@@ -353,16 +353,18 @@ function validateUnifiedForm(body:Record<string, any>):boolean {
  * @param {object} res - Response object
  */
 
-export function createEntitiesHandler(
+export async function createEntitiesHandler(
 	req:$Request,
 	res:$Response
 ) {
+	const {orm} = req.app.locals;
+	 req.body = await unifiedRoutes.preprocessForm(req.body, orm);
 	// validating
 	if (!validateUnifiedForm(req.body)) {
 		const err = new error.FormSubmissionError();
 		return error.sendErrorAsJSON(res, err);
 	}
-	// transforming
+	// // // transforming
 	req.body = unifiedRoutes.transformForm(req.body);
 	return unifiedRoutes.handleCreateMultipleEntities(req as PassportRequest, res);
 }

--- a/src/server/helpers/entityRouteUtils.tsx
+++ b/src/server/helpers/entityRouteUtils.tsx
@@ -358,13 +358,14 @@ export async function createEntitiesHandler(
 	res:$Response
 ) {
 	const {orm} = req.app.locals;
+	// generate the state for current entity
 	 req.body = await unifiedRoutes.preprocessForm(req.body, orm);
-	// validating
+	// validating the uf state
 	if (!validateUnifiedForm(req.body)) {
 		const err = new error.FormSubmissionError();
 		return error.sendErrorAsJSON(res, err);
 	}
-	// // // transforming
+	// transforming uf state into separate entity state
 	req.body = unifiedRoutes.transformForm(req.body);
 	return unifiedRoutes.handleCreateMultipleEntities(req as PassportRequest, res);
 }

--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -236,7 +236,7 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 });
 
 
-function authorToFormState(author) {
+export function authorToFormState(author) {
 	/** The front-end expects a language id rather than the language object. */
 	const aliases = author.aliasSet ?
 		author.aliasSet.aliases.map(({languageId, ...rest}) => ({

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -226,7 +226,7 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 });
 
 
-function editionGroupToFormState(editionGroup) {
+export function editionGroupToFormState(editionGroup) {
 	/** The front-end expects a language id rather than the language object. */
 	const aliases = editionGroup.aliasSet ?
 		editionGroup.aliasSet.aliases.map(({languageId, ...rest}) => ({

--- a/src/server/routes/entity/edition.ts
+++ b/src/server/routes/entity/edition.ts
@@ -368,7 +368,7 @@ router.post(
 );
 
 
-function editionToFormState(edition) {
+export function editionToFormState(edition) {
 	/** The front-end expects a language id rather than the language object. */
 	const aliases = edition.aliasSet ?
 		edition.aliasSet.aliases.map(({languageId, ...rest}) => ({

--- a/src/server/routes/entity/process-unified-form.ts
+++ b/src/server/routes/entity/process-unified-form.ts
@@ -146,6 +146,9 @@ export async function preprocessForm(body:Record<string, any>, orm):Promise<Reco
 				]
 			});
 			await addRelationships(currentEntity, relationshipSet, orm);
+			if (!currentEntity.annotation) {
+				_.set(currentEntity, ['annotation', 'content'], '');
+			}
 			// convert this state to normal entity-editor state
 			const oldFormState = entityToFormStateMap[_.camelCase(type)](currentEntity);
 			// deep merge the old state with new one

--- a/src/server/routes/entity/process-unified-form.ts
+++ b/src/server/routes/entity/process-unified-form.ts
@@ -219,9 +219,10 @@ export function handleCreateMultipleEntities(
 			await Object.keys(body).reduce((promise, entityKey) => promise.then(() => processEntity(entityKey)), Promise.resolve());
 
 			// adding relationship on newly created entites
-			await Promise.all(Object.keys(allRelationships).map((entityId) => processRelationship(
+			await Object.keys(allRelationships).reduce((promise, entityId) => promise.then(() => processRelationship(
 				allRelationships[entityId], savedMainEntities[entityId], bbidMap, editorJSON.id, orm, transacting
-			)));
+			)), Promise.resolve());
+
 			return savedMainEntities;
 		}
 		catch (err) {

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -246,7 +246,7 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 });
 
 
-function publisherToFormState(publisher) {
+export function publisherToFormState(publisher) {
 	/** The front-end expects a language id rather than the language object. */
 	const aliases = publisher.aliasSet ?
 		publisher.aliasSet.aliases.map(({languageId, ...rest}) => ({

--- a/src/server/routes/entity/series.js
+++ b/src/server/routes/entity/series.js
@@ -233,7 +233,7 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 	entityRoutes.updateDisplayedRevisions(req, res, next, SeriesRevision);
 });
 
-function seriesToFormState(series) {
+export function seriesToFormState(series) {
 	const aliases = series.aliasSet ?
 		series.aliasSet.aliases.map(({languageId, ...rest}) => ({
 			...rest,

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -258,8 +258,7 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 	entityRoutes.updateDisplayedRevisions(req, res, next, WorkRevision);
 });
 
-
-function workToFormState(work) {
+export function workToFormState(work) {
 	/** The front-end expects a language id rather than the language object. */
 	const aliases = work.aliasSet ?
 		work.aliasSet.aliases.map(({languageId, ...rest}) => ({

--- a/test/src/server/routes/unifiedform.js
+++ b/test/src/server/routes/unifiedform.js
@@ -95,7 +95,6 @@ describe('Unified form routes', () => {
 			type: 'Work'
 		}};
 		const newName = 'changedName';
-		// postData.b0.nameSection.language = newLanguage.id;
 		postData.b0.nameSection.name = newName;
 		const res = await agent.post('/create/handler').send(postData);
 		const editEntities = res.body;

--- a/test/src/server/routes/unifiedform.js
+++ b/test/src/server/routes/unifiedform.js
@@ -84,17 +84,18 @@ describe('Unified form routes', () => {
 	});
 	it('should not throw error while editing single entity', async () => {
 		const postData = {b0: {
-			...baseState,
 			__isNew__: false,
 			id: wBBID,
-			type: 'Work',
-			workSection: {
-				languages: [],
-				type: null
-			}
+			nameSection: {},
+			submissionSection: {
+				note: 'note',
+				submitError: '',
+				submitted: false
+			},
+			type: 'Work'
 		}};
 		const newName = 'changedName';
-		postData.b0.nameSection.language = newLanguage.id;
+		// postData.b0.nameSection.language = newLanguage.id;
 		postData.b0.nameSection.name = newName;
 		const res = await agent.post('/create/handler').send(postData);
 		const editEntities = res.body;
@@ -109,7 +110,6 @@ describe('Unified form routes', () => {
 	it('should not throw error while adding relationship to single entity', async () => {
 		// we need to pass extra id and __isNew__ attributes
 		const postData = {b0: {
-			...baseState,
 			__isNew__: false,
 			id: wBBID,
 			relationshipSection: {
@@ -130,13 +130,13 @@ describe('Unified form routes', () => {
 					}
 				}
 			},
-			type: 'Work',
-			workSection: {
-				languages: [],
-				type: null
-			}
+			submissionSection: {
+				note: 'note',
+				submitError: '',
+				submitted: false
+			},
+			type: 'Work'
 		}};
-		postData.b0.nameSection.language = newLanguage.id;
 		const res = await agent.post('/create/handler').send(postData);
 		const editEntities = res.body;
 		expect(editEntities.length).equal(1);
@@ -144,9 +144,10 @@ describe('Unified form routes', () => {
 		const fetchedworkEntity = await getEntityByBBID(orm, workEntity.bbid);
 		expect(Boolean(fetchedworkEntity)).to.be.true;
 		const relationships = get(fetchedworkEntity, ['relationshipSet', 'relationships'], []);
-		expect(relationships.length).to.be.equal(1);
-		expect(get(relationships[0], 'targetBbid')).to.be.equal(wBBID);
-		expect(get(relationships[0], 'sourceBbid')).to.be.equal(aBBID);
+		// one relationship added on creation
+		expect(relationships.length).to.be.equal(2);
+		expect(get(relationships[1], 'targetBbid')).to.be.equal(wBBID);
+		expect(get(relationships[1], 'sourceBbid')).to.be.equal(aBBID);
 		expect(res).to.be.ok;
 		expect(res).to.have.status(200);
 	});

--- a/test/src/server/routes/unifiedform.js
+++ b/test/src/server/routes/unifiedform.js
@@ -1,5 +1,5 @@
 import {authorWorkRelationshipTypeData, baseState, createAuthor, createEditionGroup,
-	createEditor, createPublisher, createWork, getRandomUUID, truncateEntities} from '../../../test-helpers/create-entities';
+	createEditor, createPublisher, createWork, getRandomUUID, languageAttribs, truncateEntities} from '../../../test-helpers/create-entities';
 import {every, forOwn, get, map} from 'lodash';
 import app from '../../../../src/server/app';
 import chai from 'chai';
@@ -8,7 +8,7 @@ import {getEntityByBBID} from '../../../../src/common/helpers/utils';
 import orm from '../../../bookbrainz-data';
 
 
-const {RelationshipType} = orm;
+const {Language, RelationshipType} = orm;
 const relationshipTypeData = {
 	description: 'test descryption',
 	label: 'test label',
@@ -36,7 +36,7 @@ function testDefaultAlias(entity, languageId) {
 
 describe('Unified form routes', () => {
 	let agent;
-	const languageId = 42;
+	let newLanguage;
 	let newRelationshipType;
 	let authorWorkRelationshipType;
 	const wBBID = getRandomUUID();
@@ -51,6 +51,8 @@ describe('Unified form routes', () => {
 			await createEditionGroup(egBBID);
 			await createAuthor(aBBID);
 			newRelationshipType = await new RelationshipType(relationshipTypeData)
+				.save(null, {method: 'insert'});
+			newLanguage = await new Language({...languageAttribs})
 				.save(null, {method: 'insert'});
 			authorWorkRelationshipType = await new RelationshipType(authorWorkRelationshipTypeData)
 				.save(null, {method: 'insert'});
@@ -69,13 +71,14 @@ describe('Unified form routes', () => {
 			editionSection: {},
 			type: 'Edition'
 		}};
+		postData.b0.nameSection.language = newLanguage.id;
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(1);
 		const editionEntity = createdEntities[0];
 		const fetchedEditionEntity = await getEntityByBBID(orm, editionEntity.bbid);
 		expect(Boolean(fetchedEditionEntity)).to.be.true;
-		expect(testDefaultAlias(fetchedEditionEntity, languageId)).to.be.true;
+		expect(testDefaultAlias(fetchedEditionEntity, newLanguage.id)).to.be.true;
 		expect(res).to.be.ok;
 		expect(res).to.have.status(200);
 	});
@@ -91,6 +94,7 @@ describe('Unified form routes', () => {
 			}
 		}};
 		const newName = 'changedName';
+		postData.b0.nameSection.language = newLanguage.id;
 		postData.b0.nameSection.name = newName;
 		const res = await agent.post('/create/handler').send(postData);
 		const editEntities = res.body;
@@ -132,6 +136,7 @@ describe('Unified form routes', () => {
 				type: null
 			}
 		}};
+		postData.b0.nameSection.language = newLanguage.id;
 		const res = await agent.post('/create/handler').send(postData);
 		const editEntities = res.body;
 		expect(editEntities.length).equal(1);
@@ -159,12 +164,15 @@ describe('Unified form routes', () => {
 				type: null
 			}
 		}};
+		forOwn(postData, (value) => {
+			value.nameSection.language = newLanguage.id;
+		});
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(2);
 		const conditions = await map(createdEntities, async (entity) => {
 			const fetchedEntity = await getEntityByBBID(orm, entity.bbid);
-			return !fetchedEntity ? false : testDefaultAlias(fetchedEntity, languageId);
+			return !fetchedEntity ? false : testDefaultAlias(fetchedEntity, newLanguage.id);
 		});
 		expect(every(conditions)).to.be.true;
 		expect(res).to.be.ok;
@@ -195,6 +203,9 @@ describe('Unified form routes', () => {
 			},
 			type: 'Edition'
 		}};
+		forOwn(postData, (value) => {
+			value.nameSection.language = newLanguage.id;
+		});
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(1);
@@ -240,6 +251,9 @@ describe('Unified form routes', () => {
 				type: null
 			}
 		}};
+		forOwn(postData, (value) => {
+			value.nameSection.language = newLanguage.id;
+		});
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(2);
@@ -268,6 +282,7 @@ describe('Unified form routes', () => {
 			},
 			type: 'Edition'
 		}};
+		postData.b0.nameSection.language = newLanguage.id;
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(1);
@@ -310,6 +325,9 @@ describe('Unified form routes', () => {
 			},
 			type: 'Edition'
 		}};
+		forOwn(postData, (value) => {
+			value.nameSection.language = newLanguage.id;
+		});
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(2);
@@ -334,6 +352,7 @@ describe('Unified form routes', () => {
 			},
 			type: 'Edition'
 		}};
+		postData.b0.nameSection.language = newLanguage.id;
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(1);
@@ -362,6 +381,9 @@ describe('Unified form routes', () => {
 			},
 			type: 'Edition'
 		}};
+		forOwn(postData, (value) => {
+			value.nameSection.language = newLanguage.id;
+		});
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(2);
@@ -391,6 +413,7 @@ describe('Unified form routes', () => {
 			editionSection: {},
 			type: 'Edition'
 		}};
+		postData.b0.nameSection.language = newLanguage.id;
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(1);
@@ -423,6 +446,9 @@ describe('Unified form routes', () => {
 				type: 'Edition'
 			}
 		};
+		forOwn(postData, (value) => {
+			value.nameSection.language = newLanguage.id;
+		});
 		const res = await agent.post('/create/handler').send(postData);
 		const createdEntities = res.body;
 		expect(createdEntities.length).equal(2);

--- a/test/test-helpers/create-entities.js
+++ b/test/test-helpers/create-entities.js
@@ -55,9 +55,9 @@ export const baseState = {
 	identifierEditor: {},
 	nameSection: {
 		disambiguation: '',
-		language: 1,
-		name: 'bob',
-		sortName: 'bob'
+		language: 42,
+		name: 'Entity name',
+		sortName: 'Entity sort name'
 	},
 	relationshipSection: {
 		relationships: {}
@@ -67,6 +67,15 @@ export const baseState = {
 		submitError: '',
 		submitted: false
 	}
+};
+
+export const authorWorkRelationshipTypeData = {
+	description: 'test descryption',
+	label: 'test label',
+	linkPhrase: 'test phrase',
+	reverseLinkPhrase: 'test reverse link phrase',
+	sourceEntityType: 'Author',
+	targetEntityType: 'Work'
 };
 
 export const editorTypeAttribs = {


### PR DESCRIPTION
Since now we need to edit entity for use cases like adding relationships for work with author, /create/handler POST route should support that as well.
This route expect client to send ~complete state of existing entity with~ required changes only.
Also passing `id`  (bbid of entity), `__isNew__`   (falsy for existing entity) attributes is mandatory with entity state.
Entity state must include submission note for the revision.

### Tasks

- [x]  Fix relationship overriding issue
- [x]  Make route support edits
- [x]  Add basic edit tests

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/server/routes/entity/process-unified-form.ts