### PR TITLE
Fix(AC): Handle AC modal state for editionGroup entity

### DIFF
--- a/src/client/entity-editor/author-credit-editor/author-credit-section.tsx
+++ b/src/client/entity-editor/author-credit-editor/author-credit-section.tsx
@@ -28,7 +28,7 @@ import {
 import {Button, Col, Form, InputGroup, OverlayTrigger, Row, Tooltip} from 'react-bootstrap';
 
 import {SingleValueProps, components} from 'react-select';
-import {map as _map, values as _values} from 'lodash';
+import {map as _map, values as _values, camelCase} from 'lodash';
 
 import {faPencilAlt, faQuestionCircle} from '@fortawesome/free-solid-svg-icons';
 import AuthorCreditEditor from './author-credit-editor';
@@ -143,15 +143,16 @@ AuthorCreditSection.propTypes = {
 	showEditor: PropTypes.bool.isRequired
 };
 
-function mapStateToProps(rootState): StateProps {
+function mapStateToProps(rootState, {type}): StateProps {
 	const firstRowKey = rootState.get('authorCreditEditor').keySeq().first();
 	const authorCreditRow = rootState.getIn(['authorCreditEditor', firstRowKey]);
 	const isEditable = !(rootState.get('authorCreditEditor').size > 1) &&
-	 authorCreditRow.get('name') === authorCreditRow.getIn(['author', 'text'], '');
+	authorCreditRow.get('name') === authorCreditRow.getIn(['author', 'text'], '');
+	const entitySection = `${camelCase(type)}Section`;
 	return {
 		authorCreditEditor: convertMapToObject(rootState.get('authorCreditEditor')),
 		isEditable,
-		showEditor: rootState.getIn(['editionSection', 'authorCreditEditorVisible'])
+		showEditor: rootState.getIn([entitySection, 'authorCreditEditorVisible'])
 	};
 }
 

--- a/src/client/entity-editor/edition-group-section/edition-group-section.tsx
+++ b/src/client/entity-editor/edition-group-section/edition-group-section.tsx
@@ -17,13 +17,12 @@
  */
 
 import * as React from 'react';
-import AuthorCreditSection from '../author-credit-editor/author-credit-section';
 import {Action, updateType} from './actions';
 import {Col, Form, OverlayTrigger, Row, Tooltip} from 'react-bootstrap';
+import AuthorCreditSection from '../author-credit-editor/author-credit-section';
 
 import type {Dispatch} from 'redux';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import type {Map} from 'immutable';
 import Select from 'react-select';
 import {connect} from 'react-redux';
 import {faQuestionCircle} from '@fortawesome/free-solid-svg-icons';
@@ -35,7 +34,7 @@ type EditionGroupType = {
 };
 
 type StateProps = {
-	typeValue: Map<string, any>
+	typeValue: number
 };
 
 type DispatchProps = {
@@ -80,7 +79,7 @@ function EditionGroupSection({
 			<h2>
 				What else do you know about the Edition Group?
 			</h2>
-			<AuthorCreditSection/>
+			<AuthorCreditSection type="editionGroup"/>
 			<p className="text-muted">
 				All fields optional — leave something blank if you don&rsquo;t
 				know it

--- a/src/client/entity-editor/edition-group-section/reducer.ts
+++ b/src/client/entity-editor/edition-group-section/reducer.ts
@@ -21,6 +21,7 @@ import * as Immutable from 'immutable';
 import {
 	Action, UPDATE_TYPE
 } from './actions';
+import {HIDE_AUTHOR_CREDIT_EDITOR, SHOW_AUTHOR_CREDIT_EDITOR} from '../author-credit-editor/actions';
 
 
 type State = Immutable.Map<string, any>;
@@ -35,6 +36,11 @@ function reducer(
 	switch (type) {
 		case UPDATE_TYPE:
 			return state.set('type', payload);
+		case SHOW_AUTHOR_CREDIT_EDITOR:
+			return state.set('authorCreditEditorVisible', true);
+		case HIDE_AUTHOR_CREDIT_EDITOR:
+			return state.set('authorCreditEditorVisible', false);
+
 		// no default
 	}
 	return state;

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -265,7 +265,7 @@ function EditionSection({
 			<h2>
 				What else do you know about the Edition?
 			</h2>
-			<AuthorCreditSection/>
+			<AuthorCreditSection type="edition"/>
 			<p className="text-muted">
 				Edition Group is required — this cannot be blank. You can search for and choose an existing Edition Group,
 				or choose to automatically create one instead.


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Edit button on AC section doesn't work for edition-group entity form.

### Solution
<!-- What does this PR do to fix the problem? -->
Add AC modal state in editionGroupSection.

