### PR TITLE
Fix URLs in placeholder text

### DIFF
--- a/src/client/components/pages/entities/identifiers.js
+++ b/src/client/components/pages/entities/identifiers.js
@@ -21,9 +21,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 
-function EntityIdentifiers({identifiers, identifierTypes}) {
-	const editLink = typeof window !== 'undefined' ? `${window.location.pathname}/edit` : '';
-
+function EntityIdentifiers({entityUrl, identifiers, identifierTypes}) {
 	return (
 		<div>
 			<h2>Identifiers</h2>
@@ -55,7 +53,10 @@ function EntityIdentifiers({identifiers, identifierTypes}) {
 						];
 					}) :
 					<p className="text-muted">
-						<b>No identifiers.</b> <a href={editLink}>Click here to edit</a> and add new identifiers (e.g. ISBN, Wikidata ID, etc.).
+						<b>No identifiers.</b>
+						<a href={`${entityUrl}/edit`}>
+							Click here to edit
+						</a> and add new identifiers (e.g. ISBN, Wikidata ID, etc.).
 					</p>
 			}
 		</div>
@@ -64,6 +65,7 @@ function EntityIdentifiers({identifiers, identifierTypes}) {
 
 EntityIdentifiers.displayName = 'EntityIdentifiers';
 EntityIdentifiers.propTypes = {
+	entityUrl: PropTypes.string.isRequired,
 	identifierTypes: PropTypes.array.isRequired,
 	identifiers: PropTypes.array
 };

--- a/src/client/components/pages/entities/links.js
+++ b/src/client/components/pages/entities/links.js
@@ -47,6 +47,7 @@ function EntityLinks({entity, identifierTypes, urlPrefix}) {
 			<Row>
 				<Col>
 					<EntityIdentifiers
+						entityUrl={urlPrefix}
 						identifierTypes={identifierTypes}
 						identifiers={entity.identifierSet && entity.identifierSet.identifiers}
 					/>

--- a/src/client/components/pages/entities/related-collections.js
+++ b/src/client/components/pages/entities/related-collections.js
@@ -41,7 +41,7 @@ function EntityRelatedCollections({collections}) {
 				) :
 					<p className="text-muted">
 						<b>This entity does not appear in any public collection.</b>
-						Click the <b>&quot;Add to collection&quot;</b>
+						<br/>Click the <b>&quot;Add to collection&quot;</b>
 						button below to add it to an existing collection or create a new one.
 					</p>
 				}

--- a/src/client/components/pages/entities/relationships.js
+++ b/src/client/components/pages/entities/relationships.js
@@ -21,9 +21,7 @@ import React from 'react';
 import Relationship from '../../../entity-editor/relationship-editor/relationship';
 
 
-function EntityRelationships({contextEntity, relationships}) {
-	const editLink = typeof window !== 'undefined' ? `${window.location.pathname}/edit` : '';
-
+function EntityRelationships({contextEntity, relationships, entityUrl}) {
 	return (
 		<div>
 			<h2>Relationships</h2>
@@ -45,7 +43,7 @@ function EntityRelationships({contextEntity, relationships}) {
 				</ul>
 			) : (
 				<p className="text-muted">
-					<b>No relationships.</b> <a href={editLink}>Click here to edit</a> and create new relationships.
+					<b>No relationships.</b> <a href={`${entityUrl}/edit`}>Click here to edit</a> and create new relationships.
 				</p>
 			)}
 		</div>
@@ -55,6 +53,7 @@ function EntityRelationships({contextEntity, relationships}) {
 EntityRelationships.displayName = 'EntityRelationships';
 EntityRelationships.propTypes = {
 	contextEntity: PropTypes.object.isRequired,
+	entityUrl: PropTypes.string.isRequired,
 	relationships: PropTypes.array.isRequired
 };
 


### PR DESCRIPTION
On the heels of #983 which I deployed to beta, I realized the link is not always created properly.
Rather than trying to investigate the core reason, we have the entity url available as a prop in the parent (and already available in EntityRelationships) so we might as well use it !