### PR TITLE
chore: Fix CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "scripts": {
     "clean": "./scripts/clean.sh",
-    "prepublishOnly": "npm run clean",
-    "postinstall": "npm run prepublishOnly",
+    "prepare": "npm run clean",
     "build-server-js": "babel src --out-dir lib --source-maps --ignore src/api --extensions .js,.jsx,.ts,.tsx",
     "build-api-js": "babel src --out-dir lib --ignore 'src/server','src/client' --extensions .js,.jsx,.ts,.tsx",
     "build-scss": "./scripts/build-scss.sh",
@@ -25,7 +24,7 @@
     "dupreport": "npx jsinspect src/ || true"
   },
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 16.16.0"
   },
   "browserslist": "> 0.25%, not dead",
   "dependencies": {


### PR DESCRIPTION
I've been hitting some weird issue with the build workflow failing at postinstall step.
This is apparently due to the docker user's HOME path being set to `/root` instead of the home for the user `node`.
The NPM postinstall step was being run, which somehow was breaking with error code 243, apparently related to permission issues with the cache directory.
See https://github.com/npm/cli/issues/4769

Removing the postinstall step (which is not required and left over from way back when) solves the issue, but some investigation still needs to be done to figure out why the user's home is not set right in the docker image (or if we are using the wrong user somehow).

