### PR TITLE
Updates for Docker compose v2

### DIFF
--- a/develop-api.sh
+++ b/develop-api.sh
@@ -5,5 +5,13 @@ if [[ ! -d "src" ]]; then
     exit -1
 fi
 
-docker-compose -f docker-compose.api.yml run --rm startup &&
-docker-compose -f docker-compose.api.yml up --build bookbrainz-api
+echo "Checking docker compose version"
+if docker compose version &> /dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    DOCKER_COMPOSE_CMD="docker-compose"
+fi
+
+
+$DOCKER_COMPOSE_CMD -f docker-compose.api.yml run --rm startup &&
+$DOCKER_COMPOSE_CMD -f docker-compose.api.yml up --build bookbrainz-api

--- a/develop.sh
+++ b/develop.sh
@@ -5,5 +5,13 @@ if [[ ! -d "src" ]]; then
     exit -1
 fi
 
-docker-compose run --rm startup &&
-docker-compose up --build bookbrainz-site
+echo "Checking docker compose version"
+if docker compose version &> /dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    DOCKER_COMPOSE_CMD="docker-compose"
+fi
+
+
+$DOCKER_COMPOSE_CMD run --rm startup &&
+$DOCKER_COMPOSE_CMD up --build bookbrainz-site

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
 
   bookbrainz-api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
 
   bookbrainz-site:

--- a/scripts/database-init-docker.sh
+++ b/scripts/database-init-docker.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 
-docker-compose build &&
-docker-compose run --rm bookbrainz-site scripts/wait-for-postgres.sh scripts/download-import-dump.sh
+echo "Checking docker compose version"
+if docker compose version &> /dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    DOCKER_COMPOSE_CMD="docker-compose"
+fi
+
+$DOCKER_COMPOSE_CMD build &&
+$DOCKER_COMPOSE_CMD run --rm bookbrainz-site scripts/wait-for-postgres.sh scripts/download-import-dump.sh

--- a/stop.sh
+++ b/stop.sh
@@ -1,2 +1,10 @@
-docker-compose down
-docker-compose -f docker-compose.api.yml down
+echo "Checking docker compose version"
+if docker compose version &> /dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    DOCKER_COMPOSE_CMD="docker-compose"
+fi
+
+
+$DOCKER_COMPOSE_CMD down
+$DOCKER_COMPOSE_CMD -f docker-compose.api.yml down


### PR DESCRIPTION
Depending on the version of docker, we want to call either `docker-compose` or `docker compose`.
See https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/
Version detection code copied from ListenBrainz

Also removes the 'version' argument in docker-compose files, which is now deprecated.