### PR TITLE
fix(revision): Links with symbols like % - # now work 

### DIFF
--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -180,7 +180,7 @@ export function dateObjectToISOString(value: DateObject) {
  */
 export function stringToHTMLWithLinks(content: string) {
 	// eslint-disable-next-line max-len, no-useless-escape
-	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\:\w]*))?)/g;
+	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\:\w]*)%?(?:[\/\-\+=&;%~*@\.\w_]*)#?(?:[\/\-\+=&;%~*@\.\w_]*))?)/g;
 	const replacedContent = content.replace(
 		urlRegex,
 		(url) => `<a href="${url.startsWith('www.') ? `https://${url}` : url}" target="_blank">${url}</a>`


### PR DESCRIPTION
I updated the stringToHTMLWithLinks function such that the regular expression
in it now supports links with special characters such as "%", "-", "#".
These links are correctly now displayed as hyperlinks in revision page.

<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->BB-778


### Solution
<!-- What does this PR do to fix the problem? -->
I updated the stringToHTMLWithLinks function such that the regular expression in it now supports links with special characters such as "%", "-", "#".


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
These links are correctly now displayed as hyperlinks in revision page.

