### PR TITLE
BB-712: Change alias delimiter to middle dot 

### DIFF
--- a/src/client/helpers/entity.tsx
+++ b/src/client/helpers/entity.tsx
@@ -238,9 +238,8 @@ export function getEntitySecondaryAliases(entity) {
 	if (entity.aliasSet && Array.isArray(entity.aliasSet.aliases) && entity.aliasSet.aliases.length > 1) {
 		const aliases = entity.aliasSet.aliases
 			.filter(item => item.id !== entity.defaultAlias.id)
-			.map(item => item.name)
-			.join(', ');
-		return <h4>{aliases}</h4>;
+			.map((item) => <li>{item.name}</li>);
+		return <ul className="inline-aliases">{aliases}</ul>;
 	}
 
 	return null;

--- a/src/client/stylesheets/style.scss
+++ b/src/client/stylesheets/style.scss
@@ -383,6 +383,20 @@ a.contact-text:visited {
 	height: 10px;
 }
 
+/* Style inline alias lists the same way as the previously used h4 elements */
+ul.inline-aliases {
+	@extend h4;
+	padding: 0;
+	li {
+		display: inline;
+	}
+	li::after {
+		content: ", ";
+	}
+	li:last-child:after {
+		content: "";
+	}
+}
 
 /* Text wrapping in list-group-items (for long revision notes, for example) */
 /* ============= */

--- a/src/client/stylesheets/style.scss
+++ b/src/client/stylesheets/style.scss
@@ -391,7 +391,8 @@ ul.inline-aliases {
 		display: inline;
 	}
 	li::after {
-		content: ", ";
+		content: " · ";
+		font-weight: bolder;
 	}
 	li:last-child:after {
 		content: "";


### PR DESCRIPTION
### Problem

[BB-712](https://tickets.metabrainz.org/browse/BB-712): The display of multiple aliases looks confusing [in certain cases](https://beta.bookbrainz.org/work/03ab2c2e-ff8a-4e10-bb07-f0afb6189dc8):

![before](https://user-images.githubusercontent.com/52860029/221633992-255c65a4-da4d-4e11-a657-aba34117c032.png)

### Solution

* [Render aliases as an inline list](https://github.com/metabrainz/bookbrainz-site/commit/e712e6079b6b79833cea1ae8f0911f18e08f8541): This makes it clearer where an alias begins and ends if the alias contains the text which is used as list separator. This change alone causes no visible difference.
* Use a character which is less likely to be used within an alias than a comma (middle dot, as agreed on IRC)
* Make the dot a bit more visible by increasing its font weight

![after](https://user-images.githubusercontent.com/52860029/221633824-8f46bc96-43c9-4100-ba60-d1eae632b234.png)

### Areas of Impact

The title section of all entity display pages.