### PR TITLE
fix(language-select): Correctly format language options for alias row

### DIFF
--- a/src/client/entity-editor/alias-editor/alias-row.js
+++ b/src/client/entity-editor/alias-editor/alias-row.js
@@ -107,7 +107,7 @@ const AliasRow = ({
 					error={!validateAliasLanguage(languageValue)}
 					instanceId="language"
 					options={languageOptions}
-					value={languageValue}
+					value={languageOptions.filter((el) => el.value === languageValue)}
 					onChange={onLanguageChange}
 				/>
 			</Col>


### PR DESCRIPTION
Fix language display issue in alias-row
