### PR TITLE
Fix search entity type

### DIFF
--- a/src/common/helpers/search.ts
+++ b/src/common/helpers/search.ts
@@ -51,6 +51,7 @@ function sanitizeEntityType(type) {
 }
 
 export type IndexableEntities = EntityTypeString | 'Editor' | 'Collection' | 'Area';
+export type IndexableEntitiesOrAll = IndexableEntities | 'allEntities';
 const commonProperties = ['bbid', 'id', 'name', 'type', 'disambiguation'];
 
 const indexMappings = {
@@ -334,7 +335,7 @@ async function _processEntityListForBulk(entityList) {
 	await Promise.all(indexOperations);
 }
 
-export async function autocomplete(orm, query, type, size = 42) {
+export async function autocomplete(orm:ORM, query:string, type:IndexableEntitiesOrAll | IndexableEntities[], size = 42) {
 	let queryBody = null;
 
 	if (commonUtils.isValidBBID(query)) {

--- a/src/server/routes/search.tsx
+++ b/src/server/routes/search.tsx
@@ -105,7 +105,7 @@ router.get('/', async (req, res, next) => {
 router.get('/search', (req, res) => {
 	const {orm} = req.app.locals;
 	const query = req.query.q;
-	const type = req.query.type?.toString() || 'allEntities';
+	const type = req.query.type as search.IndexableEntitiesOrAll ?? 'allEntities';
 
 	const {size, from} = req.query;
 
@@ -120,8 +120,8 @@ router.get('/search', (req, res) => {
  */
 router.get('/autocomplete', (req, res) => {
 	const {orm} = req.app.locals;
-	const query = req.query.q;
-	const type = req.query.type?.toString() || 'allEntities';
+	const query = req.query.q.toString();
+	const type = req.query.type as search.IndexableEntitiesOrAll ?? 'allEntities';
 	const size = Number(req.query.size) || 42;
 
 	const searchPromise = search.autocomplete(orm, query, type, size);


### PR DESCRIPTION
Broke the search autocomplete endpoint in #1093  when I forgot we can use an array of types in some search endpoints, and calling `toString` on the array of types results in a comma separated joined string which is not recognized as an entity type
