### PR TITLE
TypeScript migration of the ORM

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "array-move": "^3.0.1",
-    "bookbrainz-data": "4.1.1",
+    "bookbrainz-data": "^5.0.0",
     "chart.js": "^2.9.4",
     "chartjs-adapter-date-fns": "^1.0.0",
     "classnames": "^2.3.2",

--- a/src/client/components/input/drag-and-drop.tsx
+++ b/src/client/components/input/drag-and-drop.tsx
@@ -36,6 +36,7 @@ type Achievement = {
 	src: string;
 	id: string;
 };
+
 /**
  * Props for DragAndDropImage component
  * @typedef {Object} Props

--- a/src/client/components/pages/entities/wikipedia-extract.tsx
+++ b/src/client/components/pages/entities/wikipedia-extract.tsx
@@ -20,13 +20,13 @@ import {Col, Row} from 'react-bootstrap';
 import React, {useEffect, useState} from 'react';
 import {WikipediaArticleExtract, buildWikipediaUrl, getWikidataId} from '../../../../common/helpers/wikimedia';
 import DOMPurify from 'isomorphic-dompurify';
-import type {EntityT} from 'bookbrainz-data/lib/types/entity';
+import type {LazyLoadedEntityT} from 'bookbrainz-data/lib/types/entity';
 import {getAliasLanguageCodes} from '../../../../common/helpers/utils';
 import {uniq} from 'lodash';
 
 
 type Props = {
-	entity: EntityT,
+	entity: LazyLoadedEntityT,
 	articleExtract?: WikipediaArticleExtract,
 };
 

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -1,8 +1,8 @@
 import {EntityType, Relationship, RelationshipForDisplay} from '../../client/entity-editor/relationship-editor/types';
 
 import {isString, kebabCase, toString, upperFirst} from 'lodash';
-import type {EntityT} from 'bookbrainz-data/lib/types/entity';
 import {IdentifierType} from '../../client/unified-form/interface/type';
+import type {LazyLoadedEntityT} from 'bookbrainz-data/lib/types/entity';
 
 /**
  * Regular expression for valid BookBrainz UUIDs (bbid)
@@ -318,7 +318,7 @@ export async function getEntityAlias(orm, bbid:string, type:EntityType):Promise<
 	return entityData;
 }
 
-export function getAliasLanguageCodes(entity: EntityT) {
+export function getAliasLanguageCodes(entity: LazyLoadedEntityT) {
 	return entity.aliasSet?.aliases
 		.map((alias) => alias.language?.isoCode1)
 		// less common languages (and [Multiple languages]) do not have a two-letter ISO code, ignore them for now

--- a/src/common/helpers/wikimedia.ts
+++ b/src/common/helpers/wikimedia.ts
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import type {EntityT, EntityTypeString} from 'bookbrainz-data/lib/types/entity';
+import type {EntityTypeString, LazyLoadedEntityT} from 'bookbrainz-data/lib/types/entity';
 
 
 export type WikipediaArticle = {
@@ -56,7 +56,7 @@ const wikidataIdentifierTypeIds: Record<EntityTypeString, number> = {
 	Work: 21
 };
 
-export function getWikidataId(entity: EntityT) {
+export function getWikidataId(entity: LazyLoadedEntityT) {
 	const identifiers = entity.identifierSet?.identifiers;
 	const wikidataTypeId = wikidataIdentifierTypeIds[entity.type];
 	return identifiers?.find((identifier) => identifier.typeId === wikidataTypeId)?.value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,10 +1591,10 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@metabrainz/bookshelf@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@metabrainz/bookshelf/-/bookshelf-1.3.1.tgz#e8a1e607b1dc074ecfc43781aced87e9ea42e496"
-  integrity sha512-zlcMCXPrhddIfAyiD+XawtwRRn8cs3/f3ELYz3vTrRLm5dZKtWSpXPRn3uBgunejgV2Zc3/ljRkXQEW1EbpYXg==
+"@metabrainz/bookshelf@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@metabrainz/bookshelf/-/bookshelf-1.4.0.tgz#83b44ccebbf8421fdffa79ecbc103b4e43da3881"
+  integrity sha512-m1znuBtL4fX6tQctFFVvl6WYTg3gDUuwqM4B7d4VaKepI4/L1Qoar65VD2zto+oknPsFBmKrBLOJAD614nMF7Q==
   dependencies:
     bluebird "^3.7.2"
     create-error "~0.3.1"
@@ -2692,12 +2692,12 @@ body-parser@1.20.1:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-bookbrainz-data@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/bookbrainz-data/-/bookbrainz-data-4.1.1.tgz#911b55f9772f1dc0d813ba66477b544c47b08bcf"
-  integrity sha512-nCf6v9e62lqRqCZjjMWkdQO4VW8HbCgP1CzY8R6J3TSB0fgQb+fAMhu00I84H7qIsqc5Q1obspHrBxQ5Y78fXg==
+bookbrainz-data@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bookbrainz-data/-/bookbrainz-data-5.0.0.tgz#02ef3ef8483300fed33d1e3bc64b21466fdb62e5"
+  integrity sha512-CqpJHYrQGeQjxhjJBbzdSpl6FEvrINc05yAb23ClDsLEEgDvWMPoB85+FElCtR+KcvqA44oMmq95ez3nHVvX0g==
   dependencies:
-    "@metabrainz/bookshelf" "^1.3.1"
+    "@metabrainz/bookshelf" "^1.4.0"
     bookshelf-virtuals-plugin "^1.0.0"
     deep-diff "^1.0.2"
     immutable "^3.8.2"


### PR DESCRIPTION
In https://github.com/metabrainz/bookbrainz-data-js/pull/309 a few types have been renamed to be more consistent, this PR does the necessary changes for types which have already been used by the server.

~TODO: Bump version of bb-data once a new release of it is available on npm.~