### PR TITLE
fix: optional gender in registration form

### DIFF
--- a/src/client/components/forms/registration-details.js
+++ b/src/client/components/forms/registration-details.js
@@ -46,10 +46,10 @@ class RegistrationForm extends React.Component {
 	handleSubmit(event) {
 		event.preventDefault();
 
-		const gender = this.gender.select.getValue()[0].id;
+		const genderId = this.gender?.select?.getValue()?.[0]?.id;
 		const data = {
 			displayName: this.displayName.value,
-			gender: gender ? parseInt(gender, 10) : null
+			gender: genderId ? parseInt(genderId, 10) : null
 		};
 
 		this.setState({


### PR DESCRIPTION
As reported in https://community.metabrainz.org/t/cant-sign-up-with-bookbrainz/652424/3 , the registration form sohuld allow for the gender select to be optional. 
Currently, the code to access the value of the gender select input assumes one is selected, and throws an error in the console when that is not the case, preventing the registration from completing successfully, but also not giving any visual indication that something is wrong.