### PR TITLE
BB-709: Add Author Credits column in publisher editions listing

### DIFF
--- a/src/client/components/pages/entities/edition-table.js
+++ b/src/client/components/pages/entities/edition-table.js
@@ -22,6 +22,7 @@ import * as utilHelper from '../../../helpers/utils';
 
 import {faBook, faPlus} from '@fortawesome/free-solid-svg-icons';
 
+import AuthorCreditDisplay from '../../author-credit-display';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -30,17 +31,18 @@ import {kebabCase as _kebabCase} from 'lodash';
 
 const {
 	getEditionReleaseDate, getEntityLabel, getEntityDisambiguation,
-	getISBNOfEdition, getEditionFormat
+	getISBNOfEdition, getEditionFormat, getAuthorCreditNames
 } = entityHelper;
 const {Button, Table} = bootstrap;
 
-function EditionTableRow({edition, showAddedAtColumn, showCheckboxes, selectedEntities, onToggleRow}) {
+function EditionTableRow({edition, showAddedAtColumn, showAuthorCreditsColumn, showCheckboxes, selectedEntities, onToggleRow}) {
 	const name = getEntityLabel(edition);
 	const disambiguation = getEntityDisambiguation(edition);
 	const number = edition.number || '?';
 	const releaseDate = getEditionReleaseDate(edition);
 	const isbn = getISBNOfEdition(edition);
 	const editionFormat = getEditionFormat(edition);
+	const authorCreditNames = showAuthorCreditsColumn ? getAuthorCreditNames(edition) : [];
 	const addedAt = showAddedAtColumn ? utilHelper.formatDate(new Date(edition.addedAt), true) : null;
 
 	/* eslint-disable react/jsx-no-bind */
@@ -61,6 +63,7 @@ function EditionTableRow({edition, showAddedAtColumn, showCheckboxes, selectedEn
 				<a href={`/edition/${edition.bbid}`}>{name}</a>
 				{disambiguation}
 			</td>
+			{showAuthorCreditsColumn && <td>{authorCreditNames.length ? <AuthorCreditDisplay names={authorCreditNames}/> : '?'}</td>}
 			<td>{editionFormat}</td>
 			<td>
 				{
@@ -87,15 +90,17 @@ EditionTableRow.propTypes = {
 	onToggleRow: PropTypes.func,
 	selectedEntities: PropTypes.array,
 	showAddedAtColumn: PropTypes.bool.isRequired,
+	showAuthorCreditsColumn: PropTypes.bool,
 	showCheckboxes: PropTypes.bool
 };
 EditionTableRow.defaultProps = {
 	onToggleRow: null,
 	selectedEntities: [],
+	showAuthorCreditsColumn: false,
 	showCheckboxes: false
 };
 
-function EditionTable({editions, entity, showAddedAtColumn, showAdd, showCheckboxes, selectedEntities, onToggleRow}) {
+function EditionTable({editions, entity, showAddedAtColumn, showAdd, showAuthorCreditsColumn, showCheckboxes, selectedEntities, onToggleRow}) {
 	let tableContent;
 	if (editions.length) {
 		tableContent = (
@@ -105,6 +110,7 @@ function EditionTable({editions, entity, showAddedAtColumn, showAdd, showCheckbo
 						<tr>
 							{editions[0].displayNumber && <th style={{width: '10%'}}>#</th>}
 							<th>Name</th>
+							{showAuthorCreditsColumn && <th>Author Credits</th>}
 							<th>Format</th>
 							<th>ISBN</th>
 							<th>Release Date</th>
@@ -121,6 +127,7 @@ function EditionTable({editions, entity, showAddedAtColumn, showAdd, showCheckbo
 									key={edition.bbid}
 									selectedEntities={selectedEntities}
 									showAddedAtColumn={showAddedAtColumn}
+									showAuthorCreditsColumn={showAuthorCreditsColumn}
 									showCheckboxes={showCheckboxes}
 									onToggleRow={onToggleRow}
 								/>
@@ -184,6 +191,7 @@ EditionTable.propTypes = {
 	selectedEntities: PropTypes.array,
 	showAdd: PropTypes.bool,
 	showAddedAtColumn: PropTypes.bool,
+	showAuthorCreditsColumn: PropTypes.bool,
 	showCheckboxes: PropTypes.bool
 };
 EditionTable.defaultProps = {
@@ -192,6 +200,7 @@ EditionTable.defaultProps = {
 	selectedEntities: [],
 	showAdd: true,
 	showAddedAtColumn: false,
+	showAuthorCreditsColumn: false,
 	showCheckboxes: false
 };
 

--- a/src/client/components/pages/entities/publisher.js
+++ b/src/client/components/pages/entities/publisher.js
@@ -101,7 +101,7 @@ function PublisherDisplayPage({entity, identifierTypes, user}) {
 			<EntityAnnotation entity={entity}/>
 			{!entity.deleted &&
 			<React.Fragment>
-				<EditionTable editions={entity.editions} entity={entity} showAuthorCreditsColumn/>
+				<EditionTable showAuthorCreditsColumn editions={entity.editions} entity={entity}/>
 				<EntityLinks
 					entity={entity}
 					identifierTypes={identifierTypes}

--- a/src/client/components/pages/entities/publisher.js
+++ b/src/client/components/pages/entities/publisher.js
@@ -101,7 +101,7 @@ function PublisherDisplayPage({entity, identifierTypes, user}) {
 			<EntityAnnotation entity={entity}/>
 			{!entity.deleted &&
 			<React.Fragment>
-				<EditionTable editions={entity.editions} entity={entity}/>
+				<EditionTable editions={entity.editions} entity={entity} showAuthorCreditsColumn={entity.showAuthorCreditsColumn}/>
 				<EntityLinks
 					entity={entity}
 					identifierTypes={identifierTypes}

--- a/src/client/components/pages/entities/publisher.js
+++ b/src/client/components/pages/entities/publisher.js
@@ -101,7 +101,7 @@ function PublisherDisplayPage({entity, identifierTypes, user}) {
 			<EntityAnnotation entity={entity}/>
 			{!entity.deleted &&
 			<React.Fragment>
-				<EditionTable editions={entity.editions} entity={entity} showAuthorCreditsColumn={entity.showAuthorCreditsColumn}/>
+				<EditionTable editions={entity.editions} entity={entity} showAuthorCreditsColumn/>
 				<EntityLinks
 					entity={entity}
 					identifierTypes={identifierTypes}

--- a/src/client/helpers/entity.tsx
+++ b/src/client/helpers/entity.tsx
@@ -197,6 +197,13 @@ export function getEditionReleaseDate(edition) {
 	return '?';
 }
 
+export function getAuthorCreditNames(edition) {
+	if (edition.authorCreditId === null) {
+		return [];
+	}
+	return edition.authorCredit.names;
+}
+
 export function getEditionPublishers(edition) {
 	const hasPublishers = edition.publisherSet &&
 		edition.publisherSet.publishers.length > 0;

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -208,7 +208,6 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res, next) => {
 	return editionsPromise
 		.then((editions) => {
 			res.locals.entity.editions = editions.toJSON();
-			res.locals.entity.showAuthorCreditsColumn = true;
 			_setPublisherTitle(res);
 			res.locals.entity.editions.sort(entityRoutes.compareEntitiesByDate);
 			return entityRoutes.displayEntity(req, res);

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -198,7 +198,8 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res, next) => {
 		'disambiguation',
 		'releaseEventSet.releaseEvents',
 		'identifierSet.identifiers.type',
-		'editionFormat'
+		'editionFormat',
+		'authorCredit.names'
 	];
 	const editionsPromise =
 		Publisher.forge({bbid: res.locals.entity.bbid})
@@ -207,6 +208,7 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res, next) => {
 	return editionsPromise
 		.then((editions) => {
 			res.locals.entity.editions = editions.toJSON();
+			res.locals.entity.showAuthorCreditsColumn = true;
 			_setPublisherTitle(res);
 			res.locals.entity.editions.sort(entityRoutes.compareEntitiesByDate);
 			return entityRoutes.displayEntity(req, res);


### PR DESCRIPTION

### Problem
It would be quite informative to see the author(s) of an edition in the list of editions for a given publisher. This PR addresses [BB-709](https://tickets.metabrainz.org/browse/BB-709)


### Solution
Added a column to display the author credits using the already existing AuthorCreditDisplay component.

