### PR TITLE
fix([BB-698]): Line break at the character level in annotations

### DIFF
--- a/src/client/stylesheets/style.scss
+++ b/src/client/stylesheets/style.scss
@@ -453,6 +453,7 @@ hr.wide {
 
 .annotation-content {
 	white-space: pre-wrap;
+	word-break: break-word;
 	position: relative;
 	font-family: inherit;
 	font-size: inherit;


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
This PR addresses [BB-698](https://tickets.metabrainz.org/browse/BB-698). Text in the annotations is breaking after any character (line-break: anywhere) rather than at the word level.


### Solution
<!-- What does this PR do to fix the problem? -->
Overriding the `word-break: break-all` property which is inherited due to the `pre` element.


