### PR TITLE
fix BB-758 : Link from edit page to entity page

### DIFF
--- a/src/client/entity-editor/entity-editor.tsx
+++ b/src/client/entity-editor/entity-editor.tsx
@@ -73,6 +73,7 @@ const EntityEditor = (props: Props) => {
 		entity
 	} = props;
 	const currentState = (useSelector((state) => state) as any).toJS();
+	let entityURL;
 	// eslint-disable-next-line consistent-return
 	const handleUrlChange = React.useCallback(() => {
 		if (!_.isEqual(currentState, props.intitialState) && !currentState.submissionSection.submitted) {
@@ -82,8 +83,11 @@ const EntityEditor = (props: Props) => {
 	React.useEffect(() => {
 		window.onbeforeunload = handleUrlChange;
 	}, [handleUrlChange]);
-	const entityURL = getEntityUrl(entity);
 
+	if(entity){
+	entityURL = getEntityUrl(entity);
+	}
+	
 	return (
 		<form onSubmit={onSubmit}>
 			<Card>

--- a/src/client/entity-editor/entity-editor.tsx
+++ b/src/client/entity-editor/entity-editor.tsx
@@ -27,6 +27,7 @@ import NameSection from './name-section/name-section';
 import RelationshipSection from './relationship-editor/relationship-section';
 import SubmissionSection from './submission-section/submission-section';
 import _ from 'lodash';
+import {getEntityUrl} from '../helpers/entity';
 import {submit} from './submission-section/actions';
 
 
@@ -34,6 +35,7 @@ type OwnProps = {
 	children: React.ReactElement<any>,
 	heading: string,
 	intitialState:Record<string, any>,
+	entity: any
 };
 
 type StateProps = {
@@ -67,7 +69,8 @@ const EntityEditor = (props: Props) => {
 		children,
 		heading,
 		identifierEditorVisible,
-		onSubmit
+		onSubmit,
+		entity
 	} = props;
 	const currentState = (useSelector((state) => state) as any).toJS();
 	// eslint-disable-next-line consistent-return
@@ -79,12 +82,15 @@ const EntityEditor = (props: Props) => {
 	React.useEffect(() => {
 		window.onbeforeunload = handleUrlChange;
 	}, [handleUrlChange]);
+	const entityURL = getEntityUrl(entity);
 
 	return (
 		<form onSubmit={onSubmit}>
 			<Card>
 				<Card.Header as="h4">
-					{heading}
+					<div>
+					 <a href={entityURL}>{heading}</a>
+					</div>
 				</Card.Header>
 				<Card.Body>
 					<AliasEditor show={aliasEditorVisible} {...props}/>

--- a/src/client/entity-editor/entity-editor.tsx
+++ b/src/client/entity-editor/entity-editor.tsx
@@ -93,7 +93,7 @@ const EntityEditor = (props: Props) => {
 			<Card>
 				<Card.Header as="h4">
 					<div>
-					 <a href={entityURL}>{heading}</a>
+					 {entityURL ? <a href={entityURL}>{heading}</a> : heading}
 					</div>
 				</Card.Header>
 				<Card.Body>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one --> BB-758


### Solution
<!-- What does this PR do to fix the problem? -->
Using anchor tag I added a link inside the heading of entity in editor page , see the screenshot . A direct link to entity page from entity editor page makes it very  convenient while comparing the fields being edited with the original ones 

![ent](https://github.com/metabrainz/bookbrainz-site/assets/97682967/1de5e84c-f0a5-4e13-8ea8-ff8c8618d0e0)


https://github.com/metabrainz/bookbrainz-site/assets/97682967/e4d297f3-7e27-40a2-9c79-66d57584226f



### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
This PR effect the entity-editor page section of the codebase
