### PR TITLE
fix(display): always use Col as container inside Row flex-boxes 

### DIFF
--- a/src/client/components/pages/entities/links.js
+++ b/src/client/components/pages/entities/links.js
@@ -27,7 +27,7 @@ import React from 'react';
 
 
 const {filterOutRelationshipTypeById} = entityHelper;
-const {Row} = bootstrap;
+const {Row, Col} = bootstrap;
 
 function EntityLinks({entity, identifierTypes, urlPrefix}) {
 	// relationshipTypeId = 10 refers the relation (<Work> is contained by <Edition>)
@@ -36,17 +36,21 @@ function EntityLinks({entity, identifierTypes, urlPrefix}) {
 	return (
 		<React.Fragment>
 			<Row>
-				<EntityRelationships
-					contextEntity={entity}
-					entityUrl={urlPrefix}
-					relationships={relationships}
-				/>
+				<Col>
+					<EntityRelationships
+						contextEntity={entity}
+						entityUrl={urlPrefix}
+						relationships={relationships}
+					/>
+				</Col>
 			</Row>
 			<Row>
-				<EntityIdentifiers
-					identifierTypes={identifierTypes}
-					identifiers={entity.identifierSet && entity.identifierSet.identifiers}
-				/>
+				<Col>
+					<EntityIdentifiers
+						identifierTypes={identifierTypes}
+						identifiers={entity.identifierSet && entity.identifierSet.identifiers}
+					/>
+				</Col>
 			</Row>
 		</React.Fragment>
 	);

--- a/src/client/components/pages/entities/related-collections.js
+++ b/src/client/components/pages/entities/related-collections.js
@@ -27,17 +27,19 @@ const {Row} = bootstrap;
 function EntityRelatedCollections({collections}) {
 	return (
 		<Row>
-			<h2>Related Collections</h2>
-			{collections &&
-			<ul className="list-unstyled">
-				{collections.map((collection) => (
-					<li key={collection.id}>
-						<a href={`/collection/${collection.id}`}>{collection.name}</a> by {' '}
-						<a href={`/editor/${collection.ownerId}`}>{collection.owner.name}</a>
-					</li>
-				))}
-			</ul>
-			}
+			<div>
+				<h2>Related Collections</h2>
+				{collections &&
+				<ul className="list-unstyled">
+					{collections.map((collection) => (
+						<li key={collection.id}>
+							<a href={`/collection/${collection.id}`}>{collection.name}</a> by {' '}
+							<a href={`/editor/${collection.ownerId}`}>{collection.owner.name}</a>
+						</li>
+					))}
+				</ul>
+				}
+			</div>
 		</Row>
 	);
 }

--- a/src/client/components/pages/entities/related-collections.js
+++ b/src/client/components/pages/entities/related-collections.js
@@ -22,12 +22,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 
-const {Row} = bootstrap;
+const {Row, Col} = bootstrap;
 
 function EntityRelatedCollections({collections}) {
 	return (
 		<Row>
-			<div>
+			<Col>
 				<h2>Related Collections</h2>
 				{collections &&
 				<ul className="list-unstyled">
@@ -39,7 +39,7 @@ function EntityRelatedCollections({collections}) {
 					))}
 				</ul>
 				}
-			</div>
+			</Col>
 		</Row>
 	);
 }


### PR DESCRIPTION
### Problem

Previously the list of collections was displayed inline with the heading:
![before](https://user-images.githubusercontent.com/52860029/223231631-91537079-470b-489b-907e-b257e85ab48a.png)

### Solution

Wrap heading and list into a `<div>` container which serves as flex item of the `<Row>` flex-box:
![after](https://user-images.githubusercontent.com/52860029/223231744-fe25e453-8249-4328-8984-fecf3c51bd65.png)

I'm wondering whether I should have used a `<Col>` instead of a `<div>` which seems to be the semantically correct way. For now I have decided against it because the "Relationships" and "Identifiers" sections directly above are also using a `<div>` which results in [less unused space](https://user-images.githubusercontent.com/52860029/223233846-8ccd9bc2-6a0e-4777-a05c-7a826547e4d5.png) to the left than a `<Col>` (which is used by "Annotation" and the "Works" section of an Edition).
But I think we should make this consistent in the end?

Another related question: Should we really show the headings for empty sections? I would either leave them away or show at least a placeholder text.
Maybe even handle that on a case by case basis as an empty relationship section is a call to action while an empty collection section is usually not.

### Areas of Impact

"Related Collections" section  of all entity display pages.