### PR TITLE
Make approval of imported entities work & other improvements

### DIFF
--- a/src/client/components/pages/import-entities/author.js
+++ b/src/client/components/pages/import-entities/author.js
@@ -27,11 +27,10 @@ import ImportFooter from './footer';
 import ImportTitle from './title';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {startCase} from 'lodash';
 
 
 const {getImportUrl} = importHelper;
-const {Alert, Col, Row} = bootstrap;
+const {Col, Row} = bootstrap;
 
 
 function ImportAuthorDisplayPage({importEntity, identifierTypes}) {
@@ -56,20 +55,12 @@ function ImportAuthorDisplayPage({importEntity, identifierTypes}) {
 				urlPrefix={urlPrefix}
 			/>
 			<hr className="margin-top-d40"/>
-			<Row>
-				<Alert
-					className="text-center font-weight-bold"
-					variant="success"
-				>
-					This {startCase(importEntity.type.toLowerCase())} has been automatically added.{' '}
-					Kindly approve/discard it to help us improve our data.
-				</Alert>
-			</Row>
 			<ImportFooter
 				hasVoted={importEntity.hasVoted}
 				importUrl={urlPrefix}
 				importedAt={importEntity.importedAt}
 				source={importEntity.source}
+				type={importEntity.type}
 			/>
 		</div>
 	);

--- a/src/client/components/pages/import-entities/discard-import-entity.js
+++ b/src/client/components/pages/import-entities/discard-import-entity.js
@@ -85,7 +85,7 @@ class DiscardImportEntity extends React.Component {
 				<h1> Discard Imported Entity </h1>
 				<Row className="margin-top-2">
 					{loadingComponent}
-					<Col md={6} mdOffset={3}>
+					<Col md={{offset: 3, span: 6}}>
 						{errorComponent}
 						<Card bg="danger">
 							<Card.Header>Confirm Discard</Card.Header>
@@ -103,11 +103,11 @@ class DiscardImportEntity extends React.Component {
 								to the imported entity page.
 							</Card.Body>
 						</Card>
-						<ButtonGroup justified className="margin-top-2">
+						<ButtonGroup className="d-flex margin-top-2">
 							<Button
 								href={getImportUrl(importEntity)}
-								title="Edit"
-								variant="default"
+								title="Cancel"
+								variant="secondary"
 							>
 								Cancel
 							</Button>

--- a/src/client/components/pages/import-entities/edition-group.js
+++ b/src/client/components/pages/import-entities/edition-group.js
@@ -27,11 +27,10 @@ import ImportFooter from './footer';
 import ImportTitle from './title';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {startCase} from 'lodash';
 
 
 const {getImportUrl} = importHelper;
-const {Alert, Col, Row} = bootstrap;
+const {Col, Row} = bootstrap;
 
 
 function ImportEditionGroupDisplayPage({importEntity, identifierTypes}) {
@@ -56,20 +55,12 @@ function ImportEditionGroupDisplayPage({importEntity, identifierTypes}) {
 				urlPrefix={urlPrefix}
 			/>
 			<hr className="margin-top-d40"/>
-			<Row>
-				<Alert
-					className="text-center font-weight-bold"
-					variant="success"
-				>
-					This {startCase(importEntity.type.toLowerCase())} has been automatically added.{' '}
-					Kindly approve/discard it to help us improve our data.
-				</Alert>
-			</Row>
 			<ImportFooter
 				hasVoted={importEntity.hasVoted}
 				importUrl={urlPrefix}
 				importedAt={importEntity.importedAt}
 				source={importEntity.source}
+				type={importEntity.type}
 			/>
 		</div>
 	);

--- a/src/client/components/pages/import-entities/edition.js
+++ b/src/client/components/pages/import-entities/edition.js
@@ -27,12 +27,11 @@ import ImportFooter from './footer';
 import ImportTitle from './title';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {startCase} from 'lodash';
 
 
 const {getImportUrl} = importHelper;
 
-const {Alert, Col, Row} = bootstrap;
+const {Col, Row} = bootstrap;
 
 
 function ImportEditionDisplayPage({importEntity, identifierTypes}) {
@@ -57,20 +56,12 @@ function ImportEditionDisplayPage({importEntity, identifierTypes}) {
 				urlPrefix={urlPrefix}
 			/>
 			<hr className="margin-top-d40"/>
-			<Row>
-				<Alert
-					className="text-center font-weight-bold"
-					variant="success"
-				>
-					This {startCase(importEntity.type.toLowerCase())} has been automatically added.{' '}
-					Kindly approve/discard it to help us improve our data.
-				</Alert>
-			</Row>
 			<ImportFooter
 				hasVoted={importEntity.hasVoted}
 				importUrl={urlPrefix}
 				importedAt={importEntity.importedAt}
 				source={importEntity.source}
+				type={importEntity.type}
 			/>
 		</div>
 	);

--- a/src/client/components/pages/import-entities/footer.js
+++ b/src/client/components/pages/import-entities/footer.js
@@ -23,14 +23,15 @@ import {faCheck, faPencil, faRemove} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {startCase} from 'lodash';
 
 
 const {formatDate} = utilsHelper;
 const {
-	Button, ButtonGroup, Col, Row, Tooltip
+	Alert, Button, ButtonGroup, Col, Row, Tooltip
 } = bootstrap;
 
-function ImportFooter({importUrl, importedAt, source, hasVoted}) {
+function ImportFooter({importUrl, importedAt, source, type, hasVoted}) {
 	const tooltip = (
 		<Tooltip id="tooltip">
 		  <strong>You can only vote once to discard an import.</strong>
@@ -39,6 +40,17 @@ function ImportFooter({importUrl, importedAt, source, hasVoted}) {
 
 	return (
 		<div>
+			<Row>
+				<Col>
+					<Alert
+						className="text-center font-weight-bold"
+						variant="success"
+					>
+						This {startCase(type.toLowerCase())} has been automatically added.{' '}
+						Kindly approve/discard it to help us improve our data.
+					</Alert>
+				</Col>
+			</Row>
 			<Row>
 				<Col className="text-center" md={{offset: 3, span: 6}}>
 					<ButtonGroup>
@@ -86,7 +98,8 @@ ImportFooter.propTypes = {
 	hasVoted: PropTypes.bool.isRequired,
 	importUrl: PropTypes.string.isRequired,
 	importedAt: PropTypes.string.isRequired,
-	source: PropTypes.string.isRequired
+	source: PropTypes.string.isRequired,
+	type: PropTypes.string.isRequired
 };
 
 export default ImportFooter;

--- a/src/client/components/pages/import-entities/footer.js
+++ b/src/client/components/pages/import-entities/footer.js
@@ -40,8 +40,8 @@ function ImportFooter({importUrl, importedAt, source, hasVoted}) {
 	return (
 		<div>
 			<Row>
-				<Col md={6} mdOffset={3}>
-					<ButtonGroup justified>
+				<Col className="text-center" md={{offset: 3, span: 6}}>
+					<ButtonGroup>
 						<Button
 							href={`${importUrl}/approve`}
 							title="Approve"

--- a/src/client/components/pages/import-entities/publisher.js
+++ b/src/client/components/pages/import-entities/publisher.js
@@ -27,12 +27,11 @@ import ImportTitle from './title';
 import PropTypes from 'prop-types';
 import {PublisherAttributes} from '../entities/publisher';
 import React from 'react';
-import {startCase} from 'lodash';
 
 
 const {getImportUrl} = importHelper;
 
-const {Alert, Col, Row} = bootstrap;
+const {Col, Row} = bootstrap;
 
 
 function ImportPublisherDisplayPage({importEntity, identifierTypes}) {
@@ -57,20 +56,12 @@ function ImportPublisherDisplayPage({importEntity, identifierTypes}) {
 				urlPrefix={urlPrefix}
 			/>
 			<hr className="margin-top-d40"/>
-			<Row>
-				<Alert
-					className="text-center font-weight-bold"
-					variant="success"
-				>
-					This {startCase(importEntity.type.toLowerCase())} has been automatically added.{' '}
-					Kindly approve/discard it to help us improve our data.
-				</Alert>
-			</Row>
 			<ImportFooter
 				hasVoted={importEntity.hasVoted}
 				importUrl={urlPrefix}
 				importedAt={importEntity.importedAt}
 				source={importEntity.source}
+				type={importEntity.type}
 			/>
 		</div>
 	);

--- a/src/client/components/pages/import-entities/work.js
+++ b/src/client/components/pages/import-entities/work.js
@@ -27,11 +27,10 @@ import ImportTitle from './title';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {WorkAttributes} from '../entities/work';
-import {startCase} from 'lodash';
 
 
 const {getImportUrl} = importHelper;
-const {Alert, Col, Row} = bootstrap;
+const {Col, Row} = bootstrap;
 
 
 function ImportWorkDisplayPage({importEntity, identifierTypes}) {
@@ -56,20 +55,12 @@ function ImportWorkDisplayPage({importEntity, identifierTypes}) {
 				urlPrefix={urlPrefix}
 			/>
 			<hr className="margin-top-d40"/>
-			<Row>
-				<Alert
-					className="text-center font-weight-bold"
-					variant="success"
-				>
-					This {startCase(importEntity.type.toLowerCase())} has been automatically added.{' '}
-					Kindly approve/discard it to help us improve our data.
-				</Alert>
-			</Row>
 			<ImportFooter
 				hasVoted={importEntity.hasVoted}
 				importUrl={urlPrefix}
 				importedAt={importEntity.importedAt}
 				source={importEntity.source}
+				type={importEntity.type}
 			/>
 		</div>
 	);

--- a/src/client/components/pages/parts/recent-import-results.js
+++ b/src/client/components/pages/parts/recent-import-results.js
@@ -39,8 +39,8 @@ function RecentImportsTable(props) {
 			<div> <h2 className="text-center">Click to review them!</h2> </div>
 			<Table
 				bordered
-				size='sm'
 				striped
+				size="sm"
 			>
 				<thead>
 					<tr>

--- a/src/client/components/pages/parts/recent-import-results.js
+++ b/src/client/components/pages/parts/recent-import-results.js
@@ -39,7 +39,7 @@ function RecentImportsTable(props) {
 			<div> <h2 className="text-center">Click to review them!</h2> </div>
 			<Table
 				bordered
-				condensed
+				size='sm'
 				striped
 			>
 				<thead>

--- a/src/client/controllers/import-entity/discard-import-entity.js
+++ b/src/client/controllers/import-entity/discard-import-entity.js
@@ -36,3 +36,13 @@ const markup = (
 );
 
 ReactDOM.hydrate(markup, document.getElementById('target'));
+
+/*
+ * As we are not exporting a component,
+ * we cannot use the react-hot-loader module wrapper,
+ * but instead directly use webpack Hot Module Replacement API
+ */
+
+if (module.hot) {
+	module.hot.accept();
+}

--- a/src/client/controllers/import-entity/import-entity.js
+++ b/src/client/controllers/import-entity/import-entity.js
@@ -45,3 +45,13 @@ const markup = (
 
 
 ReactDOM.hydrate(markup, document.getElementById('target'));
+
+/*
+ * As we are not exporting a component,
+ * we cannot use the react-hot-loader module wrapper,
+ * but instead directly use webpack Hot Module Replacement API
+ */
+
+if (module.hot) {
+	module.hot.accept();
+}

--- a/src/client/controllers/import-entity/recent-imports.js
+++ b/src/client/controllers/import-entity/recent-imports.js
@@ -35,3 +35,13 @@ const markup = (
 );
 
 ReactDOM.hydrate(markup, document.getElementById('target'));
+
+/*
+ * As we are not exporting a component,
+ * we cannot use the react-hot-loader module wrapper,
+ * but instead directly use webpack Hot Module Replacement API
+ */
+
+if (module.hot) {
+	module.hot.accept();
+}

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -1067,7 +1067,7 @@ export async function processSingleEntity(formBody, JSONEntity, reqSession,
 	entityType, orm:any, editorJSON, derivedProps, isMergeOperation, transacting):Promise<any> {
 	const {Entity, Revision} = orm;
 	// Sanitize nameSection inputs
-	let body = sanitizeBody(formBody);
+	const body = sanitizeBody(formBody);
 	let currentEntity: {
 		aliasSet: {id: number} | null | undefined,
 		annotation: {id: number} | null | undefined,

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -1066,6 +1066,7 @@ function sanitizeBody(body:any) {
 export async function processSingleEntity(formBody, JSONEntity, reqSession,
 	entityType, orm:any, editorJSON, derivedProps, isMergeOperation, transacting):Promise<any> {
 	const {Entity, Revision} = orm;
+	// Sanitize nameSection inputs
 	let body = sanitizeBody(formBody);
 	let currentEntity: {
 		aliasSet: {id: number} | null | undefined,
@@ -1079,8 +1080,6 @@ export async function processSingleEntity(formBody, JSONEntity, reqSession,
 	try {
 		// Determine if a new entity is being created
 		const isNew = !currentEntity;
-		// sanitize namesection inputs
-		body = sanitizeBody(body);
 		if (isNew) {
 			const newEntity = await new Entity({type: entityType})
 				.save(null, {transacting});

--- a/src/server/routes/import-entity/import-routes.tsx
+++ b/src/server/routes/import-entity/import-routes.tsx
@@ -145,8 +145,12 @@ export async function approveImportEntity(req, res: Response) {
 export function editImportEntity(req: Request, res: Response) {
 	const {importEntity} = res.locals;
 	const initialState = entityToFormState(importEntity);
+	const additionalProps: Record<string, any> = {};
+	if (res.locals.genders) {
+		additionalProps.genderOptions = res.locals.genders;
+	}
 	const importEntityProps = generateImportEntityProps(
-		req, res, initialState, {}
+		req, res, initialState, additionalProps
 	);
 	const {markup, props} = entityEditorMarkup(importEntityProps);
 	return res.send(target({

--- a/src/server/routes/import-entity/import-routes.tsx
+++ b/src/server/routes/import-entity/import-routes.tsx
@@ -121,22 +121,23 @@ export async function approveImportEntity(req, res: Response) {
 	const {orm} = res.app.locals;
 	const editorId = req.session.passport.user.id;
 	const {importEntity} = res.locals;
-	const entity = await orm.bookshelf.transaction((transacting) =>
+	const savedEntityModel = await orm.bookshelf.transaction((transacting) =>
 		orm.func.imports.approveImport(
 			{editorId, importEntity, orm, transacting}
 		));
-	const entityUrl = getEntityUrl(entity);
+	const entityJSON = savedEntityModel.toJSON();
+	const entityUrl = getEntityUrl(entityJSON);
 
 	/* Add code to remove import and add the newly created entity to the elastic
 		search index and remove delete import */
 
 	// Update editor achievement
-	entity.alert = (await achievement.processEdit(
-		orm, editorId, entity.revisionId
+	entityJSON.alert = (await achievement.processEdit(
+		orm, editorId, entityJSON.revisionId
 	)).alert;
 
 	// Cleanup search indexing
-	search.indexEntity(entity);
+	search.indexEntity(savedEntityModel);
 	// Todo: Add functionality to remove imports from ES index upon deletion
 
 	res.redirect(entityUrl);
@@ -157,7 +158,7 @@ export function editImportEntity(req: Request, res: Response) {
 		markup,
 		props: escapeProps(props),
 		script: '/js/entity-editor.js',
-		title: 'Edit Work Import'
+		title: 'Edit Import'
 	}));
 }
 
@@ -177,7 +178,7 @@ export async function approveImportPostEditing(req, res) {
 
 	const entityData = transformForm[type](formData);
 
-	const entity = await orm.bookshelf.transaction(async (transacting) => {
+	const savedEntityModel = await orm.bookshelf.transaction(async (transacting) => {
 		await orm.func.imports.deleteImport(
 			transacting, importId
 		);
@@ -185,15 +186,16 @@ export async function approveImportPostEditing(req, res) {
 			{editorId, entityData, orm, transacting}
 		);
 	});
+	const entityJSON = savedEntityModel.toJSON();
 
 	// Update editor achievement
-	entity.alert = (await achievement.processEdit(
-		orm, editorId, entity.revisionId
+	entityJSON.alert = (await achievement.processEdit(
+		orm, editorId, entityJSON.revisionId
 	)).alert;
 
 	// Cleanup search indexing
-	await search.indexEntity(entity);
+	await search.indexEntity(savedEntityModel);
 	// To-do: Add code to remove importEntity from the search index
 
-	res.send(entity);
+	res.send(entityJSON);
 }

--- a/src/server/routes/import-entity/transform-import.js
+++ b/src/server/routes/import-entity/transform-import.js
@@ -46,9 +46,9 @@ export function areaToOption(area) {
 
 function getAliasEditor(importEntity) {
 	const aliases = importEntity.aliasSet ?
-		importEntity.aliasSet.aliases.map(({language, ...rest}) => ({
-			language: language.id,
-			...rest
+		importEntity.aliasSet.aliases.map(({languageId, ...rest}) => ({
+			...rest,
+			language: languageId
 		})) : [];
 
 	const {defaultAlias} = importEntity;


### PR DESCRIPTION
Continuation of #1096

- Approval of import is now working thanks to https://github.com/metabrainz/bookbrainz-data-js/pull/319
- Loads author genders to make the entity editor load for the "Edit & Approve" action
  (Similar adjustments might be necessary for the other entity types, but currently we are only importing authors)
- Fixes a search indexing related type error (but search indexing still has not been fixed, as we agreed)
- Fixes HMR for the import pages
- More Bootstrap migration changes and layout fixes

The changes in 14340385d75426fd45d7bfe8d89b36cd7f487298 and f289c7189f6e58f0c40c2f57cda2f3f485cabb6b may have not been relevant in the end, but I spotted these inconsistencies before I fixed the real issues in the ORM.