### PR TITLE
fix(BB-793): Improve the UX with the search field option entity

### DIFF
--- a/src/client/entity-editor/common/entity-search-field-option.js
+++ b/src/client/entity-editor/common/entity-search-field-option.js
@@ -130,7 +130,7 @@ class EntitySearchFieldOption extends React.Component {
 		if (!buttonAfter) {
 			return (
 				<>
-					{React.cloneElement(wrappedSelect, props)}
+					{React.cloneElement(wrappedSelect, wrappedSelect.props)}
 					{help && <Form.Text muted>{help}</Form.Text>}
 				</>
 			);
@@ -138,7 +138,7 @@ class EntitySearchFieldOption extends React.Component {
 
 		return (
 			<InputGroup>
-				{React.cloneElement(wrappedSelect, props)}
+				{React.cloneElement(wrappedSelect, wrappedSelect.props)}
 				{help && <Form.Text muted>{help}</Form.Text>}
 				<InputGroup.Append>{buttonAfter}</InputGroup.Append>
 			</InputGroup>
@@ -182,7 +182,7 @@ class EntitySearchFieldOption extends React.Component {
 					Option: LinkedEntitySelect,
 					SingleValue: EntitySelect,
 					...this.props.customComponents &&
-						this.props.customComponents
+					this.props.customComponents
 				}}
 				filterOptions={false}
 				getOptionLabel={this.getOptionLabel}


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->
Hi there,
While searching for issues to contribute to Bookbrainz I found `BB-793` for improving the UX of the add authors to collection form, I have found it a good start for a beginner such as me so I have started to work to know where is the problem and how to solve it.

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->
The first time, I was trying to improve the search field element in authors to collection form such as the `BB-793` issue, then I found that the search field element at more places such as add collaborators to the collection as you can see in the images below.
![Screenshot from 2024-03-09 23-53-43](https://github.com/metabrainz/bookbrainz-site/assets/76850143/617b7599-96f9-4bd2-a30a-81f142700648)
![Screenshot from 2024-03-10 03-29-25](https://github.com/metabrainz/bookbrainz-site/assets/76850143/5e30d394-418a-4550-b9a7-857b902e20c0)



### Solution
<!-- What does this PR do to fix the problem? -->
The first solution was to add a CSS class to handle the search field width to be suitable to screen width and provide a good UX, but I have found that this has happened but no effect we can notice. 
The class `Select` is responsible for handling the width of the element, but it didn't work because the cloned element took its props from the parent of the wrapper select element without taking the wrapper select props as expected.

![Screenshot from 2024-03-10 03-28-11](https://github.com/metabrainz/bookbrainz-site/assets/76850143/7e84647c-4d79-41fe-a137-d49672f53995)
![Screenshot from 2024-03-10 03-29-06](https://github.com/metabrainz/bookbrainz-site/assets/76850143/3a049df9-f62b-4116-a47a-f925b75f85d1)


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
The PR effect on the common element `EntitySearchFieldOption` which is a part of the entity editor.
