### PR TITLE
Enforce Unix end-of-line convention.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,15 +1,7 @@
-# Cross-platform line endings configuration
-# Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+# all text files follow Unix end-of-line convention
+* text eol=lf
 
-# Explicitly declare text files you want to always be normalized and converted
-# to native line endings on checkout.
-*.sh text
-
-# Declare files that will always have CRLF line endings on checkout.
-# *.sln text eol=crlf
-
-# Denote all files that are truly binary and should not be modified.
+# avoid modifying binary files
 *.png binary
 *.jpg binary
 *.svg binary


### PR DESCRIPTION
### Problem
Windows systems cloning repo would insert CRs to end of lines. This causes shell scripts executing in WSL to fail.

### Solution
Enforce Unix end-of-line convention; IDEs can handle this quite well.

### Areas of Impact
Git client will avoid adding CRs, and will strip CRs from text files on commit.