### PR TITLE
chore(deps): Override dependency for react-select-fast-filter-options

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
     "node": ">= 18"
   },
   "browserslist": "> 0.25%, not dead",
+  "overrides": {
+    "react-select-fast-filter-options":{
+      "react-select": "$react-select"
+    }
+  },
   "dependencies": {
     "@babel/runtime": "^7.17.7",
     "@cospired/i18n-iso-languages": "^4.0.0",


### PR DESCRIPTION
Hasn't been updated in years to [react-select-fast-filter-options](https://github.com/bvaughn/react-select-fast-filter-options), but it doesn't rely on any internals of react-select so we can override the peer dependency to use our current version of react-select define in our direct dependencies.

I should investigate whether newer version of react-select are faster with the search implementation for loooong lists of items (we originally did this for the list of languages which is quite long), if so we can dump the package entirely.