### PR TITLE
BB-764: Unified form ISBNs bug

### DIFF
--- a/src/client/unified-form/cover-tab/isbn-field.tsx
+++ b/src/client/unified-form/cover-tab/isbn-field.tsx
@@ -53,7 +53,7 @@ function mapStateToProps(rootState:State):ISBNStateProps {
 }
 
 function mapDispatchToProps(dispatch):ISBNDispatchProps {
-	let gett:dispatchResultProps|null;
+	let autoAddedISBN:dispatchResultProps|null;
 	function onChange(value:string, autoISBN = false) {
 		const isbn10rgx = new
 		RegExp('^(?:ISBN(?:-10)?:?●)?(?=[0-9X]{10}$|(?=(?:[0-9]+[-●]){3})[-●0-9X]{13}$)[0-9]{1,5}[-●]?[0-9]+[-●]?[0-9]+[-●]?[0-9X]$');
@@ -78,16 +78,16 @@ function mapDispatchToProps(dispatch):ISBNDispatchProps {
 		}
 		dispatch(updateISBNType(type));
 		if (autoISBN && otherISBN.type) {
-			 gett = dispatch(addOtherISBN(otherISBN.type, otherISBN.value));
+			 autoAddedISBN = dispatch(addOtherISBN(otherISBN.type, otherISBN.value));
 		}
 		dispatch(debouncedUpdateISBNValue(value));
 	}
 	return {
 		onAutoISBNChange: (checked:boolean) => {
 			dispatch(updateAutoISBN(checked));
-			if(gett){
-				dispatch(removeIdentifierRow(gett.payload.rowId));
-				gett=null;
+			if(autoAddedISBN){
+				dispatch(removeIdentifierRow(autoAddedISBN.payload.rowId));
+				autoAddedISBN=null;
 			}
 			return;
 		},

--- a/src/client/unified-form/cover-tab/isbn-field.tsx
+++ b/src/client/unified-form/cover-tab/isbn-field.tsx
@@ -1,10 +1,10 @@
 import {ISBNDispatchProps, ISBNProps, ISBNStateProps, RInputEvent, State, dispatchResultProps} from '../interface/type';
+import {addOtherISBN, removeIdentifierRow} from '../../entity-editor/identifier-editor/actions';
 import {debouncedUpdateISBNValue, updateAutoISBN, updateISBNType} from './action';
 import {isbn10To13, isbn13To10} from '../../../common/helpers/utils';
 import {FormCheck} from 'react-bootstrap';
 import NameField from '../../entity-editor/common/name-field';
 import React from 'react';
-import {addOtherISBN, removeIdentifierRow} from '../../entity-editor/identifier-editor/actions';
 import {connect} from 'react-redux';
 
 

--- a/src/client/unified-form/cover-tab/isbn-field.tsx
+++ b/src/client/unified-form/cover-tab/isbn-field.tsx
@@ -1,19 +1,20 @@
-import {ISBNDispatchProps, ISBNProps, ISBNStateProps, RInputEvent, State} from '../interface/type';
+import {ISBNDispatchProps, ISBNProps, ISBNStateProps, RInputEvent, State, dispatchResultProps} from '../interface/type';
 import {debouncedUpdateISBNValue, updateAutoISBN, updateISBNType} from './action';
 import {isbn10To13, isbn13To10} from '../../../common/helpers/utils';
 import {FormCheck} from 'react-bootstrap';
 import NameField from '../../entity-editor/common/name-field';
 import React from 'react';
-import {addOtherISBN} from '../../entity-editor/identifier-editor/actions';
+import {addOtherISBN, removeIdentifierRow} from '../../entity-editor/identifier-editor/actions';
 import {connect} from 'react-redux';
 
 
 export function ISBNField(props:ISBNProps) {
 	const {value, type, onChange, autoISBN, onAutoISBNChange} = props;
 	const onChangeHandler = React.useCallback((event:RInputEvent) => onChange(event.target.value, autoISBN), [onChange, autoISBN]);
-	const onAutoISBNChangeHandler = React.useCallback(
-		(event:RInputEvent) => onAutoISBNChange(event.target.checked) && onChange(value, event.target.checked), [onAutoISBNChange, onChange, value]
-	);
+	const onAutoISBNChangeHandler = React.useCallback((event:RInputEvent) => {
+			onAutoISBNChange(event.target.checked);
+			onChange(value, event.target.checked);
+		}, [onAutoISBNChange, onChange, value]);
 	let checkboxLabel = 'Automatically add ISBN';
 	if (type) {
 		checkboxLabel += type === 10 ? `13 (${isbn10To13(value)})` : `10 (${isbn13To10(value)})`;
@@ -52,6 +53,7 @@ function mapStateToProps(rootState:State):ISBNStateProps {
 }
 
 function mapDispatchToProps(dispatch):ISBNDispatchProps {
+	let gett:dispatchResultProps|null;
 	function onChange(value:string, autoISBN = false) {
 		const isbn10rgx = new
 		RegExp('^(?:ISBN(?:-10)?:?●)?(?=[0-9X]{10}$|(?=(?:[0-9]+[-●]){3})[-●0-9X]{13}$)[0-9]{1,5}[-●]?[0-9]+[-●]?[0-9]+[-●]?[0-9X]$');
@@ -76,12 +78,19 @@ function mapDispatchToProps(dispatch):ISBNDispatchProps {
 		}
 		dispatch(updateISBNType(type));
 		if (autoISBN && otherISBN.type) {
-			dispatch(addOtherISBN(otherISBN.type, otherISBN.value));
+			 gett = dispatch(addOtherISBN(otherISBN.type, otherISBN.value));
 		}
 		dispatch(debouncedUpdateISBNValue(value));
 	}
 	return {
-		onAutoISBNChange: (checked:boolean) => dispatch(updateAutoISBN(checked)),
+		onAutoISBNChange: (checked:boolean) => {
+			dispatch(updateAutoISBN(checked));
+			if(gett){
+				dispatch(removeIdentifierRow(gett.payload.rowId));
+				gett=null;
+			}
+			return;
+		},
 		onChange
 	};
 }

--- a/src/client/unified-form/interface/type.ts
+++ b/src/client/unified-form/interface/type.ts
@@ -94,6 +94,15 @@ export type ISBNDispatchProps = {
 };
 export type ISBNProps = ISBNStateProps & ISBNDispatchProps;
 
+export type dispatchResultProps = {
+	payload: {
+			rowId: number,
+			type:number,
+			value:string
+		},
+		type: string
+}
+
 export type EntitySelect = {
 	text:string,
 	id:string


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->
BB-764: On the unified form, ticking and then unticking the "Automatically add ISBN" checkbox results in the generated ISBN to be left over in the "edit identifiers" modal.
Unchecking should remove the auto-generated ISBN.

### Solution
<!-- What does this PR do to fix the problem? -->
With the present code, what happens is that when the user checks the box for the first time, an action is dispatched to have the auto generated ISBN in the list of identifiers, but when he unchecks again, there was no direction to remove the added identifier. Hence, I have used this already defined removeIdentifierRow action:-
![image](https://github.com/metabrainz/bookbrainz-site/assets/116253210/4018f2ef-ffb5-4c13-9683-900828f7291e)

It requires rowId as a parameter, which we get using the addAutoIdentifier:-
![image](https://github.com/metabrainz/bookbrainz-site/assets/116253210/24fbc6ee-a55d-4369-bef3-e25647bf1236)

After changes:-
https://github.com/metabrainz/bookbrainz-site/assets/116253210/ecfc1a2b-2f7e-45f0-817a-cc77243a27d9



### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
 src/client/unified-form/cover-tab/isbn-field.tsx
 src/client/unified-form/interface/type.ts