### PR TITLE
BB-730: Rewrite test files using async/await syntax

### DIFF
--- a/data/test-data.js
+++ b/data/test-data.js
@@ -475,7 +475,7 @@ export function createSprinter() {
 		);
 }
 
-export function sprinterHelper(numRevisions) {
+export async function sprinterHelper(numRevisions) {
 	const promiseList = [];
 	for (let i = 0; i < numRevisions; i++) {
 		promiseList.push(
@@ -483,7 +483,8 @@ export function sprinterHelper(numRevisions) {
 				.save(null, {method: 'insert'})
 		);
 	}
-	return Promise.all(promiseList);
+	const result = await Promise.all(promiseList);
+	return result;
 }
 
 export function createFunRunner() {

--- a/test/common.js
+++ b/test/common.js
@@ -29,41 +29,52 @@ export function expectFalse() {
 	return (promise) => expect(promise).to.eventually.equal(false);
 }
 
+
 export function expectIds(prop, rev) {
-	return (promise) => Promise.all([
-		expect(promise).to.eventually.have
-			.property('editorId', testData.editorAttribs.id),
-		expect(promise).to.eventually.have
-			.property('achievementId', testData[`${prop}${rev}Attribs`].id)
-	]);
+	return async (promise) => {
+		const results = await Promise.all([
+			expect(promise).to.eventually.have
+				.property('editorId', testData.editorAttribs.id),
+			expect(promise).to.eventually.have
+				.property('achievementId', testData[`${prop}${rev}Attribs`].id)
+		]);
+		return results;
+	};
 }
 
+
 export function expectRevNamedIds(name, prop, rev) {
-	return (promise) => Promise.all([
-		expect(promise).to.eventually.have.nested
-			.property(`${name} ${rev}.editorId`,
-				testData.editorAttribs.id),
-		expect(promise).to.eventually.have.nested
-			.property(`${name} ${rev}.achievementId`,
-				testData[`${prop}${rev}Attribs`].id)
-	]);
+	return async (promise) => {
+		const results = await Promise.all([
+			expect(promise).to.eventually.have.nested
+				.property(`${name} ${rev}.editorId`,
+					testData.editorAttribs.id),
+			expect(promise).to.eventually.have.nested
+				.property(`${name} ${rev}.achievementId`,
+					testData[`${prop}${rev}Attribs`].id)
+		]);
+		return results;
+	};
 }
 
 export function expectAllNamedIds(name, prop, rev) {
-	return (promise) => Promise.all([
-		expect(promise).to.eventually.have.nested
-			.property(`${name} ${rev}.editorId`,
-				testData.editorAttribs.id),
-		expect(promise).to.eventually.have.nested
-			.property(`${name} ${rev}.achievementId`,
-				testData[`${prop}${rev}Attribs`].id),
-		expect(promise).to.eventually.have.nested
-			.property(`${name}.editorId`,
-				testData.editorAttribs.id),
-		expect(promise).to.eventually.have.nested
-			.property(`${name}.titleId`,
-				testData[`${prop}Attribs`].id)
-	]);
+	return async (promise) => {
+		const results = await Promise.all([
+			expect(promise).to.eventually.have.nested
+				.property(`${name} ${rev}.editorId`,
+					testData.editorAttribs.id),
+			expect(promise).to.eventually.have.nested
+				.property(`${name} ${rev}.achievementId`,
+					testData[`${prop}${rev}Attribs`].id),
+			expect(promise).to.eventually.have.nested
+				.property(`${name}.editorId`,
+					testData.editorAttribs.id),
+			expect(promise).to.eventually.have.nested
+				.property(`${name}.titleId`,
+					testData[`${prop}Attribs`].id)
+		]);
+		return results;
+	};
 }
 
 export function getAttrPromise(Achievement, orm, full) {

--- a/test/test-achievement.js
+++ b/test/test-achievement.js
@@ -48,7 +48,7 @@ function tests() {
 	describe('awardAchievement', () => {
 		afterEach(testData.truncate);
 
-		it('should award achievements', () => {
+		it('should award achievements', async () => {
 			const unlockPromise = testData.createEditor()
 				.then(() => testData.createRevisionist())
 				.then(
@@ -59,7 +59,7 @@ function tests() {
 					)
 				);
 
-			return Promise.all([
+			const result = await Promise.all([
 				expect(unlockPromise).to.eventually.have.nested.property(
 					'Revisionist I.editorId',
 					testData.editorAttribs.id
@@ -69,6 +69,7 @@ function tests() {
 					testData.revisionistIAttribs.id
 				)
 			]);
+			return result;
 		});
 
 		// suppress warnings from rejections
@@ -112,7 +113,7 @@ function tests() {
 	describe('awardTitle', () => {
 		afterEach(testData.truncate);
 
-		it('should award titles', () => {
+		it('should award titles', async () => {
 			const unlockPromise = testData.createEditor()
 				.then(() => testData.createRevisionist())
 				.then(
@@ -123,7 +124,7 @@ function tests() {
 					)
 				);
 
-			return Promise.all([
+			const result = await Promise.all([
 				expect(unlockPromise).to.eventually.have.nested.property(
 					'Revisionist.editorId',
 					testData.editorAttribs.id
@@ -133,6 +134,7 @@ function tests() {
 					testData.revisionistAttribs.id
 				)
 			]);
+			return result;
 		});
 
 		it('should reject invalid editors', () => {


### PR DESCRIPTION
Problem
[BB-673](https://tickets.metabrainz.org/browse/BB-673):
Across the codebase, we have asynchronous code written using promises, which is hard to read and to maintain and error-prone.

Solution
All this code was rewritten using the async/await syntax.

Areas of Impact
The changes were reflected in test/common.js