### PR TITLE
fix(display): prevent two consecutive spaces in JSX

### DIFF
--- a/src/client/components/pages/entities/related-collections.js
+++ b/src/client/components/pages/entities/related-collections.js
@@ -41,8 +41,8 @@ function EntityRelatedCollections({collections}) {
 				) :
 					<p className="text-muted">
 						<b>This entity does not appear in any public collection.</b>
-						<br/>Click the <b>&quot;Add to collection&quot;</b>&nbsp;
-						button below to add it to an existing collection or create a new one.
+						<br/>
+						Click the <b>&quot;Add to collection&quot;</b> button below to add it to an existing collection or create a new one.
 					</p>
 				}
 			</Col>


### PR DESCRIPTION
3feb7142977b652015456838ae6d7178e7068330 inserted a non-breaking space at the end of the line which is not automatically stripped, but treated as text. Because the next line also starts with text, an additional space is inserted to separate "words" (which was unwanted in this case).