### PR TITLE
BB-714: Fix search results page on Safari

### DIFF
--- a/src/client/components/pages/entities/series-table.js
+++ b/src/client/components/pages/entities/series-table.js
@@ -79,7 +79,7 @@ function SeriesTable({series, showAddedAtColumn, showCheckboxes, selectedEntitie
 				<Table striped>
 					<thead>
 						<tr>
-							<th style={{width: '40%'}}>Name</th>
+							<th width="40%">Name</th>
 							<th>Series Type</th>
 							<th>Ordering Type</th>
 							{

--- a/src/client/components/pages/parts/collections-table.js
+++ b/src/client/components/pages/parts/collections-table.js
@@ -128,26 +128,26 @@ class CollectionsTable extends React.Component {
 						>
 							<thead>
 								<tr>
-									<th style={{width: '16%'}}>Name</th>
-									<th style={{width: '33%'}}>Description</th>
-									<th style={{width: '16%'}}>Entity Type</th>
-									<th style={{width: '16%'}}>Entities</th>
+									<th width="16%">Name</th>
+									<th width="33%">Description</th>
+									<th width="16%">Entity Type</th>
+									<th width="16%">Entities</th>
 									{
 										showPrivacy ?
-											<th style={{width: '16%'}}>Privacy</th> : null
+											<th width="16%">Privacy</th> : null
 									}
 									{
 										showIfOwnerOrCollaborator ?
-											<th style={{width: '16%'}}>Collaborator/Owner</th> : null
+											<th width="16%">Collaborator/Owner</th> : null
 									}
 									{
 										showOwner ?
-											<th style={{width: '16%'}}>Owner</th> : null
+											<th width="16%">Owner</th> : null
 
 									}
 									{
 										showLastModified ?
-											<th style={{width: '16%'}}>Last Modified</th> : null
+											<th width="16%">Last Modified</th> : null
 									}
 								</tr>
 							</thead>

--- a/src/client/components/pages/parts/collections-table.js
+++ b/src/client/components/pages/parts/collections-table.js
@@ -128,26 +128,26 @@ class CollectionsTable extends React.Component {
 						>
 							<thead>
 								<tr>
-									<th className="col-md-2">Name</th>
-									<th className="col-md-4">Description</th>
-									<th className="col-md-2">Entity Type</th>
-									<th className="col-md-2">Entities</th>
+									<th style={{width: '16%'}}>Name</th>
+									<th style={{width: '33%'}}>Description</th>
+									<th style={{width: '16%'}}>Entity Type</th>
+									<th style={{width: '16%'}}>Entities</th>
 									{
 										showPrivacy ?
-											<th className="col-md-2">Privacy</th> : null
+											<th style={{width: '16%'}}>Privacy</th> : null
 									}
 									{
 										showIfOwnerOrCollaborator ?
-											<th className="col-md-2">Collaborator/Owner</th> : null
+											<th style={{width: '16%'}}>Collaborator/Owner</th> : null
 									}
 									{
 										showOwner ?
-											<th className="col-md-2">Owner</th> : null
+											<th style={{width: '16%'}}>Owner</th> : null
 
 									}
 									{
 										showLastModified ?
-											<th className="col-md-2">Last Modified</th> : null
+											<th style={{width: '16%'}}>Last Modified</th> : null
 									}
 								</tr>
 							</thead>

--- a/src/client/components/pages/parts/editor-profile.js
+++ b/src/client/components/pages/parts/editor-profile.js
@@ -97,26 +97,26 @@ class EditorProfileTab extends React.Component {
 					}
 				</h2>
 				<dl className="row editor-info">
-					<dt width="16%">MusicBrainz Account</dt>
-					<dd width="84%">
+					<dt className="col-md-2">MusicBrainz Account</dt>
+					<dd className="col-md-10">
 						{musicbrainzAccount}
 					</dd>
-					<dt width="16%">Display Name</dt>
-					<dd width="84%">{name}</dd>
-					<dt width="16%">Area</dt>
-					<dd width="84%">{editor.area ? editor.area.name : '?'}</dd>
-					<dt width="16%">Gender</dt>
-					<dd width="84%">{gender ? gender.name : '?'}</dd>
-					<dt width="16%">Type</dt>
-					<dd width="84%">{editor.type.label}</dd>
-					<dt width="16%">Reputation</dt>
-					<dd width="84%">0</dd>
-					<dt width="16%">Joined</dt>
-					<dd width="84%">{createdAtDate}</dd>
-					<dt width="16%">Last login</dt>
-					<dd width="84%">{lastActiveDate}</dd>
-					<dt width="16%">Bio</dt>
-					<dd width="84%">{editor.bio ? editor.bio : '-'}</dd>
+					<dt className="col-md-2">Display Name</dt>
+					<dd className="col-md-10">{name}</dd>
+					<dt className="col-md-2">Area</dt>
+					<dd className="col-md-10">{editor.area ? editor.area.name : '?'}</dd>
+					<dt className="col-md-2">Gender</dt>
+					<dd className="col-md-10">{gender ? gender.name : '?'}</dd>
+					<dt className="col-md-2">Type</dt>
+					<dd className="col-md-10">{editor.type.label}</dd>
+					<dt className="col-md-2">Reputation</dt>
+					<dd className="col-md-10">0</dd>
+					<dt className="col-md-2">Joined</dt>
+					<dd className="col-md-10">{createdAtDate}</dd>
+					<dt className="col-md-2">Last login</dt>
+					<dd className="col-md-10">{lastActiveDate}</dd>
+					<dt className="col-md-2">Bio</dt>
+					<dd className="col-md-10">{editor.bio ? editor.bio : '-'}</dd>
 				</dl>
 			</div>
 		);
@@ -129,12 +129,12 @@ class EditorProfileTab extends React.Component {
 			<div>
 				<h2>Stats</h2>
 				<dl className="row editor-info">
-					<dt width="67%">Total Revisions</dt>
-					<dd width="33%">{editor.totalRevisions}</dd>
-					<dt width="67%">Revisions Applied</dt>
-					<dd width="33%">{editor.revisionsApplied}</dd>
-					<dt width="67%">Revisions Reverted</dt>
-					<dd width="33%">{editor.revisionsReverted}</dd>
+					<dt className="col-md-8">Total Revisions</dt>
+					<dd className="col-md-4">{editor.totalRevisions}</dd>
+					<dt className="col-md-8">Revisions Applied</dt>
+					<dd className="col-md-4">{editor.revisionsApplied}</dd>
+					<dt className="col-md-8">Revisions Reverted</dt>
+					<dd className="col-md-4">{editor.revisionsReverted}</dd>
 				</dl>
 			</div>
 		);

--- a/src/client/components/pages/parts/editor-profile.js
+++ b/src/client/components/pages/parts/editor-profile.js
@@ -97,26 +97,26 @@ class EditorProfileTab extends React.Component {
 					}
 				</h2>
 				<dl className="row editor-info">
-					<dt style={{width: '16%'}}>MusicBrainz Account</dt>
-					<dd style={{width: '84%'}}>
+					<dt width="16%">MusicBrainz Account</dt>
+					<dd width="84%">
 						{musicbrainzAccount}
 					</dd>
-					<dt style={{width: '16%'}}>Display Name</dt>
-					<dd style={{width: '84%'}}>{name}</dd>
-					<dt style={{width: '16%'}}>Area</dt>
-					<dd style={{width: '84%'}}>{editor.area ? editor.area.name : '?'}</dd>
-					<dt style={{width: '16%'}}>Gender</dt>
-					<dd style={{width: '84%'}}>{gender ? gender.name : '?'}</dd>
-					<dt style={{width: '16%'}}>Type</dt>
-					<dd style={{width: '84%'}}>{editor.type.label}</dd>
-					<dt style={{width: '16%'}}>Reputation</dt>
-					<dd style={{width: '84%'}}>0</dd>
-					<dt style={{width: '16%'}}>Joined</dt>
-					<dd style={{width: '84%'}}>{createdAtDate}</dd>
-					<dt style={{width: '16%'}}>Last login</dt>
-					<dd style={{width: '84%'}}>{lastActiveDate}</dd>
-					<dt style={{width: '16%'}}>Bio</dt>
-					<dd style={{width: '84%'}}>{editor.bio ? editor.bio : '-'}</dd>
+					<dt width="16%">Display Name</dt>
+					<dd width="84%">{name}</dd>
+					<dt width="16%">Area</dt>
+					<dd width="84%">{editor.area ? editor.area.name : '?'}</dd>
+					<dt width="16%">Gender</dt>
+					<dd width="84%">{gender ? gender.name : '?'}</dd>
+					<dt width="16%">Type</dt>
+					<dd width="84%">{editor.type.label}</dd>
+					<dt width="16%">Reputation</dt>
+					<dd width="84%">0</dd>
+					<dt width="16%">Joined</dt>
+					<dd width="84%">{createdAtDate}</dd>
+					<dt width="16%">Last login</dt>
+					<dd width="84%">{lastActiveDate}</dd>
+					<dt width="16%">Bio</dt>
+					<dd width="84%">{editor.bio ? editor.bio : '-'}</dd>
 				</dl>
 			</div>
 		);
@@ -129,12 +129,12 @@ class EditorProfileTab extends React.Component {
 			<div>
 				<h2>Stats</h2>
 				<dl className="row editor-info">
-					<dt style={{width: '67%'}}>Total Revisions</dt>
-					<dd style={{width: '33%'}}>{editor.totalRevisions}</dd>
-					<dt style={{width: '67%'}}>Revisions Applied</dt>
-					<dd style={{width: '33%'}}>{editor.revisionsApplied}</dd>
-					<dt style={{width: '67%'}}>Revisions Reverted</dt>
-					<dd style={{width: '33%'}}>{editor.revisionsReverted}</dd>
+					<dt width="67%">Total Revisions</dt>
+					<dd width="33%">{editor.totalRevisions}</dd>
+					<dt width="67%">Revisions Applied</dt>
+					<dd width="33%">{editor.revisionsApplied}</dd>
+					<dt width="67%">Revisions Reverted</dt>
+					<dd width="33%">{editor.revisionsReverted}</dd>
 				</dl>
 			</div>
 		);

--- a/src/client/components/pages/parts/editor-profile.js
+++ b/src/client/components/pages/parts/editor-profile.js
@@ -97,26 +97,26 @@ class EditorProfileTab extends React.Component {
 					}
 				</h2>
 				<dl className="row editor-info">
-					<dt className="col-md-2">MusicBrainz Account</dt>
-					<dd className="col-md-10">
+					<dt style={{width: '16%'}}>MusicBrainz Account</dt>
+					<dd style={{width: '84%'}}>
 						{musicbrainzAccount}
 					</dd>
-					<dt className="col-md-2">Display Name</dt>
-					<dd className="col-md-10">{name}</dd>
-					<dt className="col-md-2">Area</dt>
-					<dd className="col-md-10">{editor.area ? editor.area.name : '?'}</dd>
-					<dt className="col-md-2">Gender</dt>
-					<dd className="col-md-10">{gender ? gender.name : '?'}</dd>
-					<dt className="col-md-2">Type</dt>
-					<dd className="col-md-10">{editor.type.label}</dd>
-					<dt className="col-md-2">Reputation</dt>
-					<dd className="col-md-10">0</dd>
-					<dt className="col-md-2">Joined</dt>
-					<dd className="col-md-10">{createdAtDate}</dd>
-					<dt className="col-md-2">Last login</dt>
-					<dd className="col-md-10">{lastActiveDate}</dd>
-					<dt className="col-md-2">Bio</dt>
-					<dd className="col-md-10">{editor.bio ? editor.bio : '-'}</dd>
+					<dt style={{width: '16%'}}>Display Name</dt>
+					<dd style={{width: '84%'}}>{name}</dd>
+					<dt style={{width: '16%'}}>Area</dt>
+					<dd style={{width: '84%'}}>{editor.area ? editor.area.name : '?'}</dd>
+					<dt style={{width: '16%'}}>Gender</dt>
+					<dd style={{width: '84%'}}>{gender ? gender.name : '?'}</dd>
+					<dt style={{width: '16%'}}>Type</dt>
+					<dd style={{width: '84%'}}>{editor.type.label}</dd>
+					<dt style={{width: '16%'}}>Reputation</dt>
+					<dd style={{width: '84%'}}>0</dd>
+					<dt style={{width: '16%'}}>Joined</dt>
+					<dd style={{width: '84%'}}>{createdAtDate}</dd>
+					<dt style={{width: '16%'}}>Last login</dt>
+					<dd style={{width: '84%'}}>{lastActiveDate}</dd>
+					<dt style={{width: '16%'}}>Bio</dt>
+					<dd style={{width: '84%'}}>{editor.bio ? editor.bio : '-'}</dd>
 				</dl>
 			</div>
 		);
@@ -129,12 +129,12 @@ class EditorProfileTab extends React.Component {
 			<div>
 				<h2>Stats</h2>
 				<dl className="row editor-info">
-					<dt className="col-md-8">Total Revisions</dt>
-					<dd className="col-md-4">{editor.totalRevisions}</dd>
-					<dt className="col-md-8">Revisions Applied</dt>
-					<dd className="col-md-4">{editor.revisionsApplied}</dd>
-					<dt className="col-md-8">Revisions Reverted</dt>
-					<dd className="col-md-4">{editor.revisionsReverted}</dd>
+					<dt style={{width: '67%'}}>Total Revisions</dt>
+					<dd style={{width: '33%'}}>{editor.totalRevisions}</dd>
+					<dt style={{width: '67%'}}>Revisions Applied</dt>
+					<dd style={{width: '33%'}}>{editor.revisionsApplied}</dd>
+					<dt style={{width: '67%'}}>Revisions Reverted</dt>
+					<dd style={{width: '33%'}}>{editor.revisionsReverted}</dd>
 				</dl>
 			</div>
 		);

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -45,20 +45,20 @@ function RevisionsTable(props) {
 					>
 						<thead>
 							<tr>
-								<th style={{width: '16%'}}>Revision ID</th>
+								<th width="16%">Revision ID</th>
 								{
 									showEntities ?
-										<th style={{width: '42%'}}>Modified entities</th> : null
+										<th width="42%">Modified entities</th> : null
 								}
 								{
 									showRevisionEditor ?
-										<th style={{width: '25%'}}>User</th> : null
+										<th width="25%">User</th> : null
 								}
 								{
 									showRevisionNote ?
-										<th style={{width: '16%'}}>Note</th> : null
+										<th width="16%">Note</th> : null
 								}
-								<th style={{width: '16%'}}>Date</th>
+								<th width="16%">Date</th>
 							</tr>
 						</thead>
 

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -45,20 +45,20 @@ function RevisionsTable(props) {
 					>
 						<thead>
 							<tr>
-								<th className="col-md-2">Revision ID</th>
+								<th style={{width: '16%'}}>Revision ID</th>
 								{
 									showEntities ?
-										<th className="col-md-5">Modified entities</th> : null
+										<th style={{width: '42%'}}>Modified entities</th> : null
 								}
 								{
 									showRevisionEditor ?
-										<th className="col-md-3">User</th> : null
+										<th style={{width: '25%'}}>User</th> : null
 								}
 								{
 									showRevisionNote ?
-										<th className="col-md-3">Note</th> : null
+										<th style={{width: '16%'}}>Note</th> : null
 								}
-								<th className="col-md-2">Date</th>
+								<th style={{width: '16%'}}>Date</th>
 							</tr>
 						</thead>
 

--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -232,9 +232,9 @@ class SearchResults extends React.Component {
 						!this.props.condensed &&
 						<thead>
 							<tr>
-								<th style={{width: '25%'}}>Type</th>
-								<th style={{width: '42%'}}>Name</th>
-								<th style={{width: '33%'}}>Aliases</th>
+								<th width="25%">Type</th>
+								<th width="42%">Name</th>
+								<th width="33%">Aliases</th>
 							</tr>
 						</thead>
 					}

--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -232,9 +232,9 @@ class SearchResults extends React.Component {
 						!this.props.condensed &&
 						<thead>
 							<tr>
-								<th className="col-md-3">Type</th>
-								<th className="col-md-5">Name</th>
-								<th className="col-md-4">Aliases</th>
+								<th style={{width: '25%'}}>Type</th>
+								<th style={{width: '42%'}}>Name</th>
+								<th style={{width: '33%'}}>Aliases</th>
 							</tr>
 						</thead>
 					}

--- a/src/client/components/pages/statistics.js
+++ b/src/client/components/pages/statistics.js
@@ -48,10 +48,10 @@ function TopEditorsTable(props) {
 			>
 				<thead>
 					<tr>
-						<th style={{width: '8%'}} >#</th>
-						<th style={{width: '42%'}} >Editor&apos;s Name</th>
-						<th style={{width: '25%'}} >Total Revisions</th>
-						<th style={{width: '25%'}} >Registration Date</th>
+						<th width="8%" >#</th>
+						<th width="42%" >Editor&apos;s Name</th>
+						<th width="25%" >Total Revisions</th>
+						<th width="25%" >Registration Date</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -101,10 +101,10 @@ function EntityCountTable(props) {
 			>
 				<thead>
 					<tr>
-						<th style={{width: '8%'}} >#</th>
-						<th style={{width: '42%'}} >Entity Type</th>
-						<th style={{width: '25%'}} >Total</th>
-						<th style={{width: '25%'}} >Added in Last 30 days</th>
+						<th width="8%" >#</th>
+						<th width="42%" >Entity Type</th>
+						<th width="25%" >Total</th>
+						<th width="25%" >Added in Last 30 days</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/client/components/pages/statistics.js
+++ b/src/client/components/pages/statistics.js
@@ -48,10 +48,10 @@ function TopEditorsTable(props) {
 			>
 				<thead>
 					<tr>
-						<th className="col-md-1" >#</th>
-						<th className="col-md-5" >Editor&apos;s Name</th>
-						<th className="col-md-3" >Total Revisions</th>
-						<th className="col-md-3" >Registration Date</th>
+						<th style={{width: '8%'}} >#</th>
+						<th style={{width: '42%'}} >Editor&apos;s Name</th>
+						<th style={{width: '25%'}} >Total Revisions</th>
+						<th style={{width: '25%'}} >Registration Date</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -101,10 +101,10 @@ function EntityCountTable(props) {
 			>
 				<thead>
 					<tr>
-						<th className="col-md-1" >#</th>
-						<th className="col-md-5" >Entity Type</th>
-						<th className="col-md-3" >Total</th>
-						<th className="col-md-3" >Added in Last 30 days</th>
+						<th style={{width: '8%'}} >#</th>
+						<th style={{width: '42%'}} >Entity Type</th>
+						<th style={{width: '25%'}} >Total</th>
+						<th style={{width: '25%'}} >Added in Last 30 days</th>
 					</tr>
 				</thead>
 				<tbody>


### PR DESCRIPTION
[BB-714](https://tickets.metabrainz.org/browse/BB-714)
### Problem
The width of tables on the Webkit-based browser are broken.

The width of the columns is defined using Bootstrap CSS classes, which is not working on Webkit.

### Solution
Setting the column sizes using the width attribute in percentages solves the issue.

### Areas of Impact
All tables rendered on the Bookbrainz website that use the `col-md` class name to specify the width.