### PR TITLE
fix(helpers): Replace deleted utility by lodash function

### DIFF
--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -256,7 +256,7 @@ export function checkValidTypeId(req: $Request, res: $Response, next: NextFuncti
 export function checkValidEntityType(req: $Request, res: $Response, next: NextFunction, entityType: string) {
 	const entityTypes = ENTITY_TYPES.map(entity => _.snakeCase(entity));
 	if (!_.includes(entityTypes, entityType)) {
-		return next(new error.BadRequestError(`Invalid Entity Type: ${commonUtils.snakeCaseToSentenceCase(entityType)}`, req));
+		return next(new error.BadRequestError(`Invalid Entity Type: ${_.startCase(entityType)}`, req));
 	}
 	return next();
 }


### PR DESCRIPTION
This broke in https://github.com/metabrainz/bookbrainz-site/commit/d44d67a1e4ad54302ae3f0230cd77d402d253585

Untested, but this is the same function with which all other occurrences were replaced in the above commit. Should have been the last occurrence.