### PR TITLE
Test dependencies: replace UUID package and duplicate faker package

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-react": "^7.26.1",
     "eslint-webpack-plugin": "^2.4.1",
-    "faker": "^4.1.0",
     "file-loader": "^6.2.0",
     "jsdom": "22.1.0",
     "jsdom-global": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "sass-loader": "^13.2.0",
     "sinon": "^14.0.0",
     "typescript": "^4.0.5",
-    "uuid": "^8.3.2",
     "webpack": "^5.76.0",
     "webpack-bundle-analyzer": "^4.3.0",
     "webpack-cli": "^4.10.0",

--- a/test/src/server/helpers/collections.js
+++ b/test/src/server/helpers/collections.js
@@ -25,7 +25,7 @@ import {
 } from '../../../../src/server/helpers/collections';
 import assertArrays from 'chai-arrays';
 import chai from 'chai';
-import {date} from 'faker';
+import {date} from '@faker-js/faker';
 import isSorted from 'chai-sorted';
 import orm from '../../../bookbrainz-data';
 

--- a/test/src/server/helpers/collections.js
+++ b/test/src/server/helpers/collections.js
@@ -25,7 +25,7 @@ import {
 } from '../../../../src/server/helpers/collections';
 import assertArrays from 'chai-arrays';
 import chai from 'chai';
-import {date} from '@faker-js/faker';
+import {faker} from '@faker-js/faker';
 import isSorted from 'chai-sorted';
 import orm from '../../../bookbrainz-data';
 
@@ -50,8 +50,8 @@ describe('getOrderedPublicCollections', () => {
 		};
 		// create 5 public author collections
 		for (let i = 1; i <= 5; i++) {
-			collectionAttrib.lastModified = date.recent();
-			collectionAttrib.createdAt = date.recent();
+			collectionAttrib.lastModified = faker.date.recent();
+			collectionAttrib.createdAt = faker.date.recent();
 			promiseArray.push(
 				new UserCollection(collectionAttrib).save(null, {method: 'insert'})
 			);

--- a/test/src/server/helpers/revisions.js
+++ b/test/src/server/helpers/revisions.js
@@ -19,10 +19,12 @@ import {
 } from '../../../../src/server/helpers/revisions';
 
 import chai from 'chai';
-import {date} from '@faker-js/faker';
+import {faker} from '@faker-js/faker';
 import isSorted from 'chai-sorted';
 import orm from '../../../bookbrainz-data';
 
+
+const {date} = faker;
 
 const {expect} = chai;
 chai.use(isSorted);

--- a/test/src/server/helpers/revisions.js
+++ b/test/src/server/helpers/revisions.js
@@ -19,7 +19,7 @@ import {
 } from '../../../../src/server/helpers/revisions';
 
 import chai from 'chai';
-import {date} from 'faker';
+import {date} from '@faker-js/faker';
 import isSorted from 'chai-sorted';
 import orm from '../../../bookbrainz-data';
 

--- a/test/src/server/routes/collection.js
+++ b/test/src/server/routes/collection.js
@@ -1,12 +1,11 @@
 import {createAuthor, createEditor, truncateEntities} from '../../../test-helpers/create-entities';
 import {generateIndex, refreshIndex, searchByName} from '../../../../src/common/helpers/search';
-
 import app from '../../../../src/server/app';
 import assertArrays from 'chai-arrays';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
+import {faker} from '@faker-js/faker';
 import orm from '../../../bookbrainz-data';
-import {v4 as uuidv4} from 'uuid';
 
 
 chai.use(chaiHttp);
@@ -856,7 +855,7 @@ describe('POST /collection/:collectionID/add', () => {
 		};
 		const collection = await new UserCollection(collectionData).save(null, {method: 'insert'});
 		const data = {
-			bbids: [uuidv4()]
+			bbids: [faker.string.uuid()]
 		};
 		const response = await agent.post(`/collection/${collection.get('id')}/add`).send(data);
 		const item = await new UserCollectionItem().where('collection_id', collection.get('id')).fetchAll({});

--- a/test/test-helpers/create-entities.js
+++ b/test/test-helpers/create-entities.js
@@ -17,10 +17,12 @@
  */
 /* eslint-disable no-console */
 
-import {faker, internet, random} from '@faker-js/faker';
+import {faker} from '@faker-js/faker';
 import {isNil} from 'lodash';
 import orm from '../bookbrainz-data';
 
+
+const {internet, random, string} = faker;
 
 const {
 	bookshelf, util, Editor, EditorType, Revision, Relationship, RelationshipAttribute,
@@ -134,7 +136,7 @@ const entityAttribs = {
 	aliasSetId: 1,
 	annotationId: 1,
 	// bbid should normally be overwritten when calling create{Entity}
-	bbid: faker.string.uuid(),
+	bbid: string.uuid(),
 	disambiguationId: 1,
 	identifierSetId: 1,
 	relationshipSetId: 1,
@@ -221,8 +223,8 @@ async function createRelationshipAttributeSet() {
 }
 
 async function createRelationshipSet(sourceBbid, targetBbid, targetEntityType = 'Author', attributeSetId) {
-	const safeTargetBbid = targetBbid || faker.string.uuid();
-	const safeSourceBbid = sourceBbid || faker.string.uuid();
+	const safeTargetBbid = targetBbid || string.uuid();
+	const safeSourceBbid = sourceBbid || string.uuid();
 
 	/* Create the relationship target entity */
 	await new Entity({bbid: safeTargetBbid, type: targetEntityType})
@@ -271,7 +273,7 @@ async function createLanguageSet() {
 }
 
 export function getRandomUUID() {
-	return faker.string.uuid();
+	return string.uuid();
 }
 
 async function createEntityPrerequisites(entityBbid, entityType) {
@@ -301,7 +303,7 @@ async function createEntityPrerequisites(entityBbid, entityType) {
 }
 
 export async function createEdition(optionalBBID, optionalEditionAttribs = {}) {
-	const bbid = optionalBBID || faker.string.uuid();
+	const bbid = optionalBBID || string.uuid();
 	await new Entity({bbid, type: 'Edition'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Edition');
@@ -312,7 +314,7 @@ export async function createEdition(optionalBBID, optionalEditionAttribs = {}) {
 }
 
 export async function createWork(optionalBBID, optionalWorkAttribs = {}) {
-	const bbid = optionalBBID || faker.string.uuid();
+	const bbid = optionalBBID || string.uuid();
 	await new Entity({bbid, type: 'Work'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Work');
@@ -350,7 +352,7 @@ export async function createWork(optionalBBID, optionalWorkAttribs = {}) {
 }
 
 export async function createEditionGroup(optionalBBID, optionalEditionGroupAttrib = {}) {
-	const bbid = optionalBBID || faker.string.uuid();
+	const bbid = optionalBBID || string.uuid();
 	await new Entity({bbid, type: 'EditionGroup'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'EditionGroup');
@@ -374,12 +376,12 @@ export async function createEditionGroup(optionalBBID, optionalEditionGroupAttri
 }
 
 export async function createAuthor(optionalBBID, optionalAuthorAttribs = {}) {
-	const bbid = optionalBBID || faker.string.uuid();
+	const bbid = optionalBBID || string.uuid();
 	await new Entity({bbid, type: 'Author'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Author');
 
-	const area = await new Area({gid: faker.string.uuid(), name: 'Rlyeh'})
+	const area = await new Area({gid: string.uuid(), name: 'Rlyeh'})
 		.save(null, {method: 'insert'});
 
 	// Front-end requires 'Person' and 'Group' types
@@ -419,7 +421,7 @@ export async function createAuthor(optionalBBID, optionalAuthorAttribs = {}) {
 }
 
 export async function createSeries(optionalBBID, optionalSeriesAttribs = {}) {
-	const bbid = optionalBBID || faker.string.uuid();
+	const bbid = optionalBBID || string.uuid();
 	await new Entity({bbid, type: 'Series'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Work');
@@ -459,7 +461,7 @@ async function fetchOrCreatePublisherType(PublisherTypeModel, optionalPublisherA
 }
 
 export async function createPublisher(optionalBBID, optionalPublisherAttribs = {}, optionalPublisherTypeAttribs = {}) {
-	const bbid = optionalBBID || faker.string.uuid();
+	const bbid = optionalBBID || string.uuid();
 	await new Entity({bbid, type: 'Publisher'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Publisher');
@@ -472,7 +474,7 @@ export async function createPublisher(optionalBBID, optionalPublisherAttribs = {
 			.fetch({require: false});
 	}
 	if (!area) {
-		area = await new Area({gid: faker.string.uuid(), name: `Area ${optionalPublisherAttribs.areaId || random.number()}`, ...optionalAreaAttribs})
+		area = await new Area({gid: string.uuid(), name: `Area ${optionalPublisherAttribs.areaId || random.number()}`, ...optionalAreaAttribs})
 			.save(null, {method: 'insert'});
 	}
 

--- a/test/test-helpers/create-entities.js
+++ b/test/test-helpers/create-entities.js
@@ -17,12 +17,9 @@
  */
 /* eslint-disable no-console */
 
-import {internet, random} from 'faker';
-
-import {faker} from '@faker-js/faker';
+import {faker, internet, random} from '@faker-js/faker';
 import {isNil} from 'lodash';
 import orm from '../bookbrainz-data';
-import {v4 as uuidv4} from 'uuid';
 
 
 const {
@@ -137,7 +134,7 @@ const entityAttribs = {
 	aliasSetId: 1,
 	annotationId: 1,
 	// bbid should normally be overwritten when calling create{Entity}
-	bbid: uuidv4(),
+	bbid: faker.string.uuid(),
 	disambiguationId: 1,
 	identifierSetId: 1,
 	relationshipSetId: 1,
@@ -224,8 +221,8 @@ async function createRelationshipAttributeSet() {
 }
 
 async function createRelationshipSet(sourceBbid, targetBbid, targetEntityType = 'Author', attributeSetId) {
-	const safeTargetBbid = targetBbid || uuidv4();
-	const safeSourceBbid = sourceBbid || uuidv4();
+	const safeTargetBbid = targetBbid || faker.string.uuid();
+	const safeSourceBbid = sourceBbid || faker.string.uuid();
 
 	/* Create the relationship target entity */
 	await new Entity({bbid: safeTargetBbid, type: targetEntityType})
@@ -274,7 +271,7 @@ async function createLanguageSet() {
 }
 
 export function getRandomUUID() {
-	return uuidv4();
+	return faker.string.uuid();
 }
 
 async function createEntityPrerequisites(entityBbid, entityType) {
@@ -304,7 +301,7 @@ async function createEntityPrerequisites(entityBbid, entityType) {
 }
 
 export async function createEdition(optionalBBID, optionalEditionAttribs = {}) {
-	const bbid = optionalBBID || uuidv4();
+	const bbid = optionalBBID || faker.string.uuid();
 	await new Entity({bbid, type: 'Edition'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Edition');
@@ -315,7 +312,7 @@ export async function createEdition(optionalBBID, optionalEditionAttribs = {}) {
 }
 
 export async function createWork(optionalBBID, optionalWorkAttribs = {}) {
-	const bbid = optionalBBID || uuidv4();
+	const bbid = optionalBBID || faker.string.uuid();
 	await new Entity({bbid, type: 'Work'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Work');
@@ -353,7 +350,7 @@ export async function createWork(optionalBBID, optionalWorkAttribs = {}) {
 }
 
 export async function createEditionGroup(optionalBBID, optionalEditionGroupAttrib = {}) {
-	const bbid = optionalBBID || uuidv4();
+	const bbid = optionalBBID || faker.string.uuid();
 	await new Entity({bbid, type: 'EditionGroup'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'EditionGroup');
@@ -377,12 +374,12 @@ export async function createEditionGroup(optionalBBID, optionalEditionGroupAttri
 }
 
 export async function createAuthor(optionalBBID, optionalAuthorAttribs = {}) {
-	const bbid = optionalBBID || uuidv4();
+	const bbid = optionalBBID || faker.string.uuid();
 	await new Entity({bbid, type: 'Author'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Author');
 
-	const area = await new Area({gid: uuidv4(), name: 'Rlyeh'})
+	const area = await new Area({gid: faker.string.uuid(), name: 'Rlyeh'})
 		.save(null, {method: 'insert'});
 
 	// Front-end requires 'Person' and 'Group' types
@@ -422,7 +419,7 @@ export async function createAuthor(optionalBBID, optionalAuthorAttribs = {}) {
 }
 
 export async function createSeries(optionalBBID, optionalSeriesAttribs = {}) {
-	const bbid = optionalBBID || uuidv4();
+	const bbid = optionalBBID || faker.string.uuid();
 	await new Entity({bbid, type: 'Series'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Work');
@@ -462,7 +459,7 @@ async function fetchOrCreatePublisherType(PublisherTypeModel, optionalPublisherA
 }
 
 export async function createPublisher(optionalBBID, optionalPublisherAttribs = {}, optionalPublisherTypeAttribs = {}) {
-	const bbid = optionalBBID || uuidv4();
+	const bbid = optionalBBID || faker.string.uuid();
 	await new Entity({bbid, type: 'Publisher'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Publisher');
@@ -475,7 +472,7 @@ export async function createPublisher(optionalBBID, optionalPublisherAttribs = {
 			.fetch({require: false});
 	}
 	if (!area) {
-		area = await new Area({gid: uuidv4(), name: `Area ${optionalPublisherAttribs.areaId || random.number()}`, ...optionalAreaAttribs})
+		area = await new Area({gid: faker.string.uuid(), name: `Area ${optionalPublisherAttribs.areaId || random.number()}`, ...optionalAreaAttribs})
 			.save(null, {method: 'insert'});
 	}
 

--- a/test/test-helpers/create-entities.js
+++ b/test/test-helpers/create-entities.js
@@ -150,12 +150,12 @@ export function createEditor(editorId, privs = 1) {
 		const gender = await new Gender({name: 'test'})
 			.save(null, {method: 'insert', transacting});
 
-		editorAttribs.id = editorId || random.number();
+		editorAttribs.id = editorId || random.numeric(5);
 		editorAttribs.genderId = gender.id;
 		editorAttribs.typeId = editorType.id;
 		editorAttribs.name = internet.userName();
 		editorAttribs.privs = privs;
-		editorAttribs.metabrainzUserId = random.number();
+		editorAttribs.metabrainzUserId = random.numeric(5);
 		editorAttribs.cachedMetabrainzName = editorAttribs.name;
 
 		const editor = await new Editor(editorAttribs)
@@ -335,7 +335,7 @@ export async function createWork(optionalBBID, optionalWorkAttribs = {}) {
 
 	if (!workType) {
 		workType = await new WorkType({description: 'A work type',
-			label: `Work Type ${optionalWorkAttribs.typeId || random.number()}`,
+			label: `Work Type ${optionalWorkAttribs.typeId || random.numeric(5)}`,
 			...optionalWorkTypeAttribs})
 			.save(null, {method: 'insert'});
 	}
@@ -361,7 +361,7 @@ export async function createEditionGroup(optionalBBID, optionalEditionGroupAttri
 		optionalEditionGroupTypeAttrib.id = optionalEditionGroupAttrib.typeId;
 	}
 	const editionGroupType = await new EditionGroupType(
-		{label: `Edition Group Type ${optionalEditionGroupAttrib.typeId || random.number()}`, ...optionalEditionGroupTypeAttrib}
+		{label: `Edition Group Type ${optionalEditionGroupAttrib.typeId || random.numeric(5)}`, ...optionalEditionGroupTypeAttrib}
 	)
 		.save(null, {method: 'insert'});
 
@@ -474,7 +474,7 @@ export async function createPublisher(optionalBBID, optionalPublisherAttribs = {
 			.fetch({require: false});
 	}
 	if (!area) {
-		area = await new Area({gid: string.uuid(), name: `Area ${optionalPublisherAttribs.areaId || random.number()}`, ...optionalAreaAttribs})
+		area = await new Area({gid: string.uuid(), name: `Area ${optionalPublisherAttribs.areaId || random.numeric(5)}`, ...optionalAreaAttribs})
 			.save(null, {method: 'insert'});
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,11 +4366,6 @@ extend@^3.0.0:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-faker@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
-  integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8517,11 +8517,6 @@ uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
1. Remove the UUID package in favor of the built in functionality in the faker package
2. Remove duplicate faker package: we were using `faker` v4 as well as the more recent `@fake-js/faker` side by side for some reason.