### PR TITLE
BB-692: Website server doesn't check revision id format before querying PostgreSQL

### DIFF
--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -192,6 +192,17 @@ export function loadEntityRelationships(req: $Request, res: $Response, next: Nex
 		})
 		.catch(next);
 }
+
+export function checkValidRevisionId(req: $Request, res: $Response, next: NextFunction, id: string) {
+	function isNumeric(value) {
+		return (/^-?\d+$/).test(value);
+	}
+	if (!isNumeric(id)) {
+		return next(new error.BadRequestError(`Invalid revision id: ${req.params.id}`, req));
+	}
+	return next();
+}
+
 export async function redirectedBbid(req: $Request, res: $Response, next: NextFunction, bbid: string) {
 	if (!commonUtils.isValidBBID(bbid)) {
 		return next(new error.BadRequestError(`Invalid bbid: ${req.params.bbid}`, req));

--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -194,10 +194,8 @@ export function loadEntityRelationships(req: $Request, res: $Response, next: Nex
 }
 
 export function checkValidRevisionId(req: $Request, res: $Response, next: NextFunction, id: string) {
-	function isNumeric(value) {
-		return (/^-?\d+$/).test(value);
-	}
-	if (!isNumeric(id)) {
+	const idToNumber = _.toNumber(id);
+	if (!_.isInteger(idToNumber) || (_.isInteger(idToNumber) && idToNumber <= 0)) {
 		return next(new error.BadRequestError(`Invalid revision id: ${req.params.id}`, req));
 	}
 	return next();

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -22,6 +22,7 @@ import * as entityFormatter from '../helpers/diffFormatters/entity';
 import * as entityRoutes from './entity/entity';
 import * as error from '../../common/helpers/error';
 import * as languageSetFormatter from '../helpers/diffFormatters/languageSet';
+import * as middleware from '../helpers/middleware';
 import * as propHelpers from '../../client/helpers/props';
 import * as publisherSetFormatter from '../helpers/diffFormatters/publisherSet';
 import * as releaseEventSetFormatter from
@@ -225,6 +226,11 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 		}
 	));
 }
+
+router.param(
+	'id',
+	middleware.checkValidRevisionId
+);
 
 router.get('/:id', async (req, res, next) => {
 	const {


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
When a revision page is requested with a crafted id, for example https://bookbrainz.org/revision/whynot, a PostgreSQL query is made.

It mainly adds a small unneeded load to the database server.


### Solution
<!-- What does this PR do to fix the problem? -->
Adding a middleware function which checks whether the parameter id is numeric or not.
