### PR TITLE
fix(call-to-action): properly encode query parameters once

### DIFF
--- a/src/client/components/pages/parts/call-to-action.js
+++ b/src/client/components/pages/parts/call-to-action.js
@@ -34,11 +34,10 @@ const {Button, ButtonGroup} = bootstrap;
  * the 'CallToAction' component.
  */
 function CallToAction(props) {
-	// double encoding to prevent browser from automatically decoding it
-	const nameQueryParameter = props.query ? `?name=${encodeURIComponent(encodeURIComponent(props.query))}` : '';
+	const seedingParameters = new URLSearchParams({name: props.query});
 	function renderEntityLink(type) {
 		return (
-			<a href={`/${camelCase(type)}/create${nameQueryParameter}`}>
+			<a href={`/${camelCase(type)}/create?${seedingParameters}`}>
 				<Button
 					className="padding-bottom-1 padding-sides-2 padding-top-1"
 					variant="secondary"

--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -382,8 +382,3 @@ export function validateCollaboratorIdsForCollectionRemove(req, res, next) {
 
 	return next();
 }
-
-export function decodeUrlQueryParams(req:$Request, res:$Response, next:NextFunction) {
-	req.query = _.mapValues(req.query, decodeURIComponent);
-	return next();
-}

--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -97,7 +97,6 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadGenders, middleware.loadLanguages,
 	middleware.loadAuthorTypes, middleware.loadRelationshipTypes,
-	middleware.decodeUrlQueryParams,
 	async (req, res) => {
 		const markupProps = generateEntityProps(
 			'author', req, res, {

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -93,7 +93,7 @@ const router = express.Router();
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadEditionGroupTypes,
-	middleware.loadRelationshipTypes, middleware.decodeUrlQueryParams,
+	middleware.loadRelationshipTypes,
 	 async (req, res) => {
 		const markupProps = generateEntityProps(
 			'editionGroup', req, res, {}

--- a/src/server/routes/entity/edition.ts
+++ b/src/server/routes/entity/edition.ts
@@ -143,7 +143,6 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadEditionStatuses, middleware.loadEditionFormats,
 	middleware.loadLanguages, middleware.loadRelationshipTypes,
-	middleware.decodeUrlQueryParams,
 	(req:PassportRequest, res, next) => {
 		const {EditionGroup, Publisher, Work} = req.app.locals.orm;
 		const propsPromise = generateEntityProps(

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -93,7 +93,7 @@ const router = express.Router();
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublisherTypes,
-	middleware.loadRelationshipTypes, middleware.decodeUrlQueryParams,
+	middleware.loadRelationshipTypes,
 	async (req, res) => {
 		const markupProps = generateEntityProps(
 			'publisher', req, res, {}

--- a/src/server/routes/entity/series.js
+++ b/src/server/routes/entity/series.js
@@ -90,7 +90,6 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages,
 	middleware.loadRelationshipTypes, middleware.loadSeriesOrderingTypes,
-	middleware.decodeUrlQueryParams,
 	async (req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'series', req, res, {}

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -91,7 +91,7 @@ const router = express.Router();
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadWorkTypes,
-	middleware.loadRelationshipTypes, middleware.decodeUrlQueryParams,
+	middleware.loadRelationshipTypes,
 	(req, res, next) => {
 		const {Author, Edition} = req.app.locals.orm;
 		let relationshipTypeId;


### PR DESCRIPTION
### Problem

Double encoding the seeding query parameters (e.g. http://localhost:9099/author/create?name=Rhythm%2520%2526%2520Beauty%253A%2520The%2520Art%2520of%2520Percussion) is entirely unnecessary.

### Solution

Properly encode the query parameter once (e.g. http://localhost:9099/author/create?name=Rhythm+%26+Beauty%3A+The+Art+of+Percussion).
Now we can also drop the `decodeUrlQueryParams` middleware (which was undoing the second encoding pass), Express.js is already doing one decoding pass for us automatically.

### Areas of Impact

"Are we missing an entry?" section of the search results page.