### PR TITLE
Search admin and indexing improvements

### DIFF
--- a/src/client/components/pages/admin-panel-search.tsx
+++ b/src/client/components/pages/admin-panel-search.tsx
@@ -145,6 +145,7 @@ class AdminPanelSearchPage extends React.Component<Props, State> {
 				</Card.Header>
 				<Card.Body>
 					<div id="pageWithPagination">
+						<h3>User search</h3>
 						<AdminPanelSearchField
 							query={query}
 							onSearch={this.handleSearch}

--- a/src/client/components/pages/searchAdmin.tsx
+++ b/src/client/components/pages/searchAdmin.tsx
@@ -48,67 +48,58 @@ export default function SearchAdminPage() {
 						}
 					}
 				>
-					<Button>
+					<Button onClick={() => { indexEntity('Author'); }}>
 						<FontAwesomeIcon
 							icon={ENTITY_TYPE_ICONS.Author}
 							size="2x"
-							onClick={() => { indexEntity('Author'); }}
 						/>
 					</Button>
 
-					<Button>
+					<Button onClick={() => { indexEntity('Work'); }}>
 						<FontAwesomeIcon
 							icon={ENTITY_TYPE_ICONS.Work}
 							size="2x"
-							onClick={() => { indexEntity('Work'); }}
 						/>
 					</Button>
-					<Button>
+					<Button onClick={() => { indexEntity('Edition'); }}>
 						<FontAwesomeIcon
 							icon={ENTITY_TYPE_ICONS.Edition}
 							size="2x"
-							onClick={() => { indexEntity('Edition'); }}
 						/>
 					</Button>
-					<Button>
+					<Button onClick={() => { indexEntity('EditionGroup'); }}>
 						<FontAwesomeIcon
 							icon={ENTITY_TYPE_ICONS.EditionGroup}
 							size="2x"
-							onClick={() => { indexEntity('EditionGroup'); }}
 						/>
 					</Button>
-					<Button>
+					<Button onClick={() => { indexEntity('Publisher'); }}>
 						<FontAwesomeIcon
 							icon={ENTITY_TYPE_ICONS.Publisher}
 							size="2x"
-							onClick={() => { indexEntity('Publisher'); }}
 						/>
 					</Button>
-					<Button>
+					<Button onClick={() => { indexEntity('Series'); }}>
 						<FontAwesomeIcon
 							icon={ENTITY_TYPE_ICONS.Series}
 							size="2x"
-							onClick={() => { indexEntity('Series'); }}
 						/>
 					</Button>
-					<Button>
+					<Button onClick={() => { indexEntity('Area'); }}>
 						<FontAwesomeIcon
 							icon={ENTITY_TYPE_ICONS.Area}
 							size="2x"
-							onClick={() => { indexEntity('Area'); }}
 						/>
 					</Button>
-					<Button>
+					<Button onClick={() => { indexEntity('Collection'); }}>
 						<FontAwesomeIcon
 							icon={ENTITY_TYPE_ICONS.Collection}
 							size="2x"
-							onClick={() => { indexEntity('Collection'); }}
 						/>
 					</Button>
-					<Button size="lg" variant="warning">
+					<Button size="lg" variant="warning" onClick={() => { indexEntity(); }}>
 						<FontAwesomeIcon
 							icon={faListCheck}
-							onClick={() => { indexEntity(); }}
 						/> All entities
 					</Button>
 				</div>

--- a/src/client/components/pages/searchAdmin.tsx
+++ b/src/client/components/pages/searchAdmin.tsx
@@ -1,0 +1,132 @@
+/* eslint-disable react/jsx-no-bind */
+
+import {Alert, Button, Card, Spinner} from 'react-bootstrap';
+import React, {useCallback, useState} from 'react';
+import {faCheck, faListCheck, faTriangleExclamation} from '@fortawesome/free-solid-svg-icons';
+import {ENTITY_TYPE_ICONS} from '../../helpers/entity';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+
+
+export default function SearchAdminPage() {
+	const [loading, setLoading] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string>();
+	const [success, setSuccess] = useState(false);
+	const indexEntity = useCallback(async (entityType?:string) => {
+		let url = '/search/reindex';
+		if (entityType) {
+			url += `?type=${entityType}`;
+		}
+		setSuccess(false);
+		setLoading(true);
+		try {
+			const res = await fetch(url, {headers: {'Request-Timeout': '600'}});
+			if (!res.ok) {
+				const body = await res.json();
+				const err = body?.error;
+				throw new Error(err || res.statusText);
+			}
+			setSuccess(true);
+		}
+		catch (error) {
+			setErrorMessage(error);
+		}
+		setLoading(false);
+	}, []);
+	return (
+		<Card>
+			<Card.Header as="h2">
+				Search indexing
+			</Card.Header>
+			<Card.Body>
+				<div
+					style={
+						{
+							display: 'flex',
+							flexWrap: 'wrap',
+							gap: '0.5em',
+							justifyContent: 'space-evenly'
+						}
+					}
+				>
+					<Button>
+						<FontAwesomeIcon
+							icon={ENTITY_TYPE_ICONS.Author}
+							size="2x"
+							onClick={() => { indexEntity('Author'); }}
+						/>
+					</Button>
+
+					<Button>
+						<FontAwesomeIcon
+							icon={ENTITY_TYPE_ICONS.Work}
+							size="2x"
+							onClick={() => { indexEntity('Work'); }}
+						/>
+					</Button>
+					<Button>
+						<FontAwesomeIcon
+							icon={ENTITY_TYPE_ICONS.Edition}
+							size="2x"
+							onClick={() => { indexEntity('Edition'); }}
+						/>
+					</Button>
+					<Button>
+						<FontAwesomeIcon
+							icon={ENTITY_TYPE_ICONS.EditionGroup}
+							size="2x"
+							onClick={() => { indexEntity('EditionGroup'); }}
+						/>
+					</Button>
+					<Button>
+						<FontAwesomeIcon
+							icon={ENTITY_TYPE_ICONS.Publisher}
+							size="2x"
+							onClick={() => { indexEntity('Publisher'); }}
+						/>
+					</Button>
+					<Button>
+						<FontAwesomeIcon
+							icon={ENTITY_TYPE_ICONS.Series}
+							size="2x"
+							onClick={() => { indexEntity('Series'); }}
+						/>
+					</Button>
+					<Button>
+						<FontAwesomeIcon
+							icon={ENTITY_TYPE_ICONS.Area}
+							size="2x"
+							onClick={() => { indexEntity('Area'); }}
+						/>
+					</Button>
+					<Button>
+						<FontAwesomeIcon
+							icon={ENTITY_TYPE_ICONS.Collection}
+							size="2x"
+							onClick={() => { indexEntity('Collection'); }}
+						/>
+					</Button>
+					<Button size="lg" variant="warning">
+						<FontAwesomeIcon
+							icon={faListCheck}
+							onClick={() => { indexEntity(); }}
+						/> All entities
+					</Button>
+				</div>
+				<br/>
+				<div>
+					{loading && <><Spinner animation="border"/> In progress...</>}
+					{success &&
+					<Alert dismissible variant="success" onClose={() => { setSuccess(false); }}>
+						<FontAwesomeIcon icon={faCheck}/> Success
+					</Alert>
+					}
+					{errorMessage &&
+					<Alert dismissible variant="danger" onClose={() => { setErrorMessage(''); }}>
+						<FontAwesomeIcon icon={faTriangleExclamation}/> {errorMessage}
+					</Alert>
+					}
+				</div>
+			</Card.Body>
+		</Card>
+	);
+}

--- a/src/client/components/pages/searchAdmin.tsx
+++ b/src/client/components/pages/searchAdmin.tsx
@@ -28,7 +28,7 @@ export default function SearchAdminPage() {
 			setSuccess(true);
 		}
 		catch (error) {
-			setErrorMessage(error);
+			setErrorMessage(error.toString());
 		}
 		setLoading(false);
 	}, []);

--- a/src/client/containers/layout.js
+++ b/src/client/containers/layout.js
@@ -197,9 +197,9 @@ class Layout extends React.Component {
 
 		const reindexSearchEngineOption = (
 			<>
-				<NavDropdown.Item href="/search/reindex">
+				<NavDropdown.Item href="/search-admin">
 					<FontAwesomeIcon fixedWidth className="margin-right-0-3" icon={faSearchengin}/>
-					Reindex Search Server
+					Search Admin
 				</NavDropdown.Item>
 			</>
 		);

--- a/src/client/controllers/admin/searchAdmin.tsx
+++ b/src/client/controllers/admin/searchAdmin.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Shivam Awasthi
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {extractChildProps, extractLayoutProps} from '../../helpers/props';
+import {AppContainer} from 'react-hot-loader';
+import Layout from '../../containers/layout';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import SearchAdminPage from '../../components/pages/searchAdmin';
+
+
+const propsTarget = document.getElementById('props');
+const props = propsTarget ? JSON.parse(propsTarget.innerHTML) : {};
+
+const markup = (
+	<AppContainer>
+		<Layout {...extractLayoutProps(props)}>
+			<SearchAdminPage
+				user={props.user}
+				{...extractChildProps(props)}
+			/>
+		</Layout>
+	</AppContainer>
+);
+
+ReactDOM.hydrate(markup, document.getElementById('target'));
+
+/*
+ * As we are not exporting a component,
+ * we cannot use the react-hot-loader module wrapper,
+ * but instead directly use webpack Hot Module Replacement API
+ */
+
+if (module.hot) {
+	module.hot.accept();
+}

--- a/src/common/helpers/search.ts
+++ b/src/common/helpers/search.ts
@@ -412,9 +412,9 @@ export async function generateIndex(orm, entityType: IndexableEntities | 'allEnt
 	const allEntities = entityType === 'allEntities';
 	const mainIndexExists = await _client.indices.exists({
 		index: _index
-	})?.body;
+	});
 
-	const shouldRecreateIndex = !mainIndexExists || recreateIndex || allEntities;
+	const shouldRecreateIndex = !mainIndexExists.body || recreateIndex || allEntities;
 
 	if (shouldRecreateIndex) {
 		log.notice('Deleting search index');

--- a/src/common/helpers/search.ts
+++ b/src/common/helpers/search.ts
@@ -417,8 +417,10 @@ export async function generateIndex(orm, entityType: IndexableEntities | 'allEnt
 	const shouldRecreateIndex = !mainIndexExists.body || recreateIndex || allEntities;
 
 	if (shouldRecreateIndex) {
-		log.notice('Deleting search index');
-		await _client.indices.delete({index: _index});
+		if (mainIndexExists.body) {
+			log.notice('Deleting search index');
+			await _client.indices.delete({index: _index});
+		}
 		log.notice('Creating new search index');
 		await _client.indices.create({body: indexMappings, index: _index});
 	}

--- a/src/common/helpers/search.ts
+++ b/src/common/helpers/search.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-undefined */
 /*
  * Copyright (C) 2016  Sean Burke
  *
@@ -52,6 +53,79 @@ function sanitizeEntityType(type) {
 type IndexableEntities = EntityTypeString | 'Editor' | 'Collection' | 'Area';
 const commonProperties = ['bbid', 'id', 'name', 'type', 'disambiguation'];
 
+const indexMappings = {
+	mappings: {
+		_default_: {
+			properties: {
+				aliases: {
+					properties: {
+						name: {
+							fields: {
+								autocomplete: {
+									analyzer: 'edge',
+									type: 'text'
+								},
+								search: {
+									analyzer: 'trigrams',
+									type: 'text'
+								}
+							},
+							type: 'text'
+						}
+					}
+				},
+				authors: {
+					analyzer: 'trigrams',
+					type: 'text'
+				},
+				disambiguation: {
+					analyzer: 'trigrams',
+					type: 'text'
+				}
+			}
+		}
+	},
+	settings: {
+		analysis: {
+			analyzer: {
+				edge: {
+					filter: [
+						'asciifolding',
+						'lowercase'
+					],
+					tokenizer: 'edge_ngram_tokenizer',
+					type: 'custom'
+				},
+				trigrams: {
+					filter: [
+						'asciifolding',
+						'lowercase'
+					],
+					tokenizer: 'trigrams',
+					type: 'custom'
+				}
+			},
+			tokenizer: {
+				edge_ngram_tokenizer: {
+					max_gram: 10,
+					min_gram: 2,
+					token_chars: [
+						'letter',
+						'digit'
+					],
+					type: 'edge_ngram'
+				},
+				trigrams: {
+					max_gram: 3,
+					min_gram: 1,
+					type: 'ngram'
+				}
+			}
+		},
+		'index.mapping.ignore_malformed': true
+	}
+};
+
 /* We don't currently want to index the entire Model in ElasticSearch,
    which contains a lot of fields we don't use as well as some internal props (_pivot props)
    This utility function prepares the Model into a minimal object that will be indexed
@@ -65,16 +139,25 @@ export function getDocumentToIndex(entity:any, entityType: IndexableEntities) {
 		default:
 			break;
 	}
-	let aliases = entity.related('aliasSet')?.related('aliases')?.toJSON({ignorePivot: true, visible: 'name'});
+	let aliases = entity
+		.related('aliasSet')
+		?.related('aliases')
+		?.toJSON({ignorePivot: true, visible: 'name'});
 	if (!aliases) {
 		// Some models don't have the same aliasSet structure, i.e. Collection, Editor, Area, …
 		const name = entity.get('name');
 		aliases = {name};
 	}
-	const identifiers = entity.related('identifierSet')?.related('identifiers')?.toJSON({ignorePivot: true, visible: 'value'});
+	const identifiers = entity
+		.related('identifierSet')
+		?.related('identifiers')
+		?.toJSON({ignorePivot: true, visible: 'value'});
 
 	return {
-		...entity.toJSON({ignorePivot: true, visible: commonProperties.concat(additionalProperties)}),
+		...entity.toJSON({
+			ignorePivot: true,
+			visible: commonProperties.concat(additionalProperties)
+		}),
 		aliases,
 		identifiers: identifiers ?? null
 	};
@@ -190,9 +273,13 @@ export async function _bulkIndexEntities(entities) {
 		operationSucceeded = true;
 
 		// eslint-disable-next-line no-await-in-loop
-		const response = await _client.bulk({
-			body: bulkOperations
-		}).catch(error => { log.error('error bulk indexing entities for search:', error); });
+		const response = await _client
+			.bulk({
+				body: bulkOperations
+			})
+			.catch((error) => {
+				log.error('error bulk indexing entities for search:', error);
+			});
 
 		/*
 		 * In case of failed index operations, the promise won't be rejected;
@@ -283,114 +370,59 @@ export function indexEntity(entity) {
 	const entityType = entity.get('type');
 	const document = getDocumentToIndex(entity, entityType);
 	if (entity) {
-		return _client.index({
-			body: document,
-			id: entity.get('bbid') || entity.get('id'),
-			index: _index,
-			type: snakeCase(entityType)
-		}).catch(error => { log.error('error indexing entity for search:', error); });
+		return _client
+			.index({
+				body: document,
+				id: entity.get('bbid') || entity.get('id'),
+				index: _index,
+				type: snakeCase(entityType)
+			})
+			.catch((error) => {
+				log.error('error indexing entity for search:', error);
+			});
 	}
 }
 
 export function deleteEntity(entity) {
-	return _client.delete({
-		id: entity.bbid ?? entity.id,
-		index: _index,
-		type: snakeCase(entity.type)
-	}).catch(error => { log.error('error deleting entity from index:', error); });
+	return _client
+		.delete({
+			id: entity.bbid ?? entity.id,
+			index: _index,
+			type: snakeCase(entity.type)
+		})
+		.catch((error) => {
+			log.error('error deleting entity from index:', error);
+		});
 }
 
 export function refreshIndex() {
-	return _client.indices.refresh({index: _index}).catch(error => { log.error('error refreshing search index:', error); });
+	return _client.indices.refresh({index: _index}).catch((error) => {
+		log.error('Error refreshing search index:', error);
+	});
 }
 
-export async function generateIndex(orm) {
+export async function generateIndex(orm, entityType: IndexableEntities | 'allEntities' = 'allEntities', recreateIndex = false) {
 	const {Area, Author, Edition, EditionGroup, Editor, Publisher, Series, UserCollection, Work} = orm;
-	const indexMappings = {
-		mappings: {
-			_default_: {
-				properties: {
-					aliases: {
-						properties: {
-							name: {
-								fields: {
-									autocomplete: {
-										analyzer: 'edge',
-										type: 'text'
-									},
-									search: {
-										analyzer: 'trigrams',
-										type: 'text'
-									}
-								},
-								type: 'text'
-							}
-						}
-					},
-					authors: {
-						analyzer: 'trigrams',
-						type: 'text'
-					},
-					disambiguation: {
-						analyzer: 'trigrams',
-						type: 'text'
-					}
-				}
-			}
-		},
-		settings: {
-			analysis: {
-				analyzer: {
-					edge: {
-						filter: [
-							'asciifolding',
-							'lowercase'
-						],
-						tokenizer: 'edge_ngram_tokenizer',
-						type: 'custom'
-					},
-					trigrams: {
-						filter: [
-							'asciifolding',
-							'lowercase'
-						],
-						tokenizer: 'trigrams',
-						type: 'custom'
-					}
-				},
-				tokenizer: {
-					edge_ngram_tokenizer: {
-						max_gram: 10,
-						min_gram: 2,
-						token_chars: [
-							'letter',
-							'digit'
-						],
-						type: 'edge_ngram'
-					},
-					trigrams: {
-						max_gram: 3,
-						min_gram: 1,
-						type: 'ngram'
-					}
-				}
-			},
-			'index.mapping.ignore_malformed': true
-		}
-	};
 
-	// First, drop index and recreate
-	const mainIndexExistsRequest = await _client.indices.exists({index: _index});
-	const mainIndexExists = mainIndexExistsRequest?.body;
+	const allEntities = entityType === 'allEntities';
+	const mainIndexExists = await _client.indices.exists({
+		index: _index
+	})?.body;
 
-	if (mainIndexExists) {
+	const shouldRecreateIndex = mainIndexExists && (recreateIndex || allEntities);
+
+	if (shouldRecreateIndex) {
+		// Drop index and recreate
 		await _client.indices.delete({index: _index});
 	}
+	if (!mainIndexExists || shouldRecreateIndex) {
+		// Create the index if missing or re-create it if we just deleted it
+		await _client.indices.create({body: indexMappings, index: _index});
+	}
 
-	await _client.indices.create(
-		{body: indexMappings, index: _index}
-	);
+	log.notice(`Starting indexing of ${entityType}`);
 
+	const entityBehaviors = [];
 	const baseRelations = [
 		'annotation',
 		'defaultAlias',
@@ -398,32 +430,54 @@ export async function generateIndex(orm) {
 		'identifierSet.identifiers'
 	];
 
-	const entityBehaviors = [
-		{
+	if (allEntities || entityType === 'Author' || entityType === 'Work') {
+		entityBehaviors.push({
 			model: Author,
-			relations: [
-				'gender',
-				'beginArea',
-				'endArea'
-			]
-		},
-		{
+			relations: ['gender', 'beginArea', 'endArea'],
+			type: 'Author'
+		});
+	}
+	if (allEntities || entityType === 'Edition') {
+		entityBehaviors.push({
 			model: Edition,
-			relations: [
-				'editionGroup',
-				'editionFormat',
-				'editionStatus'
-			]
-		},
-		{model: EditionGroup, relations: []},
-		{model: Publisher, relations: ['area']},
-		{model: Series, relations: ['seriesOrderingType']},
-		{model: Work, relations: ['relationshipSet.relationships.type']}
-	];
+			relations: ['editionGroup', 'editionFormat', 'editionStatus'],
+			type: 'Edition'
+		});
+	}
+	if (allEntities || entityType === 'EditionGroup') {
+		entityBehaviors.push({
+			model: EditionGroup,
+			relations: [],
+			type: 'EditionGroup'
+		});
+	}
+	if (allEntities || entityType === 'Publisher') {
+		entityBehaviors.push({
+			model: Publisher,
+			relations: ['area'],
+			type: 'Publisher'
+		});
+	}
+	if (allEntities || entityType === 'Series') {
+		entityBehaviors.push({
+			model: Series,
+			relations: ['seriesOrderingType'],
+			type: 'Series'
+		});
+	}
+	if (allEntities || entityType === 'Work') {
+		log.info('Also indexing Author entities');
+		entityBehaviors.push({
+			model: Work,
+			relations: ['relationshipSet.relationships.type'],
+			type: 'Work'
+		});
+	}
 
 	// Update the indexed entries for each entity type
-	const behaviorPromise = entityBehaviors.map(
-		(behavior) => behavior.model.forge()
+	const behaviorPromise = entityBehaviors.map(async (behavior) => ({
+		results: await behavior.model
+			.forge()
 			.query((qb) => {
 				qb.where('master', true);
 				qb.whereNotNull('data_id');
@@ -431,96 +485,117 @@ export async function generateIndex(orm) {
 			.fetchAll({
 				withRelated: baseRelations.concat(behavior.relations)
 			})
-	);
-	const entityLists = await Promise.all(behaviorPromise);
-	/* eslint-disable @typescript-eslint/no-unused-vars */
-	const entityFetchOrder:EntityTypeString[] = ['Author', 'Edition', 'EditionGroup', 'Publisher', 'Series', 'Work'];
-	const [authorsCollection,
-		editionCollection,
-		editionGroupCollection,
-		publisherCollection,
-		seriesCollection,
-		workCollection] = entityLists;
-	/* eslint-enable @typescript-eslint/no-unused-vars */
-	const listIndexes = [];
+			.catch(log.error),
+		type: behavior.type
+	}));
+	log.info(`Finished fetching entities from database for type ${entityType}`);
 
-	workCollection.forEach(workEntity => {
-		const relationshipSet = workEntity.related('relationshipSet');
-		if (relationshipSet) {
-			const authorWroteWorkRels = relationshipSet.related('relationships')?.filter(relationshipModel => relationshipModel.get('typeId') === 8);
-			const authorNames = [];
-			authorWroteWorkRels.forEach(relationshipModel => {
-				// Search for the Author in the already fetched BookshelfJS Collection
-				const source = authorsCollection.get(relationshipModel.get('sourceBbid'));
-				const name = source?.related('defaultAlias')?.get('name');
-				if (name) {
-					authorNames.push(name);
-				}
-			});
-			workEntity.set('authors', authorNames);
-		}
-	});
+	const entityLists = await Promise.all(behaviorPromise);
+
+	if (allEntities || entityType === 'Work') {
+		log.info('Attaching author names to Work entities');
+		const authorCollection = entityLists.find(
+			({type}) => type === 'Author'
+		);
+		const workCollection = entityLists.find(({type}) => type === 'Work');
+		workCollection?.results.forEach((workEntity) => {
+			const relationshipSet = workEntity.related('relationshipSet');
+			if (relationshipSet) {
+				const authorWroteWorkRels = relationshipSet
+					.related('relationships')
+					?.filter(
+						(relationshipModel) =>
+							relationshipModel.get('typeId') === 8
+					);
+				const authorNames = [];
+				authorWroteWorkRels.forEach((relationshipModel) => {
+					// Search for the Author in the already fetched BookshelfJS Collection
+					const source = authorCollection.get(
+						relationshipModel.get('sourceBbid')
+					);
+					const name = source?.related('defaultAlias')?.get('name');
+					if (name) {
+						authorNames.push(name);
+					}
+				});
+				workEntity.set('authors', authorNames);
+			}
+		});
+	}
+
+	const listIndexes = [];
 	// Index all the entities
-	entityLists.forEach((entityList, idx) => {
-		const entityType:EntityTypeString = entityFetchOrder[idx];
-		const listArray = entityList.map(entity => getDocumentToIndex(entity, entityType));
+	entityLists.forEach((entityList) => {
+		const listArray = entityList.results.map((entity) =>
+			getDocumentToIndex(entity, entityList.type));
 		listIndexes.push(_processEntityListForBulk(listArray));
 	});
 
-	await Promise.all(listIndexes);
+	if (listIndexes.length) {
+		log.info(`Indexing documents for entity type ${entityType}`);
+		await Promise.all(listIndexes);
+		log.info(`Finished indexing entity documents for entity type ${entityType}`);
+	}
 
-	const areaCollection = await Area.forge()
-		.fetchAll();
+	if (allEntities || entityType === 'Area') {
+		log.info('Indexing Areas');
 
-	const areas = areaCollection.toJSON({omitPivot: true});
+		const areaCollection = await Area.forge().fetchAll();
 
-	/** To index names, we use aliases.name and type, which Areas don't have.
-   * We massage the area to return a similar format as BB entities
-   */
-	const processedAreas = areas.map((area) => ({
-		aliases: [
-			{name: area.name}
-		],
-		id: area.gid,
-		type: 'Area'
-	}));
-	await _processEntityListForBulk(processedAreas);
+		const areas = areaCollection.toJSON({omitPivot: true});
 
-	const editorCollection = await Editor.forge()
-		// no bots
-		.where('type_id', 1)
-		.fetchAll();
-	const editors = editorCollection.toJSON({omitPivot: true});
+		/** To index names, we use aliases.name and type, which Areas don't have.
+		 * We massage the area to return a similar format as BB entities
+		 */
+		const processedAreas = areas.map((area) => ({
+			aliases: [{name: area.name}],
+			id: area.gid,
+			type: 'Area'
+		}));
+		await _processEntityListForBulk(processedAreas);
+		log.info('Finished indexing Areas');
+	}
+	if (allEntities || entityType === 'Editor') {
+		log.info('Indexing Editors');
+		const editorCollection = await Editor.forge()
+			// no bots
+			.where('type_id', 1)
+			.fetchAll();
+		const editors = editorCollection.toJSON({omitPivot: true});
 
-	/** To index names, we use aliases.name and type, which Editors don't have.
-   * We massage the editor to return a similar format as BB entities
-   */
-	const processedEditors = editors.map((editor) => ({
-		aliases: [
-			{name: editor.name}
-		],
-		id: editor.id,
-		type: 'Editor'
-	}));
-	await _processEntityListForBulk(processedEditors);
+		/** To index names, we use aliases.name and type, which Editors don't have.
+		 * We massage the editor to return a similar format as BB entities
+		 */
+		const processedEditors = editors.map((editor) => ({
+			aliases: [{name: editor.name}],
+			id: editor.id,
+			type: 'Editor'
+		}));
+		await _processEntityListForBulk(processedEditors);
+		log.info('Finished indexing Editors');
+	}
 
-	const userCollections = await UserCollection.forge().where({public: true})
-		.fetchAll();
-	const userCollectionsJSON = userCollections.toJSON({omitPivot: true});
+	if (allEntities || entityType === 'Collection') {
+		log.info('Indexing Collections');
+		const userCollections = await UserCollection.forge()
+			.where({public: true})
+			.fetchAll();
+		const userCollectionsJSON = userCollections.toJSON({omitPivot: true});
 
-	/** To index names, we use aliases.name and type, which UserCollections don't have.
-   * We massage the editor to return a similar format as BB entities
-   */
-	const processedCollections = userCollectionsJSON.map((collection) => ({
-		aliases: [
-			{name: collection.name}
-		],
-		id: collection.id,
-		type: 'Collection'
-	}));
-	await _processEntityListForBulk(processedCollections);
-
+		/** To index names, we use aliases.name and type, which UserCollections don't have.
+		 * We massage the editor to return a similar format as BB entities
+		 */
+		const processedCollections = userCollectionsJSON.map((collection) => ({
+			aliases: [{name: collection.name}],
+			id: collection.id,
+			type: 'Collection'
+		}));
+		await _processEntityListForBulk(processedCollections);
+		log.info('Finished indexing Collections');
+	}
+	log.info('Refreshing search index');
 	await refreshIndex();
+	log.notice('Search indexing finished succesfully');
 }
 
 export async function checkIfExists(orm, name, type) {
@@ -529,7 +604,9 @@ export async function checkIfExists(orm, name, type) {
 		bookshelf.transaction(async (transacting) => {
 			try {
 				const result = await orm.func.alias.getBBIDsWithMatchingAlias(
-					transacting, snakeCase(type), name
+					transacting,
+					snakeCase(type),
+					name
 				);
 				resolve(result);
 			}
@@ -549,9 +626,13 @@ export async function checkIfExists(orm, name, type) {
 		'revision.revision'
 	];
 	const processedResults = await Promise.all(
-		bbids.map(
-			bbid => orm.func.entity.getEntity(orm, upperFirst(camelCase(type)), bbid, baseRelations)
-		)
+		bbids.map((bbid) =>
+			orm.func.entity.getEntity(
+				orm,
+				upperFirst(camelCase(type)),
+				bbid,
+				baseRelations
+			))
 	);
 
 	return processedResults;
@@ -580,7 +661,11 @@ export function searchByName(orm, name, type, size, from) {
 		index: _index,
 		type: sanitizedEntityType
 	};
-	if (sanitizedEntityType === 'work' || (Array.isArray(sanitizedEntityType) && sanitizedEntityType.includes('work'))) {
+	if (
+		sanitizedEntityType === 'work' ||
+		(Array.isArray(sanitizedEntityType) &&
+			sanitizedEntityType.includes('work'))
+	) {
 		dslQuery.body.query.multi_match.fields.push('authors');
 	}
 

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -38,6 +38,7 @@ import relationshipTypesRouter from './routes/relationship-types';
 import reviewsRouter from './routes/reviews';
 import revisionRouter from './routes/revision';
 import revisionsRouter from './routes/revisions';
+import searchAdminRouter from './routes/searchAdmin';
 import searchRouter from './routes/search';
 import seriesRouter from './routes/entity/series';
 import statisticsRouter from './routes/statistics';
@@ -59,6 +60,7 @@ function initRootRoutes(app) {
 	app.use('/statistics', statisticsRouter);
 	app.use('/external-service', externalServiceRouter);
 	app.use('/admin-panel', adminPanelRouter);
+	app.use('/search-admin', searchAdminRouter);
 	app.use('/admin-logs', adminLogsRouter);
 	app.use('/relationship-type', relationshipTypeRouter);
 	app.use('/relationship-types', relationshipTypesRouter);

--- a/src/server/routes/search.tsx
+++ b/src/server/routes/search.tsx
@@ -47,7 +47,7 @@ const {REINDEX_SEARCH_SERVER} = PrivilegeType;
 router.get('/', async (req, res, next) => {
 	const {orm} = req.app.locals;
 	const query = req.query.q ?? '';
-	const type = String(req.query.type) || 'allEntities';
+	const type = req.query.type?.toString() || 'allEntities';
 	const size = req.query.size ? parseInt(String(req.query.size), 10) : 20;
 	const from = req.query.from ? parseInt(String(req.query.from), 10) : 0;
 	try {
@@ -121,7 +121,7 @@ router.get('/search', (req, res) => {
 router.get('/autocomplete', (req, res) => {
 	const {orm} = req.app.locals;
 	const query = req.query.q;
-	const type = req.query.type || 'allEntities';
+	const type = req.query.type?.toString() || 'allEntities';
 	const size = Number(req.query.size) || 42;
 
 	const searchPromise = search.autocomplete(orm, query, type, size);

--- a/src/server/routes/search.tsx
+++ b/src/server/routes/search.tsx
@@ -27,6 +27,7 @@ import * as search from '../../common/helpers/search';
 import {keys as _keys, snakeCase as _snakeCase, camelCase, isNil, isString, upperFirst} from 'lodash';
 import {escapeProps, generateProps} from '../helpers/props';
 
+import {EntityTypeString} from 'bookbrainz-data/lib/types/entity';
 import Layout from '../../client/containers/layout';
 import {PrivilegeType} from '../../common/helpers/privileges-utils';
 import React from 'react';
@@ -34,7 +35,6 @@ import ReactDOMServer from 'react-dom/server';
 import SearchPage from '../../client/components/pages/search';
 import express from 'express';
 import target from '../templates/target';
-import { EntityTypeString } from 'bookbrainz-data/lib/types/entity';
 
 
 const router = express.Router();
@@ -150,14 +150,14 @@ router.get('/exists', (req, res) => {
 router.get('/reindex', auth.isAuthenticated, auth.isAuthorized(REINDEX_SEARCH_SERVER), async (req, res) => {
 	req.socket.setTimeout(600000);
 	const {orm} = req.app.locals;
-	const type = isString(req.query.type) ? upperFirst(camelCase(req.query.type)) : "allEntities";
+	const type = isString(req.query.type) ? upperFirst(camelCase(req.query.type)) : 'allEntities';
 	try {
-		await search.generateIndex(orm, type as EntityTypeString );
+		await search.generateIndex(orm, type as search.IndexableEntities);
 		return handler.sendPromiseResult(res, {success: true});
-	} catch (err) {
-		return error.sendErrorAsJSON(res, new error.SiteError("Cannot index entites for search, something went wrong", req));
 	}
-
+	catch (err) {
+		return error.sendErrorAsJSON(res, new error.SiteError(`Cannot index entites for search, something went wrong: ${err.toString()}`, req));
+	}
 });
 
 router.get('/entity/:bbid', async (req, res) => {

--- a/src/server/routes/search.tsx
+++ b/src/server/routes/search.tsx
@@ -24,7 +24,7 @@ import * as handler from '../helpers/handler';
 import * as propHelpers from '../../client/helpers/props';
 import * as search from '../../common/helpers/search';
 
-import {keys as _keys, snakeCase as _snakeCase, isNil} from 'lodash';
+import {keys as _keys, snakeCase as _snakeCase, camelCase, isNil, isString, upperFirst} from 'lodash';
 import {escapeProps, generateProps} from '../helpers/props';
 
 import Layout from '../../client/containers/layout';
@@ -34,6 +34,7 @@ import ReactDOMServer from 'react-dom/server';
 import SearchPage from '../../client/components/pages/search';
 import express from 'express';
 import target from '../templates/target';
+import { EntityTypeString } from 'bookbrainz-data/lib/types/entity';
 
 
 const router = express.Router();
@@ -46,9 +47,9 @@ const {REINDEX_SEARCH_SERVER} = PrivilegeType;
 router.get('/', async (req, res, next) => {
 	const {orm} = req.app.locals;
 	const query = req.query.q ?? '';
-	const type = req.query.type || 'allEntities';
-	const size = req.query.size ? parseInt(req.query.size, 10) : 20;
-	const from = req.query.from ? parseInt(req.query.from, 10) : 0;
+	const type = String(req.query.type) || 'allEntities';
+	const size = req.query.size ? parseInt(String(req.query.size), 10) : 20;
+	const from = req.query.from ? parseInt(String(req.query.from), 10) : 0;
 	try {
 		let searchResults = {
 			initialResults: [],
@@ -59,9 +60,11 @@ router.get('/', async (req, res, next) => {
 			// get 1 more results to check nextEnabled
 			const searchResponse = await search.searchByName(orm, query, _snakeCase(type), size + 1, from);
 			const {results: entities} = searchResponse;
+			const initialResults = entities.filter(entity => !isNil(entity));
 			searchResults = {
-				initialResults: entities.filter(entity => !isNil(entity)),
-				query
+				initialResults,
+				query,
+				total: initialResults.length
 			};
 		}
 
@@ -102,7 +105,7 @@ router.get('/', async (req, res, next) => {
 router.get('/search', (req, res) => {
 	const {orm} = req.app.locals;
 	const query = req.query.q;
-	const type = req.query.type || 'allEntities';
+	const type = req.query.type?.toString() || 'allEntities';
 
 	const {size, from} = req.query;
 
@@ -119,7 +122,7 @@ router.get('/autocomplete', (req, res) => {
 	const {orm} = req.app.locals;
 	const query = req.query.q;
 	const type = req.query.type || 'allEntities';
-	const size = req.query.size || 42;
+	const size = Number(req.query.size) || 42;
 
 	const searchPromise = search.autocomplete(orm, query, type, size);
 
@@ -134,7 +137,7 @@ router.get('/exists', (req, res) => {
 	const {orm} = req.app.locals;
 	const {q, type} = req.query;
 
-	const searchPromise = search.checkIfExists(orm, q, _snakeCase(type));
+	const searchPromise = search.checkIfExists(orm, q, _snakeCase(String(type)));
 
 	handler.sendPromiseResult(res, searchPromise);
 });
@@ -145,10 +148,16 @@ router.get('/exists', (req, res) => {
  * @throws {error.PermissionDeniedError} - Thrown if user is not admin.
  */
 router.get('/reindex', auth.isAuthenticated, auth.isAuthorized(REINDEX_SEARCH_SERVER), async (req, res) => {
+	req.socket.setTimeout(600000);
 	const {orm} = req.app.locals;
-	await search.generateIndex(orm);
+	const type = isString(req.query.type) ? upperFirst(camelCase(req.query.type)) : "allEntities";
+	try {
+		await search.generateIndex(orm, type as EntityTypeString );
+		return handler.sendPromiseResult(res, {success: true});
+	} catch (err) {
+		return error.sendErrorAsJSON(res, new error.SiteError("Cannot index entites for search, something went wrong", req));
+	}
 
-	handler.sendPromiseResult(res, {success: true});
 });
 
 router.get('/entity/:bbid', async (req, res) => {

--- a/src/server/routes/searchAdmin.tsx
+++ b/src/server/routes/searchAdmin.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2023 Shivam Awasthi
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as auth from '../helpers/auth';
+import * as propHelpers from '../../client/helpers/props';
+
+import {escapeProps, generateProps} from '../helpers/props';
+import Layout from '../../client/containers/layout';
+import {PrivilegeType} from '../../common/helpers/privileges-utils';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import SearchAdminPage from '../../client/components/pages/searchAdmin';
+import express from 'express';
+import target from '../templates/target';
+
+
+const {REINDEX_SEARCH_SERVER} = PrivilegeType;
+
+
+const router = express.Router();
+
+/**
+ * Generates React markup for the search admin page that is rendered by the user's
+ * browser.
+ */
+router.get('/', auth.isAuthenticated, auth.isAuthorized(REINDEX_SEARCH_SERVER), (req, res, next) => {
+	try {
+		const props = generateProps(req, res);
+		const markup = ReactDOMServer.renderToString(
+			<Layout {...propHelpers.extractLayoutProps(props)}>
+				<SearchAdminPage
+					{...propHelpers.extractChildProps(props)}
+				/>
+			</Layout>
+		);
+
+		return res.send(target({
+			markup,
+			props: escapeProps(props),
+			script: '/js/searchAdmin.js',
+			title: 'Search Admin'
+		}));
+	}
+	catch (err) {
+		return next(err);
+	}
+});
+
+export default router;

--- a/test/src/api/routes/test-search.js
+++ b/test/src/api/routes/test-search.js
@@ -45,7 +45,7 @@ describe('GET /search', () => {
 		aliasData.sortName = 'Fnord';
 		await createEditionGroup();
 		// reindex elasticSearch
-		await search.generateIndex(orm);
+		await search.generateIndex(orm, 'allEntities', true);
 	});
 	after(truncateEntities);
 

--- a/test/src/server/routes/collection.js
+++ b/test/src/server/routes/collection.js
@@ -26,7 +26,7 @@ describe('POST /collection/create', () => {
 		}
 		// The `agent` now has the sessionid cookie saved, and will send it
 		// back to the server in the next request:
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection', true);
 		agent = await chai.request.agent(app);
 		await agent.get('/cb');
 	});
@@ -206,7 +206,7 @@ describe('POST collection/edit', () => {
 		const res = await agent.post('/collection/create/handler').send(data);
 		const collection = await new UserCollection({id: res.body.id}).fetch({withRelated: ['collaborators']});
 		collectionJSON = collection.toJSON();
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection', true);
 	});
 	after((done) => {
 		// Clear DB tables then close superagent server
@@ -463,7 +463,7 @@ describe('POST /collection/collectionID/delete', () => {
 		// The `agent` now has the sessionid cookie saved, and will send it
 		// back to the server in the next request:
 		agent = await chai.request.agent(app);
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection', true);
 		await agent.get('/cb');
 	});
 	after((done) => {
@@ -482,7 +482,7 @@ describe('POST /collection/collectionID/delete', () => {
 			public: true
 		};
 		const collection = await new UserCollection(collectionData).save(null, {method: 'insert'});
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection');
 		const res = await agent.post(`/collection/${collection.get('id')}/delete/handler`).send();
 		const collections = await new UserCollection().where('id', collection.get('id')).fetchAll({require: false});
 		const collectionsJSON = collections.toJSON();
@@ -500,7 +500,7 @@ describe('POST /collection/collectionID/delete', () => {
 			public: true
 		};
 		const collection = await new UserCollection(collectionData).save(null, {method: 'insert'});
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection');
 		const author1 = await createAuthor();
 		const author2 = await createAuthor();
 		await new UserCollectionItem({
@@ -534,7 +534,7 @@ describe('POST /collection/collectionID/delete', () => {
 		const collaborator1 = await createEditor();
 		const collaborator2 = await createEditor();
 		const collection = await new UserCollection(collectionData).save(null, {method: 'insert'});
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection');
 		await new UserCollectionCollaborator({
 			collaboratorId: collaborator1.get('id'),
 			collectionId: collection.get('id')
@@ -566,7 +566,7 @@ describe('POST /collection/collectionID/delete', () => {
 		};
 
 		const collection = await new UserCollection(collectionData).save(null, {method: 'insert'});
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection');
 		// here loggedInUser is neither owner nor collaborator
 		const response = await agent.post(`/collection/${collection.get('id')}/delete/handler`).send();
 		const collections = await new UserCollection().where('id', collection.get('id')).fetchAll({require: false});
@@ -587,7 +587,7 @@ describe('POST /collection/collectionID/delete', () => {
 			public: true
 		};
 		const collection = await new UserCollection(collectionData).save(null, {method: 'insert'});
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection');
 		await new UserCollectionCollaborator({
 			collaboratorId: loggedInUser.get('id'),
 			collectionId: collection.get('id')
@@ -611,7 +611,7 @@ describe('POST /collection/collectionID/delete', () => {
 			public: true
 		};
 		const collection = await new UserCollection(collectionData).save(null, {method: 'insert'});
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection');
 		const oldResult = await searchByName(orm, collectionData.name, 'Collection', 10, 0);
 		const res = await agent.post(`/collection/${collection.get('id')}/delete/handler`).send();
 		await new Promise(resolve => setTimeout(resolve, 500));
@@ -1189,7 +1189,7 @@ describe('POST /collection/collectionID/collaborator/remove', () => {
 		// The `agent` now has the sessionid cookie saved, and will send it
 		// back to the server in the next request:
 		agent = await chai.request.agent(app);
-		await generateIndex(orm);
+		await generateIndex(orm, 'Collection', true);
 		await agent.get('/cb');
 	});
 	after((done) => {

--- a/webpack.client.js
+++ b/webpack.client.js
@@ -21,7 +21,7 @@ const clientConfig = {
 	entry: {
 		adminLogs: ['./controllers/adminLogs'],
 		adminPanel: ['./controllers/admin-panel'],
-		searchAdmin: ['./controllers/admin/searchAdmin'],
+		searchAdmin: ['./controllers/admin/searchAdmin.tsx'],
 		collection: ['./controllers/collection/collection'],
 		'collection/create': ['./controllers/collection/userCollectionForm'],
 		collections: ['./controllers/collections'],

--- a/webpack.client.js
+++ b/webpack.client.js
@@ -21,6 +21,7 @@ const clientConfig = {
 	entry: {
 		adminLogs: ['./controllers/adminLogs'],
 		adminPanel: ['./controllers/admin-panel'],
+		searchAdmin: ['./controllers/admin/searchAdmin'],
 		collection: ['./controllers/collection/collection'],
 		'collection/create': ['./controllers/collection/userCollectionForm'],
 		collections: ['./controllers/collections'],


### PR DESCRIPTION
This PR fixes a few issues with search indexing:
- Allows indexing each entity type separately
  - indexing Works also indexes Authors since we index the work's authors too
- Adds an admin panel page for search with buttons to index each entity:
![image](https://github.com/metabrainz/bookbrainz-site/assets/6179856/1647b868-606a-4ec4-829b-5da3a660a2f1)
- Fetch by chunks of 50.000 entities at a time from the database, otherwise the postgres request fails with `bind message has XXXXX parameter formats but 0 parameters` when fetching aliases (maximum 65535 parameters)
- Make the search indexing file typescript, fixes some potential issues
- Misc bug fixes