### PR TITLE
BB-803: Sort author credits by their position

### DIFF
--- a/src/client/components/author-credit-display.tsx
+++ b/src/client/components/author-credit-display.tsx
@@ -16,13 +16,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import PropTypes from 'prop-types';
+import {map as _map, sortBy} from 'lodash';
+import {AuthorCreditRow} from '../entity-editor/author-credit-editor/actions';
 import React from 'react';
-import {map as _map} from 'lodash';
 
 
-function AuthorCreditDisplay({names}) {
-	const nameElements = _map(names, (name) => {
+function AuthorCreditDisplay({names}:{names:AuthorCreditRow[]}) {
+	const nameElements = _map(sortBy(names, 'position'), (name) => {
 		const authorBBID = name.authorBBID ?? name.author?.id;
 		return (
 			<span key={`author-credit-${authorBBID}`}>
@@ -42,11 +42,5 @@ function AuthorCreditDisplay({names}) {
 }
 
 AuthorCreditDisplay.displayName = 'AuthorCreditDisplay';
-AuthorCreditDisplay.propTypes = {
-	names: PropTypes.oneOfType([
-		PropTypes.array,
-		PropTypes.object
-	]).isRequired
-};
 
 export default AuthorCreditDisplay;

--- a/src/client/entity-editor/author-credit-editor/actions.ts
+++ b/src/client/entity-editor/author-credit-editor/actions.ts
@@ -47,7 +47,7 @@ export type AuthorCreditRow = {
 	author: Author,
 	authorBBID: string,
 	position: number,
-	authohrCreditID: number
+	authorCreditID: number
 };
 export type AuthorCredit = {
 	authorCount: number,


### PR DESCRIPTION
For some reason we were not sorting the Author Credit names by their position attribute, and until recently that has not been an issue.
However recently this changed and we have seen issues with the order of items, not just in ACs but also in the order of Works for example ([see forum](https://community.metabrainz.org/t/order-of-works-in-editions-is-not-static-anymore/695814/3))

Author Credits are now sorted with the stable order we are expecting.


While in there, I took the opportunity to make that file a typescript file and fixed a typo in a TS type.