### PR TITLE
BB-741: Add https:// prefix without using a lookbehind expression

### DIFF
--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -173,17 +173,20 @@ export function dateObjectToISOString(value: DateObject) {
  * Convert any string url that has a prefix http|https|ftp|ftps to a clickable link
  * and then rendered the HTML string as real HTML.
  * @function stringToHTMLWithLinks
- * @param {string} string - Can be either revision notes or annotation content etc...
+ * @param {string} content - Can be either revision notes or annotation content etc...
  * @returns {JSX} returns a JSX Element
  */
-export function stringToHTMLWithLinks(string: string) {
-	const addHttpRegex = /(\b(?<!https?:\/\/)w{3}\.\S+\.)/gmi;
+export function stringToHTMLWithLinks(content: string) {
 	// eslint-disable-next-line max-len, no-useless-escape
 	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
-	let content = string.replace(addHttpRegex, 'https://$1');
 	content = content.replace(
 		urlRegex,
-		'<a href="$1" target="_blank">$1</a>'
+		(url) => {
+			if (url.startsWith('www.')) {
+				url = 'https://' + url;
+			}
+			return `<a href="${url}" target="_blank">${url}</a>`;
+		}
 	);
 	const sanitizedHtml = DOMPurify.sanitize(content, {ADD_ATTR: ['target']});
 	// eslint-disable-next-line react/no-danger

--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -181,12 +181,7 @@ export function stringToHTMLWithLinks(content: string) {
 	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
 	content = content.replace(
 		urlRegex,
-		(url) => {
-			if (url.startsWith('www.')) {
-				url = 'https://' + url;
-			}
-			return `<a href="${url}" target="_blank">${url}</a>`;
-		}
+		(url) => `<a href="${url.startsWith('www.') ? 'https://' + url : url}" target="_blank">${url}</a>`
 	);
 	const sanitizedHtml = DOMPurify.sanitize(content, {ADD_ATTR: ['target']});
 	// eslint-disable-next-line react/no-danger


### PR DESCRIPTION
### Problem

[BB-741](https://tickets.metabrainz.org/browse/BB-741): Regular expression error in Safari

RegExp lookbehind expressions were unsupported by Safari until version 16.4 from March 2023.

### Solution

Add missing https:// prefixes to plain text URLs without using a lookbehind expression.
This should have been the only occurrence of such an expression in our codebase.

### Areas of Impact

All pages which display annotations or revision notes, but apparently it broke the whole site's client JS in Safari (which I couldn't verify without having an installation of Safari).