### PR TITLE
Fix(AC): AC field should show error when empty

### DIFF
--- a/src/client/components/author-credit-display.js
+++ b/src/client/components/author-credit-display.js
@@ -22,15 +22,17 @@ import {map as _map} from 'lodash';
 
 
 function AuthorCreditDisplay({names}) {
-	const authorBBID = name.authorBBID ?? name.author?.id;
-	const nameElements = _map(names, (name) => (
-		<span key={`author-credit-${authorBBID}`}>
-			<a href={`/author/${authorBBID}`}>
-				{name.name}
-			</a>
-			{name.joinPhrase}
-		</span>
-	));
+	const nameElements = _map(names, (name) => {
+		const authorBBID = name.authorBBID ?? name.author?.id;
+		return (
+			<span key={`author-credit-${authorBBID}`}>
+				<a href={`/author/${authorBBID}`}>
+					{name.name}
+				</a>
+				{name.joinPhrase}
+			</span>
+		);
+	});
 
 	return (
 		<span>

--- a/src/client/entity-editor/author-credit-editor/author-credit-section.tsx
+++ b/src/client/entity-editor/author-credit-editor/author-credit-section.tsx
@@ -85,7 +85,7 @@ function AuthorCreditSection({
 		</Button>);
 
 	const label = (
-		<ValidationLabel empty={authorCreditPreview.length === 0} error={!isValid}>
+		<ValidationLabel empty={false} error={!isValid}>
 			Author Credit
 		</ValidationLabel>
 	);

--- a/src/client/entity-editor/validators/common.ts
+++ b/src/client/entity-editor/validators/common.ts
@@ -193,7 +193,7 @@ export function validateAuthorCreditRow(row: any): boolean {
 export const validateAuthorCreditSection = _.partialRight(
 	// Requires at least one Author Credit row
 	validateMultiple, _.partialRight.placeholder,
-	validateAuthorCreditRow, null, false
+	validateAuthorCreditRow, null, true
 );
 // In the merge editor we use the authorCredit directly instead of the authorCreditEditor state
 export function validateAuthorCreditSectionMerge(authorCredit:AuthorCredit) :boolean {


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Since Author Credit field is necessary in entity form, it should show error when author-credit-editor is empty.

