### PR TITLE
Fix: Deleting entity crashes the site

### DIFF
--- a/src/client/components/pages/entities/author.js
+++ b/src/client/components/pages/entities/author.js
@@ -133,7 +133,7 @@ function AuthorDisplayPage({entity, identifierTypes, user}) {
 		<div>
 			<CBReviewModal
 				entityBBID={entity.bbid}
-				entityName={entity.defaultAlias.name}
+				entityName={entity.defaultAlias?.name}
 				entityType={entity.type}
 				handleModalToggle={handleModalToggle}
 				handleUpdateReviews={handleUpdateReviews}

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -455,6 +455,9 @@ export function handleDelete(
 			transacting
 		});
 
+		// set parent revision
+		await setParentRevisions(transacting, newRevision, [entity.revisionId]);
+
 		await new HeaderModel({
 			bbid: entity.bbid,
 			masterRevisionId: entityRevision.get('id')


### PR DESCRIPTION
This PR fixes two behavior:-

1. CBRevisionModal causes the site to crash on the deleted entity.
2. Revision Parent doesn't update on deleting an entity.