### PR TITLE
Fix(AC): Fix author credit link

### DIFF
--- a/src/client/components/author-credit-display.js
+++ b/src/client/components/author-credit-display.js
@@ -22,9 +22,10 @@ import {map as _map} from 'lodash';
 
 
 function AuthorCreditDisplay({names}) {
+	const authorBBID = name.authorBBID ?? name.author?.id;
 	const nameElements = _map(names, (name) => (
-		<span key={`author-credit-${name.authorCreditID}-${name.position}`}>
-			<a href={`/author/${name.authorBBID}`}>
+		<span key={`author-credit-${authorBBID}`}>
+			<a href={`/author/${authorBBID}`}>
 				{name.name}
 			</a>
 			{name.joinPhrase}


### PR DESCRIPTION
We have two different situations for Author Credits display component: one is on the edit page when adding a new AC and the other is on the entity display pages displaying an existing AC.

Depending on which case we are looking at, the author used to construct the AC will not have the same shape, and the author BBID in particular will not be in the same place.

This results currently on broken AC links (href = `/author/undefined`) on the entity display pages (but working for edit pages).
