### PR TITLE
fix(core): handle undefined Accept-Language header

### DIFF
--- a/src/server/helpers/i18n.ts
+++ b/src/server/helpers/i18n.ts
@@ -51,6 +51,6 @@ export function parseAcceptLanguage(acceptLanguage: string): AcceptedLanguage[] 
  * @returns {string[]} Parsed language codes, sorted by weight in descending order.
  */
 export function getAcceptedLanguageCodes(request: Request): string[] {
-	return parseAcceptLanguage(request.headers['accept-language'])
+	return parseAcceptLanguage(request.headers['accept-language'] ?? '')
 		.map((language) => language.code);
 }


### PR DESCRIPTION
### Problem

The HTTP Accept-Language header can also be undefined which causes a type error.

### Solution

Treat this case the same way as an empty (`''`) or wildcard (`'*'`) header which both return an empty array of language codes.

### Areas of Impact

Server routes which are loading Wikipedia extracts.