### PR TITLE
collection modal: Set fixed position of privacy select

### DIFF
--- a/src/client/components/pages/parts/add-to-collection-modal.js
+++ b/src/client/components/pages/parts/add-to-collection-modal.js
@@ -262,8 +262,8 @@ class AddToCollectionModal extends React.Component {
 								classNamePrefix="react-select"
 								getOptionLabel={this.getOptionLabel}
 								getOptionValue={this.getOptionValue}
-								options={privacyOptions}
 								menuPosition="fixed"
+								options={privacyOptions}
 								placeholder="Select Privacy"
 								ref={(ref) => this.privacy = ref}
 							/>

--- a/src/client/components/pages/parts/add-to-collection-modal.js
+++ b/src/client/components/pages/parts/add-to-collection-modal.js
@@ -263,9 +263,9 @@ class AddToCollectionModal extends React.Component {
 								getOptionLabel={this.getOptionLabel}
 								getOptionValue={this.getOptionValue}
 								options={privacyOptions}
+								menuPosition="fixed"
 								placeholder="Select Privacy"
 								ref={(ref) => this.privacy = ref}
-
 							/>
 						</Form.Group>
 					</form>


### PR DESCRIPTION
Reported in https://community.metabrainz.org/t/creating-a-new-collection-doesnt-work/680552

The privacy options select component is being shown inside the modal body but after the scroll break, meaning by default without knowing to scroll down users won't see the options and it will look broken. Setting the menuPosition prop to "fixed" means the options component is shown over the rest of the content, which is much better.

Before:
<img width="577" alt="image" src="https://github.com/metabrainz/bookbrainz-site/assets/6179856/3d134113-8bcf-4e0c-b190-8eb187d3c335">

After:
<img width="557" alt="image" src="https://github.com/metabrainz/bookbrainz-site/assets/6179856/56109d12-fec2-4508-949a-974bb524a540">
