### PR TITLE
BB-718: CritiqueBrainz auth endpoint is called server-side

### DIFF
--- a/src/client/components/pages/entities/cbReviewModal.tsx
+++ b/src/client/components/pages/entities/cbReviewModal.tsx
@@ -136,6 +136,7 @@ class CBReviewModal extends React.Component<
 				.post('/external-service/critiquebrainz/refresh');
 
 			if (response?.status === 200 && response?.body?.accessToken) {
+				localStorage.setItem('accessToken', response.body.accessToken);
 				return response.body.accessToken;
 			}
 
@@ -502,7 +503,9 @@ class CBReviewModal extends React.Component<
 	private accessToken = '';
 
 	componentDidMount = async () => {
-		this.accessToken = await this.getAccessToken();
+		if (!this.accessToken) {
+			this.accessToken = localStorage.getItem('accessToken') || await this.getAccessToken();
+		}
 	};
 
 	render() {


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->
[BB-718: CritiqueBrainz auth endpoint is called server-side ](https://tickets.metabrainz.org/browse/BB-718?filter=11910)
When rendering any entity page on the server side (to be sent to the client), an auth endpoint is called from the server side.


### Solution
<!-- What does this PR do to fix the problem? -->
Saving the access token at localStorage and every time the component is changed if the access token is not found at localStorage it gets it from the server side using the `getAccessToken` method.


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
The changes were reflected in `src/client/components/pages/entities/cbReviewModal.tsx`