### PR TITLE
Update connect-redis 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chartjs-adapter-date-fns": "^1.0.0",
     "classnames": "^2.3.2",
     "compression": "^1.7.4",
-    "connect-redis": "^6.0.0",
+    "connect-redis": "^7.0.0",
     "core-js": "^3.20.3",
     "cross-env": "^7.0.3",
     "date-fns": "^2.15.0",

--- a/src/api/app.js
+++ b/src/api/app.js
@@ -22,6 +22,7 @@
 import * as search from '../common/helpers/search';
 import BookBrainzData from 'bookbrainz-data';
 import Debug from 'debug';
+import RedisStore from 'connect-redis';
 import {get as _get} from 'lodash';
 import appCleanup from '../common/helpers/appCleanup';
 import compression from 'compression';
@@ -30,7 +31,6 @@ import {createClient} from 'redis';
 import express from 'express';
 import initRoutes from './routes';
 import logger from 'morgan';
-import redis from 'connect-redis';
 import session from 'express-session';
 
 
@@ -38,6 +38,7 @@ import session from 'express-session';
 const app = express();
 app.locals.orm = BookBrainzData(config.database);
 
+const debug = Debug('bbapi');
 
 app.set('trust proxy', config.site.proxyTrust);
 
@@ -59,19 +60,25 @@ const sessionOptions = {
 	saveUninitialized: false,
 	secret: config.session.secret
 };
+
 if (process.env.NODE_ENV !== 'test') {
+	const redisHost = _get(config, 'session.redis.host', 'localhost');
+	const redisPort = _get(config, 'session.redis.port', 6379);
 	const redisClient = createClient({
-		// connect-redis requires we maintain the redis v3 argument structure, with legacyMode:
-		// https://github.com/tj/connect-redis/issues/361#issuecomment-1182015683
-		host: _get(config, 'session.redis.host', 'localhost'),
-		legacyMode: true,
-		port: _get(config, 'session.redis.port', 6379)
+		url: `redis://${redisHost}:${redisPort}`
 	});
 
-	const RedisStore = redis(session);
-	sessionOptions.store = new RedisStore({
+	// eslint-disable-next-line no-console
+	redisClient.connect().catch(redisError => { console.error('Redis error:', redisError); });
+	redisClient.on('connection', (stream) => {
+		// eslint-disable-next-line no-console
+		console.log('someone connected!');
+	  });
+	redisClient.on('error', (err) => debug('Error while closing server connections', err));
+	const redisStore = new RedisStore({
 		client: redisClient
-	});
+	  });
+	sessionOptions.store = redisStore;
 }
 app.use(session(sessionOptions));
 
@@ -95,8 +102,6 @@ mainRouter.use((req, res) => {
 // https://github.com/elastic/elasticsearch-js/issues/33
 search.init(app.locals.orm, Object.assign({}, config.search));
 
-
-const debug = Debug('bbapi');
 
 const DEFAULT_API_PORT = 9098;
 app.set('port', process.env.PORT || DEFAULT_API_PORT);

--- a/src/api/app.js
+++ b/src/api/app.js
@@ -70,10 +70,7 @@ if (process.env.NODE_ENV !== 'test') {
 
 	// eslint-disable-next-line no-console
 	redisClient.connect().catch(redisError => { console.error('Redis error:', redisError); });
-	redisClient.on('connection', (stream) => {
-		// eslint-disable-next-line no-console
-		console.log('someone connected!');
-	  });
+
 	redisClient.on('error', (err) => debug('Error while closing server connections', err));
 	const redisStore = new RedisStore({
 		client: redisClient

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -23,9 +23,12 @@ import * as auth from './helpers/auth';
 import * as error from '../common/helpers/error';
 import * as search from '../common/helpers/search';
 import * as serverErrorHelper from './helpers/error';
+
 import {existsSync, readFileSync} from 'fs';
+
 import BookBrainzData from 'bookbrainz-data';
 import Debug from 'debug';
+import RedisStore from 'connect-redis';
 import {get as _get} from 'lodash';
 import appCleanup from '../common/helpers/appCleanup';
 import compression from 'compression';
@@ -37,7 +40,6 @@ import initInflux from './influx';
 import logNode from 'log-node';
 import logger from 'morgan';
 import path from 'path';
-import redis from 'connect-redis';
 import routes from './routes';
 import serveStatic from 'serve-static';
 import session from 'express-session';
@@ -98,18 +100,23 @@ const sessionOptions = {
 	secret: config.session.secret
 };
 if (process.env.NODE_ENV !== 'test') {
+	const redisHost = _get(config, 'session.redis.host', 'localhost');
+	const redisPort = _get(config, 'session.redis.port', 6379);
 	const redisClient = createClient({
-		// connect-redis requires we maintain the redis v3 argument structure, with legacyMode:
-		// https://github.com/tj/connect-redis/issues/361#issuecomment-1182015683
-		host: _get(config, 'session.redis.host', 'localhost'),
-		legacyMode: true,
-		port: _get(config, 'session.redis.port', 6379)
+		url: `redis://${redisHost}:${redisPort}`
 	});
 
-	const RedisStore = redis(session);
-	sessionOptions.store = new RedisStore({
+	// eslint-disable-next-line no-console
+	redisClient.connect().catch(redisError => { console.error('Redis error:', redisError); });
+	redisClient.on('connection', (stream) => {
+		// eslint-disable-next-line no-console
+		console.log('someone connected!');
+	  });
+	redisClient.on('error', (err) => debug('Error while closing server connections', err));
+	const redisStore = new RedisStore({
 		client: redisClient
-	});
+	  });
+	sessionOptions.store = redisStore;
 }
 app.use(session(sessionOptions));
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -99,7 +99,10 @@ const sessionOptions = {
 };
 if (process.env.NODE_ENV !== 'test') {
 	const redisClient = createClient({
+		// connect-redis requires we maintain the redis v3 argument structure, with legacyMode:
+		// https://github.com/tj/connect-redis/issues/361#issuecomment-1182015683
 		host: _get(config, 'session.redis.host', 'localhost'),
+		legacyMode: true,
 		port: _get(config, 'session.redis.port', 6379)
 	});
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -108,10 +108,7 @@ if (process.env.NODE_ENV !== 'test') {
 
 	// eslint-disable-next-line no-console
 	redisClient.connect().catch(redisError => { console.error('Redis error:', redisError); });
-	redisClient.on('connection', (stream) => {
-		// eslint-disable-next-line no-console
-		console.log('someone connected!');
-	  });
+
 	redisClient.on('error', (err) => debug('Error while closing server connections', err));
 	const redisStore = new RedisStore({
 		client: redisClient

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -69,8 +69,9 @@ router.get('/cb', (req, res, next) => {
 });
 
 router.get('/logout', (req, res) => {
-	req.logOut();
-	res.redirect(status.SEE_OTHER, '/');
+	req.logOut(() => {
+		res.redirect(status.SEE_OTHER, '/');
+	});
 });
 
 export default router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3303,10 +3303,10 @@ configstore@^5.0.1:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
-connect-redis@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-6.0.0.tgz#7e443fc7028eca43302bee59f51a315f65cd56b5"
-  integrity sha512-6eGEAAPHYvcfbRNCMmPzBIjrqRWLw7at9lCUH4G6NQ8gwWDJelaUmFNOqPIhehbw941euVmIuqWsaWiKXfb+5g==
+connect-redis@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-7.0.0.tgz#8a322a5f43146aaff1644aa6355a6527007dd23b"
+  integrity sha512-f7TlBs7J0Zz6y3mSKArBEN6qQ3T8BzsD1+tFSnnbvvCG1PjHllsQU/L7dTEaJsuZgzl/XU9hz+DMiPq1UJQMAQ==
 
 content-disposition@0.5.4:
   version "0.5.4"


### PR DESCRIPTION
I borked the redis connection in #932 and needed to revisit redis.
In the meantime, connect-redis v4 came out which removes the need for legacyMode in node-redis.
This PR updates the required bits and pieces to update the whole chain.

Also see https://github.com/redis/node-redis/blob/redis%404.0.0/docs/v3-to-v4.md and https://github.com/tj/connect-redis/releases/tag/v7.0.0