### PR TITLE
BB-690: added unset functionality for dropdowns

### DIFF
--- a/src/client/components/forms/registration-details.js
+++ b/src/client/components/forms/registration-details.js
@@ -146,6 +146,7 @@ class RegistrationForm extends React.Component {
 										defaultValue={this.props.genders.filter((option) => option.id === initialGender)}
 										getOptionLabel={this.getOptionLabel}
 										instanceId="gender"
+										isClearable="true"
 										options={this.props.genders}
 										placeholder="Select gender…"
 										ref={(ref) => this.gender = ref}

--- a/src/client/entity-editor/author-section/author-section.tsx
+++ b/src/client/entity-editor/author-section/author-section.tsx
@@ -195,6 +195,7 @@ function AuthorSection({
 							options={authorTypesForDisplay}
 							value={typeOption}
 							onChange={onTypeChange}
+							isClearable={true}
 						/>
 					</Form.Group>
 				</Col>
@@ -209,6 +210,7 @@ function AuthorSection({
 							options={genderOptionsForDisplay}
 							value={genderOption}
 							onChange={onGenderChange}
+							isClearable={true}
 						/>
 					</Form.Group>
 				</Col>

--- a/src/client/entity-editor/edition-group-section/edition-group-section.tsx
+++ b/src/client/entity-editor/edition-group-section/edition-group-section.tsx
@@ -108,6 +108,7 @@ function EditionGroupSection({
 							options={editionGroupTypesForDisplay}
 							value={typeOption}
 							onChange={onTypeChange}
+							isClearable={true}
 						/>
 					</Form.Group>
 				</Col>

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -402,6 +402,7 @@ function EditionSection({
 							options={editionFormatsForDisplay}
 							value={formatOption}
 							onChange={onFormatChange}
+							isClearable={true}
 						/>
 					</Form.Group>
 				</Col>
@@ -423,6 +424,7 @@ function EditionSection({
 							options={editionStatusesForDisplay}
 							value={statusOption}
 							onChange={onStatusChange}
+							isClearable={true}
 						/>
 					</Form.Group>
 				</Col>

--- a/src/client/entity-editor/publisher-section/publisher-section.tsx
+++ b/src/client/entity-editor/publisher-section/publisher-section.tsx
@@ -151,6 +151,7 @@ function PublisherSection({
 							options={publisherTypesForDisplay}
 							value={typeOption}
 							onChange={onTypeChange}
+							isClearable={true}
 						/>
 					</Form.Group>
 				</Col>

--- a/src/client/entity-editor/work-section/work-section.tsx
+++ b/src/client/entity-editor/work-section/work-section.tsx
@@ -140,6 +140,7 @@ function WorkSection({
 							options={workTypesForDisplay}
 							value={typeOption}
 							onChange={onTypeChange}
+							isClearable={true}
 						/>
 					</Form.Group>
 				</Col>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one --> BB-690


### Solution
<!-- What does this PR do to fix the problem? -->
Reset functionality for _Select_ elements  in the +Add sections, like "Type", "Format" or "Status"

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Modified 6 files that handle 6 different pages in the +Add category. Added an attribute for _Select_ elements that enables the possibility to unset an option.
