### PR TITLE
BB-681: refresh search page on same search query

### DIFF
--- a/src/client/components/pages/search.tsx
+++ b/src/client/components/pages/search.tsx
@@ -94,6 +94,10 @@ class SearchPage extends React.Component<Props, State> {
 	 * @param {string} type - Entity type selected from dropdown
 	 */
 	handleSearch = (query: string, type: string) => {
+		// if no change in query or type, refresh the page to get new results
+		if (query === this.state.query && type === this.state.type) {
+			window.location.reload();
+		}
 		this.setState({query, type});
 	};
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
[BB-681](https://tickets.metabrainz.org/browse/BB-681): In Search page, Clicking on "search" should run search again

### Solution
<!-- What does this PR do to fix the problem? -->
There's currently no way to trigger search manually without causing rendering issues, that is search will trigger only when url params change which is not ideal for all situations so one quick way to resolve this issue is to refresh the whole page when user hit submit with same query. params.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
search-page component