### PR TITLE
docs(static): fix mischaracterization of a book mentioned in an example

### DIFF
--- a/src/client/components/pages/help.js
+++ b/src/client/components/pages/help.js
@@ -128,7 +128,7 @@ function HelpPage() {
 							Example:
 							<ul>
 								<li>The Alchemist (philosophical novel) by Paulo Coelho</li>
-								<li>The Alchemyst (Nicolas Flamel biography) by Michael Scott</li>
+								<li>The Alchemyst (YA novel featuring Nicolas Flamel) by Michael Scott</li>
 							</ul>
 						</ListGroup.Item>
 


### PR DESCRIPTION
Michael Scott’s *The Secrets of the Immortal Nicholas Flamel – The Alchemyst* is a fictional novel, not a biography.

```diff
-The Alchemyst (Nicolas Flamel biography) by Michael Scott
+The Alchemyst (YA novel featuring Nicolas Flamel) by Michael Scott
```