### PR TITLE
BB-749: Links that include "https://" as part of the non-protocol of the URL in Annotations break.

### DIFF
--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -178,7 +178,7 @@ export function dateObjectToISOString(value: DateObject) {
  */
 export function stringToHTMLWithLinks(content: string) {
 	// eslint-disable-next-line max-len, no-useless-escape
-	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
+	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\:\w]*))?)/g;
 	content = content.replace(
 		urlRegex,
 		(url) => `<a href="${url.startsWith('www.') ? 'https://' + url : url}" target="_blank">${url}</a>`


### PR DESCRIPTION
### Problem
BB-749: Links that include "https://" as part of the non-protocol of the URL in Annotations break.

### Solution
Modified `urlRegex` regular expression.

### Areas of Impact
The changes were reflected in `src/client/helpers/utils.tsx`
