### PR TITLE
chore: Allow annotation revision ids to be null (rebased)

### DIFF
--- a/sql/migrations/2024-07-17-annotation-revision-id/down.sql
+++ b/sql/migrations/2024-07-17-annotation-revision-id/down.sql
@@ -1,0 +1,6 @@
+
+BEGIN;
+
+ALTER TABLE bookbrainz.annotation ALTER COLUMN last_revision_id SET NOT NULL;
+
+COMMIT;

--- a/sql/migrations/2024-07-17-annotation-revision-id/up.sql
+++ b/sql/migrations/2024-07-17-annotation-revision-id/up.sql
@@ -1,0 +1,7 @@
+-- Allow NULL values for annotation.last_revision_id (foreing key to revision table)
+-- so that we can use annotations for entities pending import, which do not have revisions.
+BEGIN;
+
+ALTER TABLE bookbrainz.annotation ALTER COLUMN last_revision_id DROP NOT NULL;
+
+COMMIT;

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -450,7 +450,7 @@ ALTER TABLE bookbrainz.work_revision ADD FOREIGN KEY (data_id) REFERENCES bookbr
 CREATE TABLE bookbrainz.annotation (
 	id SERIAL PRIMARY KEY,
 	content TEXT NOT NULL,
-	last_revision_id INT NOT NULL
+	last_revision_id INT
 );
 ALTER TABLE bookbrainz.annotation ADD FOREIGN KEY (last_revision_id) REFERENCES bookbrainz.revision (id);
 ALTER TABLE bookbrainz.author_data ADD FOREIGN KEY (annotation_id) REFERENCES bookbrainz.annotation (id);

--- a/src/client/components/pages/entities/annotation.js
+++ b/src/client/components/pages/entities/annotation.js
@@ -54,21 +54,47 @@ class EntityAnnotation extends React.Component {
 		if (!annotation || !annotation.content) {
 			return null;
 		}
-		const lastModifiedDate = new Date(annotation.lastRevision.createdAt);
+		const lastModifiedDate =
+			annotation.lastRevision?.createdAt &&
+			new Date(annotation.lastRevision.createdAt);
 		return (
 			<Row>
 				<Col lg={12}>
 					<h2>Annotation</h2>
 					<Collapse in={this.state.open}>
-						<pre className="annotation-content" ref={this.annotationContentRef} >{stringToHTMLWithLinks(annotation.content)}</pre>
+						<pre
+							className="annotation-content"
+							ref={this.annotationContentRef}
+						>
+							{stringToHTMLWithLinks(annotation.content)}
+						</pre>
 					</Collapse>
-					{this.state.showButton &&
-					<Button variant="link" onClick={this.handleToggleCollapse}>
-						Show {this.state.open ? 'less' : 'more…'}
-					</Button>}
-					<p className="text-muted">Last modified: <span title={formatDate(lastModifiedDate, true)}>{formatDate(lastModifiedDate)}</span>
-						<span className="small"> (revision <a href={`/revision/${annotation.lastRevisionId}`}>#{annotation.lastRevisionId}</a>)</span>
-					</p>
+					{this.state.showButton && (
+						<Button
+							variant="link"
+							onClick={this.handleToggleCollapse}
+						>
+							Show {this.state.open ? 'less' : 'more…'}
+						</Button>
+					)}
+					{lastModifiedDate && (
+						<p className="text-muted">
+							Last modified:{' '}
+							<span title={formatDate(lastModifiedDate, true)}>
+								{formatDate(lastModifiedDate)}
+							</span>
+							<span className="small">
+								{' '}
+								(revision{' '}
+								<a
+									href={`/revision/${annotation.lastRevisionId}`}
+								>
+									#{annotation.lastRevisionId}
+								</a>
+								)
+							</span>
+						</p>
+					)}
 				</Col>
 			</Row>
 		);

--- a/src/client/entity-editor/annotation-section/annotation-section.js
+++ b/src/client/entity-editor/annotation-section/annotation-section.js
@@ -32,7 +32,7 @@ import {faQuestionCircle} from '@fortawesome/free-solid-svg-icons';
  *
  * @param {Object} props - The properties passed to the component.
  * @param {Object} props.annotation - The annotation object containing
- *        its content and lastRevision info
+ *        its content and lastRevision info. lastRevision can be undefined
  * @param {Function} props.onAnnotationChange - A function to be called when the
  *        annotation is changed.
  * @returns {ReactElement} React element containing the rendered
@@ -84,7 +84,7 @@ function AnnotationSection({
 						/>
 					</Form.Group>
 					{
-						annotation && annotation.lastRevision &&
+						annotation?.lastRevision?.createdAt &&
 						<p className="small text-muted">Last modified: {formatDate(new Date(annotation.lastRevision.createdAt))}</p>
 					}
 					<p className="text-muted">


### PR DESCRIPTION
Rebased version of #1105 

Also see https://github.com/metabrainz/bookbrainz-data-js/pull/320
 
For imported entities, we do not keep a history of all modifications.
As a result, editing import_* entities is not tied to any revisions.

This is an issue for annotations, whose `last_revision_id` column does not currently accept NULL values.

These small changes allow entering a row in the `annotation`table with `last_revision_id = NULL`, and ensure the website does not trip up if the value is missing (it is used to display the last modification time and link to the revision)

Before: 
<img width="313" alt="image" src="https://github.com/user-attachments/assets/541601d9-cc7a-4c2e-b825-6d615ba98202">

After:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/dd3996ce-b5f4-4ce7-a0e0-ff6826e4bafc">
