### PR TITLE
Display and preserve annotation of imported entities

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,7 +204,6 @@ const stylisticIssuesRules = {
 			properties: 'always'
 		}
 	],
-	'comma-dangle': ERROR,
 	'comma-spacing': ERROR,
 	'comma-style': ERROR,
 	'computed-property-spacing': ERROR,

--- a/sql/migrations/import/up.sql
+++ b/sql/migrations/import/up.sql
@@ -122,6 +122,7 @@ CREATE OR REPLACE VIEW bookbrainz.edition_import AS
     SELECT
         import.id AS import_id,
         edition_data.id as data_id,
+        edition_data.annotation_id,
         edition_data.disambiguation_id,
         alias_set.default_alias_id,
         edition_data.width,
@@ -146,6 +147,7 @@ CREATE OR REPLACE VIEW bookbrainz.publisher_import AS
     SELECT
         import.id AS import_id,
         publisher_data.id as data_id,
+        publisher_data.annotation_id,
         publisher_data.disambiguation_id,
         alias_set.default_alias_id,
         publisher_data.begin_year,
@@ -171,6 +173,7 @@ CREATE OR REPLACE VIEW bookbrainz.edition_group_import AS
     SELECT
         import.id AS import_id,
         edition_group_data.id as data_id,
+        edition_group_data.annotation_id,
         edition_group_data.disambiguation_id,
         alias_set.default_alias_id,
         edition_group_data.type_id,

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -983,6 +983,7 @@ CREATE VIEW bookbrainz.edition_import AS
 	SELECT
 		import.id AS import_id,
 		edition_data.id as data_id,
+		edition_data.annotation_id,
 		edition_data.disambiguation_id,
 		alias_set.default_alias_id,
 		edition_data.width,
@@ -1007,6 +1008,7 @@ CREATE VIEW bookbrainz.publisher_import AS
 	SELECT
 		import.id AS import_id,
 		publisher_data.id as data_id,
+		publisher_data.annotation_id,
 		publisher_data.disambiguation_id,
 		alias_set.default_alias_id,
 		publisher_data.begin_year,
@@ -1032,6 +1034,7 @@ CREATE VIEW bookbrainz.edition_group_import AS
 	SELECT
 		import.id AS import_id,
 		edition_group_data.id as data_id,
+		edition_group_data.annotation_id,
 		edition_group_data.disambiguation_id,
 		alias_set.default_alias_id,
 		edition_group_data.type_id,

--- a/src/client/components/pages/import-entities/author.js
+++ b/src/client/components/pages/import-entities/author.js
@@ -21,6 +21,7 @@ import * as importHelper from '../../../helpers/import-entity';
 
 import {AuthorAttributes} from '../entities/author';
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -49,6 +50,7 @@ function ImportAuthorDisplayPage({importEntity, identifierTypes}) {
 					<AuthorAttributes author={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/components/pages/import-entities/edition-group.js
+++ b/src/client/components/pages/import-entities/edition-group.js
@@ -21,6 +21,7 @@ import * as importHelper from '../../../helpers/import-entity';
 
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
 import {EditionGroupAttributes} from '../entities/edition-group';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -49,6 +50,7 @@ function ImportEditionGroupDisplayPage({importEntity, identifierTypes}) {
 					<EditionGroupAttributes editionGroup={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/components/pages/import-entities/edition.js
+++ b/src/client/components/pages/import-entities/edition.js
@@ -21,6 +21,7 @@ import * as importHelper from '../../../helpers/import-entity';
 
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
 import {EditionAttributes} from '../entities/edition';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -50,6 +51,7 @@ function ImportEditionDisplayPage({importEntity, identifierTypes}) {
 					<EditionAttributes edition={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/components/pages/import-entities/publisher.js
+++ b/src/client/components/pages/import-entities/publisher.js
@@ -20,6 +20,7 @@ import * as bootstrap from 'react-bootstrap';
 import * as importHelper from '../../../helpers/import-entity';
 
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -50,6 +51,7 @@ function ImportPublisherDisplayPage({importEntity, identifierTypes}) {
 					<PublisherAttributes publisher={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/components/pages/import-entities/work.js
+++ b/src/client/components/pages/import-entities/work.js
@@ -20,6 +20,7 @@ import * as bootstrap from 'react-bootstrap';
 import * as importHelper from '../../../helpers/import-entity';
 
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -49,6 +50,7 @@ function ImportWorkDisplayPage({importEntity, identifierTypes}) {
 					<WorkAttributes work={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/helpers/import-entity.js
+++ b/src/client/helpers/import-entity.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {get} from 'lodash';
+import {get, kebabCase} from 'lodash';
 
 
 export function getImportLabel(importEntity) {
@@ -24,13 +24,13 @@ export function getImportLabel(importEntity) {
 }
 
 export function getImportUrl(importEntity) {
-	const type = importEntity.type.toLowerCase();
+	const type = kebabCase(importEntity.type);
 	const id = importEntity.importId;
 	return `/imports/${type}/${id}`;
 }
 
 export function getImportDiscardUrl(importEntity) {
-	const type = importEntity.type.toLowerCase();
+	const type = kebabCase(importEntity.type);
 	const id = importEntity.importId;
 	return `/imports/${type}/${id}/discard/handler`;
 }

--- a/src/server/helpers/importEntityRouteUtils.ts
+++ b/src/server/helpers/importEntityRouteUtils.ts
@@ -19,9 +19,9 @@
 // @flow
 
 import * as utils from './utils';
+import {camelCase, kebabCase, partialRight} from 'lodash';
 import type express from 'express';
 import {generateProps} from './props';
-import {partialRight} from 'lodash';
 
 
 /**
@@ -39,7 +39,7 @@ export function generateImportEntityProps(
 ) {
 	const {importEntity} = res.locals;
 	const {type: importEntityName} = importEntity;
-	const importEntityType = importEntityName.toLowerCase();
+	const importEntityType = camelCase(importEntityName);
 
 	const getFilteredIdentifierTypes =
 		partialRight(utils.filterIdentifierTypesByEntity, importEntity);
@@ -48,7 +48,7 @@ export function generateImportEntityProps(
 	);
 
 	const submissionUrl =
-		`/imports/${importEntityType}/${importEntity.importId}/edit/approve`;
+		`/imports/${kebabCase(importEntityType)}/${importEntity.importId}/edit/approve`;
 
 	const props = Object.assign({
 		entityType: importEntityType,

--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -328,6 +328,7 @@ export function makeEntityLoader(modelName: string, additionalRels: Array<string
 export function makeImportLoader(modelName, additionalRels, errMessage) {
 	const relations = [
 		'aliasSet.aliases.language',
+		'annotation',
 		'defaultAlias',
 		'disambiguation',
 		'identifierSet.identifiers.type'

--- a/src/server/routes/import-entity/edition-group.js
+++ b/src/server/routes/import-entity/edition-group.js
@@ -32,9 +32,10 @@ router.param(
 		'EditionGroupImport',
 		[
 			'editionGroupType',
-			'editions.defaultAlias',
-			'editions.disambiguation',
-			'editions.releaseEventSet.releaseEvents'
+			// TODO: Reenable edition rels once imports have BBIDs
+			// 'editions.defaultAlias',
+			// 'editions.disambiguation',
+			// 'editions.releaseEventSet.releaseEvents'
 		],
 		'Edition Group Import not found'
 	)

--- a/src/server/routes/import-entity/import-routes.tsx
+++ b/src/server/routes/import-entity/import-routes.tsx
@@ -169,7 +169,7 @@ export async function approveImportPostEditing(req, res) {
 	const {importId, type} = importEntity;
 	const formData = req.body;
 
-	const validateForm = getValidator(type.toLowerCase());
+	const validateForm = getValidator(type);
 
 	if (!validateForm(formData)) {
 		const err = new error.FormSubmissionError();

--- a/src/server/routes/import-entity/transform-form.js
+++ b/src/server/routes/import-entity/transform-form.js
@@ -27,6 +27,7 @@ export function formToAuthorState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		beginAreaId: data.authorSection.beginArea &&
 			data.authorSection.beginArea.id,
 		beginDate: data.authorSection.beginDate,
@@ -55,6 +56,7 @@ export function formToEditionState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		depth: data.editionSection.depth &&
 			parseInt(data.editionSection.depth, 10),
 		disambiguation: data.nameSection.disambiguation,
@@ -88,6 +90,7 @@ export function formToEditionGroupState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		disambiguation: data.nameSection.disambiguation,
 		identifiers,
 		note: data.submissionSection.note,
@@ -102,6 +105,7 @@ export function formToPublisherState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		areaId: data.publisherSection.area && data.publisherSection.area.id,
 		beginDate: data.publisherSection.beginDate,
 		disambiguation: data.nameSection.disambiguation,
@@ -122,6 +126,7 @@ export function formToWorkState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		disambiguation: data.nameSection.disambiguation,
 		identifiers,
 		languages,

--- a/src/server/routes/import-entity/transform-import.js
+++ b/src/server/routes/import-entity/transform-import.js
@@ -184,6 +184,7 @@ export function entityToFormState(importEntity) {
 	const entitySection = `${importEntity.type.toLowerCase()}Section`;
 	return {
 		aliasEditor: getAliasEditor(importEntity),
+		annotationSection: importEntity.annotation ?? {},
 		buttonBar: getButtonBar(importEntity),
 		[entitySection]: entitySectionMap[importEntity.type](importEntity),
 		identifierEditor: getIdentifierEditor(importEntity),

--- a/src/server/routes/import-entity/transform-import.js
+++ b/src/server/routes/import-entity/transform-import.js
@@ -28,7 +28,7 @@
 	the form layout as described in the `client/entity-editor`
 */
 
-import {isEmpty, isNull} from 'lodash';
+import {camelCase, isEmpty, isNull} from 'lodash';
 
 
 export function areaToOption(area) {
@@ -181,7 +181,7 @@ export const entitySectionMap = {
 };
 
 export function entityToFormState(importEntity) {
-	const entitySection = `${importEntity.type.toLowerCase()}Section`;
+	const entitySection = `${camelCase(importEntity.type)}Section`;
 	return {
 		aliasEditor: getAliasEditor(importEntity),
 		annotationSection: importEntity.annotation ?? {},


### PR DESCRIPTION
Display annotations for all types of imported entities and preserve the annotation during the whole "Edit & Approve" process.
The corresponding changes for the "Approve" action are in https://github.com/metabrainz/bookbrainz-data-js/pull/321.