### PR TITLE
Fix(BB-538): Allow concurrent relationship edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "array-move": "^3.0.1",
-    "bookbrainz-data": "2.14.1",
+    "bookbrainz-data": "3.0.0",
     "chart.js": "^2.9.4",
     "chartjs-adapter-date-fns": "^1.0.0",
     "classnames": "^2.3.1",

--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -162,6 +162,8 @@ type RelationshipModalProps = {
 
 type RelationshipModalState = {
 	attributeSetId: number | null,
+	isAdded: boolean,
+	isRemoved: boolean,
 	relationshipType?: RelationshipType | null | undefined,
 	relationship?: _Relationship | null | undefined,
 	targetEntity?: EntitySearchResult | null | undefined,
@@ -179,6 +181,8 @@ function getInitState(
 			attributePosition: {attributeType: 1, value: {textValue: null}},
 			attributeSetId: null,
 			attributes: [],
+			isAdded: true,
+			isRemoved: false,
 			relationship: null,
 			relationshipType: null,
 			targetEntity: null
@@ -222,6 +226,8 @@ function getInitState(
 		attributePosition,
 		attributeSetId: _.get(initRelationship, ['attributeSetId']),
 		attributes,
+		isAdded: true,
+		isRemoved: false,
 		relationship: initRelationship,
 		relationshipType: _.get(initRelationship, ['relationshipType']),
 		targetEntity: searchFormatOtherEntity

--- a/src/client/entity-editor/relationship-editor/relationship-section.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-section.tsx
@@ -65,7 +65,7 @@ export function RelationshipList(
 	/* eslint-disable react/jsx-no-bind */
 	const renderedRelationships = _.map(
 		relationships,
-		({relationshipType, sourceEntity, targetEntity, attributes}, rowID) => (
+		({relationshipType, sourceEntity, targetEntity, attributes, isRemoved}, rowID) => !isRemoved && (
 			<Row className="margin-top-d5" key={rowID}>
 				<Col lg={onEdit || onRemove ? 8 : 12}>
 					<Relationship

--- a/src/client/entity-editor/relationship-editor/types.ts
+++ b/src/client/entity-editor/relationship-editor/types.ts
@@ -73,6 +73,8 @@ export type RelationshipWithLabel = {
 
 export type RelationshipForDisplay = {
 	attributes: Array<Attribute>,
+	isAdded: boolean,
+	isRemoved: boolean,
 	relationshipType: RelationshipType,
 	sourceEntity: Entity,
 	targetEntity: Entity,

--- a/src/client/entity-editor/series-section/actions.ts
+++ b/src/client/entity-editor/series-section/actions.ts
@@ -37,6 +37,7 @@ export type Action = {
 		rowID?: string,
 		seriesType?: string,
 		newType?: number,
+		nextRowID?:string
 	}
 };
 
@@ -141,7 +142,7 @@ export function sortSeriesItems(oldIndex, newIndex):any {
  */
 export function editSeriesItem(data: Attribute, rowID: string): Action {
 	return {
-		payload: {data, rowID},
+		payload: {data, nextRowID: `n${nextRowID++}`, rowID},
 		type: EDIT_SERIES_ITEM
 	};
 }

--- a/src/client/entity-editor/series-section/reducer.ts
+++ b/src/client/entity-editor/series-section/reducer.ts
@@ -44,7 +44,7 @@ function reducer(
 			const {rowID} = payload;
 			return state.setIn(
 				['seriesItems', rowID],
-				Immutable.fromJS({rowID, ...payload.data})
+				Immutable.fromJS({isAdded: true, rowID, ...payload.data})
 			);
 		}
 		case SORT_SERIES_ITEM:
@@ -52,12 +52,21 @@ function reducer(
 		case EDIT_SERIES_ITEM: {
 			// index of number attribute in the attributes array
 			const index = state.getIn(['seriesItems', payload.rowID, 'attributes']).findIndex(attribute => attribute.get('attributeType') === 2);
-			return state.setIn(
-				['seriesItems', payload.rowID, 'attributes', index],
+			let mstate = state.setIn(['seriesItems', payload.nextRowID], state.getIn(['seriesItems', payload.rowID]).set('rowID', payload.nextRowID))
+				.setIn(['seriesItems', payload.nextRowID, 'isAdded'], true);
+			if (!state.getIn(['seriesItems', payload.rowID, 'isAdded'])) {
+				mstate = mstate.setIn(['seriesItems', payload.rowID, 'isRemoved'], true);
+			}
+			else { mstate = mstate.deleteIn(['seriesItems', payload.rowID]); }
+			return mstate.setIn(
+				['seriesItems', payload.nextRowID, 'attributes', index],
 				Immutable.fromJS({...payload.data})
 			);
 		}
 		case REMOVE_SERIES_ITEM:
+			if (!state.getIn(['seriesItems', payload.rowID, 'isAdded'])) {
+				return state.setIn(['seriesItems', payload.rowID, 'isRemoved'], true);
+			}
 			return state.deleteIn(['seriesItems', payload.rowID]);
 		// no default
 	}

--- a/src/client/entity-editor/series-section/series-editor.tsx
+++ b/src/client/entity-editor/series-section/series-editor.tsx
@@ -190,7 +190,7 @@ function SeriesEditor({baseEntity, relationshipTypes, seriesType, orderType, onR
 				<> {
 					orderType === 1 ?
 						<>
-							{seriesItemsArray.map((value) => (
+							{seriesItemsArray.map((value) => !value.isRemoved && (
 								<SeriesListItem
 									baseEntity={baseEntity}
 									dragHandler={false}

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -274,14 +274,16 @@ export function isbn13To10(isbn13:string):string | null {
  *
  * @param {Object} orm - orm
  * @param {string} bbid - bookbrainz id
+ * @param {Array} otherRelations - entity specific relations to fetch
  * @returns {Promise} - Promise resolves to entity data if exist else null
  */
-export async function getEntityByBBID(orm, bbid:string):Promise<Record<string, any> | null> {
+export async function getEntityByBBID(orm, bbid:string, otherRelations:Array<string> = []):Promise<Record<string, any> | null> {
 	if (!isValidBBID(bbid)) {
 		return null;
 	}
 	const {Entity} = orm;
-	const entity = await new Entity({bbid}).fetch({require: false});
+	const redirectBbid = await orm.func.entity.recursivelyGetRedirectBBID(orm, bbid, null);
+	const entity = await new Entity({bbid: redirectBbid}).fetch({require: false});
 	if (!entity) {
 		return null;
 	}
@@ -290,8 +292,10 @@ export async function getEntityByBBID(orm, bbid:string):Promise<Record<string, a
 		'annotation',
 		'disambiguation',
 		'defaultAlias',
+		'relationshipSet.relationships.type',
 		'aliasSet.aliases',
-		'identifierSet.identifiers'
+		'identifierSet.identifiers',
+		...otherRelations
 	];
 	const entityData = await orm.func.entity.getEntity(orm, entityType, bbid, baseRelations);
 	return entityData;

--- a/src/server/helpers/entityRouteUtils.tsx
+++ b/src/server/helpers/entityRouteUtils.tsx
@@ -296,6 +296,7 @@ export function addInitialRelationship(props, relationshipTypeId, relationshipIn
 
 	const initialRelationship = {
 		attributes: [],
+		isAdded: true,
 		label: relationship.linkPhrase,
 		relationshipType: relationship,
 		rowID: rowId,

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -565,7 +565,7 @@ export async function processMergeOperation(orm, transacting, session, mainEntit
 
 					let relsHaveChanged = false;
 					// Mark relationships with entity being merged as removed
-					const modifiedRelationships = otherEntityRelationships.forEach((rel) => {
+					otherEntityRelationships.forEach((rel) => {
 						if (entityBBID === rel.sourceBbid || entityBBID === rel.targetBbid) {
 							_.set(rel, 'isRemoved', true);
 							relsHaveChanged = true;
@@ -575,7 +575,7 @@ export async function processMergeOperation(orm, transacting, session, mainEntit
 					// If there's a difference, apply the new relationships array without rels to merged entity
 					if (relsHaveChanged) {
 						const updatedRelationshipSets = await orm.func.relationship.updateRelationshipSets(
-							orm, transacting, otherEntityRelationshipSet, modifiedRelationships
+							orm, transacting, otherEntityRelationshipSet, otherEntityRelationships
 						);
 						// Make sure the entity is later updated with its new relationshipSet id
 						allEntitiesReturnArray = _.unionBy(allEntitiesReturnArray, [otherEntity], 'id');

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -1254,10 +1254,12 @@ export function constructIdentifiers(
 export function constructRelationships(parentSection, childAttributeName = 'relationships') {
 	return _.map(
 		parentSection[childAttributeName],
-		({attributeSetId, rowID, relationshipType, sourceEntity, targetEntity, attributes}) => ({
+		({attributeSetId, rowID, relationshipType, sourceEntity, targetEntity, attributes, isRemoved, isAdded}) => ({
 			attributeSetId,
 			attributes,
 			id: rowID,
+			isAdded,
+			isRemoved,
 			sourceBbid: _.get(sourceEntity, 'bbid'),
 			targetBbid: _.get(targetEntity, 'bbid'),
 			typeId: relationshipType.id

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -877,6 +877,7 @@ async function getNextIdentifierSet(orm, transacting, currentEntity, body) {
 async function getNextRelationshipAttributeSets(orm, transacting, body) {
 	const {RelationshipAttributeSet} = orm;
 	const relationships = await Promise.all(body.relationships.map(async (relationship) => {
+		if (!relationship.isAdded) { return relationship; }
 		const id = relationship.attributeSetId;
 		const oldRelationshipAttributeSet = await (
 			id &&

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -259,7 +259,7 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 });
 
 
-function workToFormState(work) {
+export function workToFormState(work) {
 	/** The front-end expects a language id rather than the language object. */
 	const aliases = work.aliasSet ?
 		work.aliasSet.aliases.map(({languageId, ...rest}) => ({

--- a/src/server/routes/merge.ts
+++ b/src/server/routes/merge.ts
@@ -122,9 +122,11 @@ function entitiesToFormState(entities: any[]) {
 	}, []);
 	const otherEntitiesBBIDs = otherEntities.map(entity => entity.bbid);
 	relationships.forEach((relationship) => {
+		const isAffectedByMerge = otherEntitiesBBIDs.includes(relationship.sourceBbid) || otherEntitiesBBIDs.includes(relationship.targetBbid);
 		const formattedRelationship = {
 			attributeSetId: relationship.attributeSetId,
 			attributes: relationship.attributeSet ? relationship.attributeSet.relationshipAttributes : [],
+			isAdded: isAffectedByMerge,
 			relationshipType: relationship.type,
 			rendered: relationship.rendered,
 			rowID: `n${relationship.id}`,

--- a/test/src/server/routes/relationship.js
+++ b/test/src/server/routes/relationship.js
@@ -1,0 +1,116 @@
+import {createEdition, createEditor, createWork, getRandomUUID, truncateEntities} from '../../../test-helpers/create-entities';
+import app from '../../../../src/server/app';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import {get} from 'lodash';
+import {getEntityByBBID} from '../../../../src/common/helpers/utils';
+import orm from '../../../bookbrainz-data';
+import {workToFormState} from '../../../../src/server/routes/entity/work';
+
+
+const {RelationshipType} = orm;
+chai.use(chaiHttp);
+const {expect} = chai;
+
+describe('Relationship', () => {
+	const wBBID = getRandomUUID();
+	const eBBID = getRandomUUID();
+	const relationshipTypeData = {
+		description: 'test descryption',
+		id: 1,
+		label: 'test label',
+		linkPhrase: 'test phrase',
+		reverseLinkPhrase: 'test reverse link phrase',
+		sourceEntityType: 'Edition',
+		targetEntityType: 'Work'
+	};
+	let work;
+	let agent;
+	const commonRels = {
+		relationshipType: {
+			id: 1
+		},
+		sourceEntity: {
+			bbid: eBBID,
+			type: 'Edition'
+		},
+		targetEntity: {
+			bbid: wBBID,
+			type: 'Work'
+		}
+	};
+	before(async () => {
+		await truncateEntities();
+		await createEditor(123456);
+		await new RelationshipType(relationshipTypeData).save(null, {method: 'insert'});
+		createEdition(eBBID);
+		work = (await (await createWork(wBBID, {relationshipSetId: null})).load('aliasSet.aliases')).toJSON();
+		agent = await chai.request.agent(app);
+		await agent.get('/cb');
+	});
+	after((done) => {
+		// Clear DB tables then close superagent server
+		truncateEntities().then(() => {
+			agent.close(done);
+		});
+	});
+	it('should be able to add relationship on an entity', async () => {
+		work.relationships = [];
+		work.annotation = {content: ''};
+		const entityState = workToFormState(work);
+		entityState.relationshipSection.relationships = {
+			0: {
+				isAdded: true,
+				...commonRels
+			}
+		};
+		entityState.submissionSection = {note: ''};
+		const res = await agent.post(`/work/${wBBID}/edit/handler`).send(entityState);
+		expect(res).to.have.status(200);
+		const fetchedworkEntity = await getEntityByBBID(orm, wBBID);
+		expect(Boolean(fetchedworkEntity)).to.be.true;
+		const relationships = get(fetchedworkEntity, ['relationshipSet', 'relationships'], []);
+		expect(relationships.length).to.be.equal(1);
+		expect(get(relationships[0], 'targetBbid')).to.be.equal(wBBID);
+		expect(get(relationships[0], 'sourceBbid')).to.be.equal(eBBID);
+	});
+	it('should be able to remove relationship of an entity', async () => {
+		work.relationships = [];
+		work.annotation = {content: ''};
+		const entityState = workToFormState(work);
+		entityState.relationshipSection.relationships = {
+			0: {
+				isRemoved: true,
+				...commonRels
+			}
+		};
+		entityState.submissionSection = {note: ''};
+		const res = await agent.post(`/work/${wBBID}/edit/handler`).send(entityState);
+		expect(res).to.have.status(200);
+		const {body} = res;
+		expect(body?.relationshipSetId).null;
+	});
+	it('should be able to add new relationships without having previous relationships', async () => {
+		work.relationships = [];
+		work.annotation = {content: ''};
+		const entityState = workToFormState(work);
+		entityState.relationshipSection.relationships = {
+			0: {
+				isAdded: true,
+				...commonRels
+			}
+		};
+		entityState.submissionSection = {note: ''};
+		// mimicing the behavior when more than one users edit the relationships on the same entity
+		await agent.post(`/work/${wBBID}/edit/handler`).send(entityState);
+		const res = await agent.post(`/work/${wBBID}/edit/handler`).send(entityState);
+		expect(res).to.have.status(200);
+		// should now have two relationships in total
+		const fetchedworkEntity = await getEntityByBBID(orm, wBBID);
+		expect(Boolean(fetchedworkEntity)).to.be.true;
+		const relationships = get(fetchedworkEntity, ['relationshipSet', 'relationships'], []);
+		expect(relationships.length).to.be.equal(2);
+		expect(get(relationships[1], 'targetBbid')).to.be.equal(wBBID);
+		expect(get(relationships[1], 'sourceBbid')).to.be.equal(eBBID);
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2343,10 +2343,10 @@ body-parser@1.19.1:
     raw-body "2.4.2"
     type-is "~1.6.18"
 
-bookbrainz-data@2.14.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/bookbrainz-data/-/bookbrainz-data-2.14.1.tgz#77eba018f2af1894bef2ea0cfb4ddc4b417f3a12"
-  integrity sha512-VrGrRLEWEvKtFfR4/MCUBWjq7XEvrUQQ0dBj2Z90aSZrQy00HEJ5/WhO6xoOeYpnvPk6TRMUc8XZiBhjvNgKyw==
+bookbrainz-data@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bookbrainz-data/-/bookbrainz-data-3.0.0.tgz#87e345243132daed3d0d1bc68b376fe3fa9f6d29"
+  integrity sha512-L5jijPCmAZBmXVaCDIEin2oM8q2BfdP7L7UzJxlpcgPh2oT0Fq9OWgXwqDCiD5OZ1Fxq9k8bDuvCmz/VZ1hRWg==
   dependencies:
     bookshelf "^1.2.0"
     bookshelf-virtuals-plugin "^0.1.1"


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Reference ticket [BB-538](https://tickets.metabrainz.org/browse/BB-538) 
Since we use old relationship items to generate the difference array of allRemovedItems & allAddedItems, this cause issue where we don't have updated rel items. 


### Solution
<!-- What does this PR do to fix the problem? -->
We can just use two new attributes on rel to track removed and added items, this will ensure difference array is independent of old rel items.
Since Orm function need some changes to support this workflow, i will be creating similar PR there.
Edit: [PR](https://github.com/metabrainz/bookbrainz-data-js/pull/289)
### Tasks
- [x] Test showing this behavior
- [x]  ORM PR

<!-- What parts of the codebase and which behaviors are affected? -->
