### PR TITLE
BB-718 CritiqueBrainz auth endpoint is called server-side

### DIFF
--- a/src/client/components/pages/entities/cbReviewModal.tsx
+++ b/src/client/components/pages/entities/cbReviewModal.tsx
@@ -501,6 +501,7 @@ class CBReviewModal extends React.Component<
 
 	private accessToken = '';
 
+	/* executes getAccessToken() only in a browser to avoid unnecessary server-side calls during component mounting */
 	componentDidMount = async () => {
 		if (typeof window !== "undefined") {
 			this.accessToken = await this.getAccessToken();

--- a/src/client/components/pages/entities/cbReviewModal.tsx
+++ b/src/client/components/pages/entities/cbReviewModal.tsx
@@ -502,7 +502,9 @@ class CBReviewModal extends React.Component<
 	private accessToken = '';
 
 	componentDidMount = async () => {
-		this.accessToken = await this.getAccessToken();
+		if (typeof window !== "undefined") {
+			this.accessToken = await this.getAccessToken();
+		}
 	};
 
 	render() {


### PR DESCRIPTION
### Problem
[BB-718: CritiqueBrainz auth endpoint is called server-side](https://tickets.metabrainz.org/browse/BB-718?filter=11910)


### Solution
The conditional check - ```typeof window !== "undefined"``` ensures that the ```getAccessToken``` method is only called when the code is executed in a browser environment (client-side), preventing the unnecessary call to the authentication endpoint on the server-side.


### Areas of Impact
The changes were reflected in ```src/client/components/pages/entities/cbReviewModal.tsx```
