### PR TITLE
feat: Improve search indexing reliability

### DIFF
--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -29,6 +29,12 @@ import {genEntityIconHTMLElement} from '../../../helpers/entity';
 
 const {Alert, Badge, Button, ButtonGroup, Table} = bootstrap;
 
+// Main entities have a BBID but some other indexed types
+// have an ID field instead (collections, editors, areas)
+function getId(entity) {
+	return entity.bbid ?? entity.id;
+}
+
 /**
  * Renders the document and displays the 'SearchResults' page.
  * @returns {ReactElement} a HTML document which displays the SearchResults.
@@ -89,8 +95,8 @@ class SearchResults extends React.Component {
 		// eslint-disable-next-line react/no-access-state-in-setstate
 		const oldSelected = this.state.selected;
 		let newSelected;
-		if (oldSelected.find(selected => selected.bbid === entity.bbid)) {
-			newSelected = oldSelected.filter(selected => selected.bbid !== entity.bbid);
+		if (oldSelected.find(selected => getId(selected) === getId(entity))) {
+			newSelected = oldSelected.filter(selected => getId(selected) !== getId(entity));
 		}
 		else {
 			newSelected = [...oldSelected, entity];
@@ -148,6 +154,7 @@ class SearchResults extends React.Component {
 			if (!result) {
 				return null;
 			}
+			const id = getId(result);
 			const name = result.defaultAlias ? result.defaultAlias.name :
 				'(unnamed)';
 
@@ -160,19 +167,19 @@ class SearchResults extends React.Component {
 			const disambiguation = result.disambiguation ? <small>({result.disambiguation.comment})</small> : '';
 			// No redirect link for Area entity results
 			const link = result.type === 'Area' ?
-				`//musicbrainz.org/area/${result.bbid}` :
-				`/${_kebabCase(result.type)}/${result.bbid}`;
+				`//musicbrainz.org/area/${id}` :
+				`/${_kebabCase(result.type)}/${id}`;
 
 			/* eslint-disable react/jsx-no-bind */
 			return (
-				<tr key={result.bbid}>
+				<tr key={id}>
 					{
 						!this.props.condensed &&
 						<td>
 							{
 								this.props.user ?
 									<input
-										checked={this.state.selected.find(selected => selected.bbid === result.bbid)}
+										checked={this.state.selected.find(selected => getId(selected) === id)}
 										className="checkboxes"
 										type="checkbox"
 										onChange={() => this.toggleRow(result)}
@@ -212,7 +219,7 @@ class SearchResults extends React.Component {
 					this.props.user ?
 						<div>
 							<AddToCollectionModal
-								bbids={this.state.selected.map(selected => selected.bbid)}
+								bbids={this.state.selected.map(getId)}
 								closeModalAndShowMessage={this.closeModalAndShowMessage}
 								entityType={this.state.selected[0]?.type}
 								handleCloseModal={this.onCloseModal}

--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -64,6 +64,7 @@ async function _fetchEntityModelsForESResults(orm, results) {
 				.fetch({withRelated: ['areaType']});
 
 			const areaJSON = area.toJSON();
+			const areaJSON = area.toJSON({omitPivot: true});
 			const areaParents = await area.parents();
 			areaJSON.defaultAlias = {
 				name: areaJSON.name
@@ -78,7 +79,7 @@ async function _fetchEntityModelsForESResults(orm, results) {
 			const editor = await Editor.forge({id: entityStub.bbid})
 				.fetch();
 
-			const editorJSON = editor.toJSON();
+			const editorJSON = editor.toJSON({omitPivot: true});
 			editorJSON.defaultAlias = {
 				name: editorJSON.name
 			};
@@ -90,7 +91,7 @@ async function _fetchEntityModelsForESResults(orm, results) {
 			const collection = await UserCollection.forge({id: entityStub.bbid})
 				.fetch();
 
-			const collectionJSON = collection.toJSON();
+			const collectionJSON = collection.toJSON({omitPivot: true});
 			collectionJSON.defaultAlias = {
 				name: collectionJSON.name
 			};
@@ -103,7 +104,7 @@ async function _fetchEntityModelsForESResults(orm, results) {
 		const entity = await model.forge({bbid: entityStub.bbid})
 			.fetch({require: false, withRelated: ['defaultAlias.language', 'disambiguation', 'aliasSet.aliases', 'identifierSet.identifiers',
 				'relationshipSet.relationships.source', 'relationshipSet.relationships.target', 'relationshipSet.relationships.type', 'annotation']});
-		const entityJSON = entity?.toJSON();
+		const entityJSON = entity?.toJSON({omitPivot: true});
 		if (entityJSON && entityJSON.relationshipSet) {
 			entityJSON.relationshipSet.relationships = await Promise.all(entityJSON.relationshipSet.relationships.map(async (rel) => {
 				rel.source = await commonUtils.getEntity(orm, rel.source.bbid, rel.source.type);
@@ -384,7 +385,7 @@ export async function generateIndex(orm) {
 		{model: EditionGroup, relations: []},
 		{model: Publisher, relations: ['area']},
 		{model: Series, relations: ['seriesOrderingType']},
-		{model: Work, relations: ['workType', 'relationshipSet.relationships.type']}
+		{model: Work, relations: ['relationshipSet.relationships.type']}
 	];
 
 	// Update the indexed entries for each entity type
@@ -427,7 +428,7 @@ export async function generateIndex(orm) {
 	});
 	// Index all the entities
 	for (const entityList of entityLists) {
-		const listArray = entityList.toJSON();
+		const listArray = entityList.toJSON({omitPivot: true});
 		listIndexes.push(_processEntityListForBulk(listArray));
 	}
 	await Promise.all(listIndexes);
@@ -435,7 +436,7 @@ export async function generateIndex(orm) {
 	const areaCollection = await Area.forge()
 		.fetchAll();
 
-	const areas = areaCollection.toJSON();
+	const areas = areaCollection.toJSON({omitPivot: true});
 
 	/** To index names, we use aliasSet.aliases.name and bbid, which Areas don't have.
 	 * We massage the area to return a similar format as BB entities
@@ -455,7 +456,7 @@ export async function generateIndex(orm) {
 		// no bots
 		.where('type_id', 1)
 		.fetchAll();
-	const editors = editorCollection.toJSON();
+	const editors = editorCollection.toJSON({omitPivot: true});
 
 	/** To index names, we use aliasSet.aliases.name and bbid, which Editors don't have.
 	 * We massage the editor to return a similar format as BB entities
@@ -473,7 +474,7 @@ export async function generateIndex(orm) {
 
 	const userCollections = await UserCollection.forge().where({public: true})
 		.fetchAll();
-	const userCollectionsJSON = userCollections.toJSON();
+	const userCollectionsJSON = userCollections.toJSON({omitPivot: true});
 
 	/** To index names, we use aliasSet.aliases.name and bbid, which UserCollections don't have.
 	 * We massage the editor to return a similar format as BB entities

--- a/src/common/helpers/search.ts
+++ b/src/common/helpers/search.ts
@@ -392,6 +392,7 @@ export async function generateIndex(orm) {
 
 	const baseRelations = [
 		'annotation',
+		'defaultAlias',
 		'aliasSet.aliases',
 		'identifierSet.identifiers'
 	];

--- a/src/common/helpers/search.ts
+++ b/src/common/helpers/search.ts
@@ -373,7 +373,6 @@ export async function generateIndex(orm) {
 						type: 'ngram'
 					}
 				}
-			}
 			},
 			'index.mapping.ignore_malformed': true
 		}
@@ -473,8 +472,6 @@ export async function generateIndex(orm) {
 
 	const areas = areaCollection.toJSON({omitPivot: true});
 
-	/** To index names, we use aliasSet.aliases.name and bbid, which Areas don't have.
-	 * We massage the area to return a similar format as BB entities
 	/** To index names, we use aliases.name and bbid, which Areas don't have.
    * We massage the area to return a similar format as BB entities
    */

--- a/src/common/helpers/search.ts
+++ b/src/common/helpers/search.ts
@@ -17,7 +17,7 @@
  */
 /* eslint-disable camelcase */
 
-import * as commonUtils from '../../common/helpers/utils';
+import * as commonUtils from './utils';
 import {camelCase, isString, snakeCase, upperFirst} from 'lodash';
 
 import ElasticSearch from '@elastic/elasticsearch';
@@ -495,7 +495,7 @@ export async function generateIndex(orm) {
 
 export async function checkIfExists(orm, name, type) {
 	const {bookshelf} = orm;
-	const bbids = await new Promise((resolve, reject) => {
+	const bbids:string[] = await new Promise((resolve, reject) => {
 		bookshelf.transaction(async (transacting) => {
 			try {
 				const result = await orm.func.alias.getBBIDsWithMatchingAlias(

--- a/src/server/helpers/collectionRouteUtils.js
+++ b/src/server/helpers/collectionRouteUtils.js
@@ -16,11 +16,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as handler from '../helpers/handler';
 import * as search from '../../common/helpers/search';
 import {camelCase, differenceWith, isEqual, toLower, upperFirst} from 'lodash';
 import {BadRequestError} from '../../common/helpers/error';
-
+import log from 'log';
 
 /**
  * A handler for create or edit actions on collections.
@@ -89,22 +88,9 @@ export async function collectionCreateOrEditHandler(req, res, next) {
 		// if it's new or the name is changed,
 		// we need to update this collection in ElasticSearch index
 		if (isNew || res.locals.collection.name !== newCollection.get('name')) {
-			const collectionPromiseForES = new Promise((resolve) => {
-				const collectionForES = {
-					aliasSet: {
-						aliases: [
-							{name: newCollection.get('name')}
-						]
-					},
-					bbid: newCollection.get('id'),
-					id: newCollection.get('id'),
-					type: 'Collection'
-				};
-				resolve(collectionForES);
-			});
-			return handler.sendPromiseResult(res, collectionPromiseForES, search.indexEntity);
+			await search.indexEntity(newCollection);
 		}
-		return res.send(newCollection.toJSON());
+		return res.status(200).send(newCollection.toJSON());
 	}
 	catch (err) {
 		return next(err);

--- a/src/server/helpers/collectionRouteUtils.js
+++ b/src/server/helpers/collectionRouteUtils.js
@@ -88,6 +88,8 @@ export async function collectionCreateOrEditHandler(req, res, next) {
 		// if it's new or the name is changed,
 		// we need to update this collection in ElasticSearch index
 		if (isNew || res.locals.collection.name !== newCollection.get('name')) {
+			// Type needed for indexing
+			newCollection.set('type', 'Collection');
 			await search.indexEntity(newCollection);
 		}
 		return res.status(200).send(newCollection.toJSON());

--- a/src/server/routes/editor.tsx
+++ b/src/server/routes/editor.tsx
@@ -20,7 +20,6 @@
 import * as auth from '../helpers/auth';
 import * as commonUtils from '../../common/helpers/utils';
 import * as error from '../../common/helpers/error';
-import * as handler from '../helpers/handler';
 import * as propHelpers from '../../client/helpers/props';
 import * as search from '../../common/helpers/search';
 import {AdminActionType, PrivilegeType} from '../../common/helpers/privileges-utils';
@@ -42,6 +41,7 @@ import _ from 'lodash';
 import express from 'express';
 import {getOrderedCollectionsForEditorPage} from '../helpers/collections';
 import {getOrderedRevisionForEditorPage} from '../helpers/revisions';
+import log from 'log';
 import target from '../templates/target';
 
 
@@ -122,8 +122,8 @@ function isCurrentUser(reqUserID, sessionUser) {
 	return reqUserID === sessionUser.id;
 }
 
-router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res) => {
-	async function runAsync() {
+router.post('/edit/handler', auth.isAuthenticatedForHandler, async (req, res) => {
+	try {
 		const {Editor} = req.app.locals.orm;
 
 		if (!isCurrentUser(req.body.id, req.user)) {
@@ -140,10 +140,10 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res) => {
 				throw new error.NotFoundError('Editor not found', req);
 			});
 		if (editor.get('areaId') === req.body.areaId &&
-			editor.get('bio') === req.body.bio &&
-			editor.get('name') === req.body.name &&
-			editor.get('titleUnlockId') === req.body.title &&
-			editor.get('genderId') === req.body.genderId
+				editor.get('bio') === req.body.bio &&
+				editor.get('name') === req.body.name &&
+				editor.get('titleUnlockId') === req.body.title &&
+				editor.get('genderId') === req.body.genderId
 		) {
 			throw new error.FormSubmissionError('No change to the profile');
 		}
@@ -164,19 +164,14 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res) => {
 			});
 
 		res.locals.user.name = req.body.name;
-		const editorJSON = modifiedEditor.toJSON();
-		return {
-			aliasSet: {
-				aliases: [
-					{name: editorJSON.name}
-				]
-			},
-			bbid: editorJSON.id,
-			type: 'Editor'
-		};
-	}
 
-	handler.sendPromiseResult(res, runAsync(), search.indexEntity);
+		await search.indexEntity(modifiedEditor);
+
+		return res.status(200).send(modifiedEditor.toJSON());
+	}
+	catch (err) {
+	 return error.sendErrorAsJSON(res, err);
+	}
 });
 
 router.post('/privs/edit/handler', auth.isAuthenticatedForHandler, auth.isAuthorized(ADMIN), async (req, res, next) => {

--- a/src/server/routes/editor.tsx
+++ b/src/server/routes/editor.tsx
@@ -165,9 +165,13 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, async (req, res) =>
 
 		res.locals.user.name = req.body.name;
 
+		const editorJSON = modifiedEditor.toJSON();
+
+		// Type needed for indexing
+		modifiedEditor.set('type', 'Editor');
 		await search.indexEntity(modifiedEditor);
 
-		return res.status(200).send(modifiedEditor.toJSON());
+		return res.status(200).send(editorJSON);
 	}
 	catch (err) {
 	 return error.sendErrorAsJSON(res, err);

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -478,7 +478,7 @@ export function handleDelete(
 				editorJSON.id,
 				body.note
 			);
-		return savedMainEntity.toJSON();
+		return savedMainEntity.toJSON({omitPivot: true});
 	});
 
 	return handler.sendPromiseResult(res, entityDeletePromise, search.deleteEntity);
@@ -1047,7 +1047,7 @@ export async function indexAutoCreatedEditionGroup(orm, newEdition, transacting)
 				transacting,
 				withRelated: 'aliasSet.aliases'
 			});
-		await search.indexEntity(editionGroup.toJSON());
+		await search.indexEntity(editionGroup.toJSON({omitPivot: true}));
 	}
 	catch (err) {
 		log.error('Could not reindex edition group after edition creation:', err);
@@ -1165,7 +1165,7 @@ export async function processSingleEntity(formBody, JSONEntity, reqSession,
 			await indexAutoCreatedEditionGroup(orm, savedMainEntity, transacting);
 		}
 
-		const entityJSON = savedMainEntity.toJSON();
+		const entityJSON = savedMainEntity.toJSON({omitPivot: true});
 		if (entityJSON && entityJSON.relationshipSet) {
 			entityJSON.relationshipSet.relationships = await Promise.all(entityJSON.relationshipSet.relationships.map(async (rel) => {
 				try {

--- a/src/server/routes/entity/process-unified-form.ts
+++ b/src/server/routes/entity/process-unified-form.ts
@@ -2,6 +2,7 @@
 import * as achievement from '../../helpers/achievement';
 import type {Request as $Request, Response as $Response} from 'express';
 import {FormSubmissionError, sendErrorAsJSON} from '../../../common/helpers/error';
+import {_bulkIndexEntities, getDocumentToIndex} from '../../../common/helpers/search';
 import {authorToFormState, transformNewForm as authorTransform} from './author';
 import {editionGroupToFormState, transformNewForm as editionGroupTransform} from './edition-group';
 import {editionToFormState, transformNewForm as editionTransform} from './edition';
@@ -13,7 +14,6 @@ import type {
 	EntityTypeString
 } from 'bookbrainz-data/lib/types/entity';
 import _ from 'lodash';
-import {_bulkIndexEntities} from '../../../common/helpers/search';
 import log from 'log';
 import {processSingleEntity} from './entity';
 
@@ -206,7 +206,7 @@ export async function handleCreateMultipleEntities(
 	}
 	// log indexing error if any
 	try {
-		_bulkIndexEntities(processedAchievements);
+		_bulkIndexEntities(processedEntities.map(en => getDocumentToIndex(en, en.get('type'))));
 	}
 	catch (err) {
 		log.error(err);

--- a/src/server/routes/register.js
+++ b/src/server/routes/register.js
@@ -123,8 +123,13 @@ router.post('/handler', async (req, res) => {
 
 		req.session.mbProfile = null;
 
+		const editorJSON = editor.toJSON();
+
+		// Type needed for indexing
+		editor.set('type', 'Editor');
 		await search.indexEntity(editor);
-		return res.status(200).send(editor.toJSON());
+
+		return res.status(200).send(editorJSON);
 	}
 	catch (err) {
 		if (_.isMatch(err, {constraint: 'editor_name_key'})) {

--- a/src/server/routes/register.js
+++ b/src/server/routes/register.js
@@ -93,65 +93,53 @@ router.get('/details', middleware.loadGenders, (req, res) => {
 	}));
 });
 
-router.post('/handler', (req, res) => {
-	const {Editor, EditorType} = req.app.locals.orm;
+router.post('/handler', async (req, res) => {
+	try {
+		const {Editor, EditorType} = req.app.locals.orm;
 
-	// Check whether the user is logged in - if so, redirect to profile page
-	if (req.user) {
-		return res.redirect(`/editor/${req.user.id}`);
-	}
+		// Check whether the user is logged in - if so, redirect to profile page
+		if (req.user) {
+			return res.redirect(`/editor/${req.user.id}`);
+		}
 
-	if (!req.session.mbProfile) {
-		return res.redirect('/auth');
-	}
+		if (!req.session.mbProfile) {
+			return res.redirect('/auth');
+		}
 
-	// Fetch the default EditorType from the database
-	const registerPromise = EditorType.forge({label: 'Editor'})
-		.fetch({require: true})
-		.then(
-			// Create a new Editor and add to the database
-			(editorType) =>
-				new Editor({
-					cachedMetabrainzName: req.session.mbProfile.sub,
-					genderId: req.body.gender,
-					metabrainzUserId: req.session.mbProfile.metabrainz_user_id,
-					name: req.body.displayName,
-					typeId: editorType.id
-				})
-					.save()
-		)
-		.then((editor) => {
-			req.session.mbProfile = null;
-			const editorJSON = editor.toJSON();
+		// Fetch the default EditorType from the database
+		const editorType = await EditorType.forge({label: 'Editor'})
+			.fetch({require: true});
 
-			// in ES index, we're storing the editor as entity
-			const editorForES = {};
-			editorForES.bbid = editorJSON.id;
-			editorForES.aliasSet = {
-				aliases: [
-					{name: editorJSON.name}
-				]
-			};
-			editorForES.type = 'Editor';
-			return editorForES;
+		// Create a new Editor and add to the database
+
+		const editor = await new Editor({
+			cachedMetabrainzName: req.session.mbProfile.sub,
+			genderId: req.body.gender,
+			metabrainzUserId: req.session.mbProfile.metabrainz_user_id,
+			name: req.body.displayName,
+			typeId: editorType.id
 		})
-		.catch((err) => {
-			log.debug(err);
+			.save();
 
-			if (_.isMatch(err, {constraint: 'editor_name_key'})) {
-				throw new error.FormSubmissionError(
-					'That username already exists - please try using another,' +
-					' or contact us to have your existing BookBrainz account' +
-					' linked to a MusicBrainz account.'
-				);
-			}
+		req.session.mbProfile = null;
 
-			throw new error.FormSubmissionError(
-				'Something went wrong when registering, please try again!'
-			);
-		});
+		await search.indexEntity(editor);
+		return res.status(200).send(editor.toJSON());
+	}
+	catch (err) {
+		if (_.isMatch(err, {constraint: 'editor_name_key'})) {
+			return error.sendErrorAsJSON(res, new error.FormSubmissionError(
+				'That username already exists - please try using another,' +
+			' or contact us to have your existing BookBrainz account' +
+			' linked to a MusicBrainz account.'
+			));
+		}
+		log.error(err);
 
-	return handler.sendPromiseResult(res, registerPromise, search.indexEntity);
+		return error.sendErrorAsJSON(res, new error.FormSubmissionError(
+			'Something went wrong when registering, please try again!'
+		));
+	}
 });
 
 export default router;


### PR DESCRIPTION
This PR came about after #740 started causing the website to crash when editing/creating Work entities.

I took this opportunity to make the search indexing more reliable by improving error catching.

While rewriting some of that code, I realized we are indexing a loooot of fields that we have no reason to index.
First of all, some internal ORM fields that are output by default when serializing to JSON.
Then the entire entity info is stored inn ElasticSearch, while on the other hand we load entities afresh from the DB based on the search results hits, which means at the moment we do absolutely nothing with all this entity info other than take disk space, slow down indexing and transferring too much data.

So we are now "cleaning" the documents before indexing them, i.e. keeping only the fields we need.
In the future, we will want to store more information and return it directly instead of fetching from the DB for presentation, but that will require more rewriting.
If we are planning on moving to SOLR soon enough that seems like a possible waste of time. A good candidate for a part 2 in any case.

Also removed some manipulation we did to  shoehorn collection, editor and area ids into a "bbid" field.
Now supports "id" field as well.

Finally, since we are now passing ORM models over for indexing, some rewriting was necessary wherever we call the search indexing, and I took that opportunity to rewrite some messy chained promises to async/await syntax.