### PR TITLE
Fix(achievements): count consecutive days for timed achievements

### DIFF
--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -401,7 +401,19 @@ export async function getEditsInDays(orm, editorId, days) {
 		and created_at > (SELECT CURRENT_DATE - INTERVAL '${days} days');`;
 
 	const out = await bookshelf.knex.raw(rawSql);
-	return out.rowCount;
+	const dateList = out.rows.map(row => row.created_at);
+	let countDays = 0;
+	let lastDate = new Date();
+	const oneDayMs = 24 * 60 * 60 * 1000;
+	// count number of consecutive days starting from today
+	for (let i = dateList.length - 1; i >= 0; i--) {
+		if (lastDate.getTime() - dateList[i].getTime() > oneDayMs) {
+			break;
+		}
+		countDays++;
+		lastDate = dateList[i];
+	}
+	return countDays;
 }
 
 async function processFunRunner(orm, editorId) {

--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -23,6 +23,7 @@
 
 import * as error from '../../common/helpers/error';
 
+import {differenceInCalendarDays, parseISO} from 'date-fns';
 import {flattenDeep, isNil} from 'lodash';
 import log from 'log';
 
@@ -386,14 +387,14 @@ async function processSprinter(orm, editorId) {
 }
 
 /**
- * Gets number of distinct days the editor created revisions within specified
+ * Gets number of consecutive days from today the editor created revisions upto a specified
  * time limit
  * @param {object} orm - the BookBrainz ORM, initialized during app setup
  * @param {int} editorId - Editor to query on
  * @param {int} days - Number of days before today to collect edits from
- * @returns {int} - Number of days edits were performed on
+ * @returns {int} - Number of consecutive days edits were performed on
  */
-export async function getEditsInDays(orm, editorId, days) {
+export async function getConsecutiveDaysWithEdits(orm, editorId, days) {
 	const {bookshelf} = orm;
 	const rawSql =
 		`SELECT DISTINCT created_at::date from bookbrainz.revision \
@@ -401,13 +402,12 @@ export async function getEditsInDays(orm, editorId, days) {
 		and created_at > (SELECT CURRENT_DATE - INTERVAL '${days} days');`;
 
 	const out = await bookshelf.knex.raw(rawSql);
-	const dateList = out.rows.map(row => row.created_at);
+	const dateList = out.rows.map(row => parseISO(row.created_at));
 	let countDays = 0;
 	let lastDate = new Date();
-	const oneDayMs = 24 * 60 * 60 * 1000;
 	// count number of consecutive days starting from today
 	for (let i = dateList.length - 1; i >= 0; i--) {
-		if (lastDate.getTime() - dateList[i].getTime() > oneDayMs) {
+		if (differenceInCalendarDays(lastDate, dateList[i]) > 1) {
 			break;
 		}
 		countDays++;
@@ -417,7 +417,7 @@ export async function getEditsInDays(orm, editorId, days) {
 }
 
 async function processFunRunner(orm, editorId) {
-	const rowCount = await getEditsInDays(orm, editorId, 6);
+	const rowCount = await getConsecutiveDaysWithEdits(orm, editorId, 6);
 	const tiers = [
 		{
 			name: 'Fun Runner',
@@ -429,7 +429,7 @@ async function processFunRunner(orm, editorId) {
 }
 
 async function processMarathoner(orm, editorId) {
-	const rowCount = await getEditsInDays(orm, editorId, 29);
+	const rowCount = await getConsecutiveDaysWithEdits(orm, editorId, 29);
 	const tiers = [{
 		name: 'Marathoner',
 		threshold: 30,

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -25,7 +25,7 @@ import * as propHelpers from '../../client/helpers/props';
 import * as search from '../../common/helpers/search';
 import {eachMonthOfInterval, format, isAfter, isValid} from 'date-fns';
 import {escapeProps, generateProps} from '../helpers/props';
-import {getEditsInDays, getEntityVisits, getTypeCreation} from '../helpers/achievement';
+import {getConsecutiveDaysWithEdits, getEntityVisits, getTypeCreation} from '../helpers/achievement';
 import AchievementsTab from '../../client/components/pages/parts/editor-achievements';
 import CollectionsPage from '../../client/components/pages/collections';
 import EditorContainer from '../../client/containers/editor';
@@ -448,11 +448,11 @@ async function getProgress(achievementId, editorId, orm) {
 	}
 	// Fun Runner
 	if (achievementId === 11) {
-		return getEditsInDays(orm, editorId, 6);
+		return getConsecutiveDaysWithEdits(orm, editorId, 6);
 	}
 	// Marathoner
 	if (achievementId === 12) {
-		return getEditsInDays(orm, editorId, 29);
+		return getConsecutiveDaysWithEdits(orm, editorId, 29);
 	}
 	// Explorer achivements
 	const explorerVisits = [24, 25, 26];

--- a/test/test-fun-runner.js
+++ b/test/test-fun-runner.js
@@ -29,7 +29,7 @@ const funRunnerDays = 6;
 
 function rewireEditsInDaysTwo(threshold) {
 	return common.rewire(Achievement, {
-		getEditsInDays: (editorId, days) => {
+		getConsecutiveDaysWithEdits: (editorId, days) => {
 			let editPromise;
 			if (days === funRunnerDays) {
 				editPromise = Promise.resolve(threshold);
@@ -44,7 +44,7 @@ function rewireEditsInDaysTwo(threshold) {
 
 function rewireEditsInDaysThree(threshold) {
 	return common.rewire(Achievement, {
-		getEditsInDays: (_orm, editorId, days) => {
+		getConsecutiveDaysWithEdits: (_orm, editorId, days) => {
 			let editPromise;
 			if (days === funRunnerDays) {
 				editPromise = Promise.resolve(threshold);

--- a/test/test-marathoner.js
+++ b/test/test-marathoner.js
@@ -29,7 +29,7 @@ const marathonerThreshold = 30;
 
 function rewireEditsInDaysTwo(threshold) {
 	return common.rewire(Achievement, {
-		getEditsInDays: (editorId, days) => {
+		getConsecutiveDaysWithEdits: (editorId, days) => {
 			let editPromise;
 			if (days === marathonerDays) {
 				editPromise = Promise.resolve(threshold);
@@ -44,7 +44,7 @@ function rewireEditsInDaysTwo(threshold) {
 
 function rewireEditsInDaysThree(threshold) {
 	return common.rewire(Achievement, {
-		getEditsInDays: (_orm, editorId, days) => {
+		getConsecutiveDaysWithEdits: (_orm, editorId, days) => {
 			let editPromise;
 			if (days === marathonerDays) {
 				editPromise = Promise.resolve(threshold);


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
[BB-680](https://tickets.metabrainz.org/projects/BB/issues/BB-680): Fun runner and Marathoner achievements are broken

### Solution
<!-- What does this PR do to fix the problem? -->
Currently, we just return the number of distinct (by date) revisions within specified interval but what we actually want is number of consecutive revisions starting from today upto to given interval. this PR does exactly that. 

_note: we might be able to use some sql magic here but i'm not sure how we would do that._

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/server/helpers/achievement.js