### PR TITLE
Support series imports & Fix edition imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,7 +204,6 @@ const stylisticIssuesRules = {
 			properties: 'always'
 		}
 	],
-	'comma-dangle': ERROR,
 	'comma-spacing': ERROR,
 	'comma-style': ERROR,
 	'computed-property-spacing': ERROR,

--- a/sql/migrations/import/up.sql
+++ b/sql/migrations/import/up.sql
@@ -122,6 +122,7 @@ CREATE OR REPLACE VIEW bookbrainz.edition_import AS
     SELECT
         import.id AS import_id,
         edition_data.id as data_id,
+        edition_data.annotation_id,
         edition_data.disambiguation_id,
         alias_set.default_alias_id,
         edition_data.width,
@@ -146,6 +147,7 @@ CREATE OR REPLACE VIEW bookbrainz.publisher_import AS
     SELECT
         import.id AS import_id,
         publisher_data.id as data_id,
+        publisher_data.annotation_id,
         publisher_data.disambiguation_id,
         alias_set.default_alias_id,
         publisher_data.begin_year,
@@ -171,6 +173,7 @@ CREATE OR REPLACE VIEW bookbrainz.edition_group_import AS
     SELECT
         import.id AS import_id,
         edition_group_data.id as data_id,
+        edition_group_data.annotation_id,
         edition_group_data.disambiguation_id,
         alias_set.default_alias_id,
         edition_group_data.type_id,

--- a/sql/migrations/import/up.sql
+++ b/sql/migrations/import/up.sql
@@ -137,7 +137,8 @@ CREATE OR REPLACE VIEW bookbrainz.edition_import AS
         import.type,
         edition_data.language_set_id,
         edition_data.release_event_set_id,
-        edition_data.edition_group_bbid
+        edition_data.edition_group_bbid,
+        edition_data.author_credit_id
     FROM bookbrainz.import import
     LEFT JOIN bookbrainz.edition_import_header edition_import_header ON import.id = edition_import_header.import_id
     LEFT JOIN bookbrainz.edition_data edition_data ON edition_import_header.data_id = edition_data.id
@@ -180,7 +181,8 @@ CREATE OR REPLACE VIEW bookbrainz.edition_group_import AS
         edition_group_data.type_id,
         edition_group_data.alias_set_id,
         edition_group_data.identifier_set_id,
-        import.type
+        import.type,
+        edition_group_data.author_credit_id
     FROM bookbrainz.import import
     LEFT JOIN bookbrainz.edition_group_import_header edition_group_import_header ON import.id = edition_group_import_header.import_id
     LEFT JOIN bookbrainz.edition_group_data edition_group_data ON edition_group_import_header.data_id = edition_group_data.id

--- a/sql/migrations/import/up.sql
+++ b/sql/migrations/import/up.sql
@@ -193,6 +193,7 @@ CREATE OR REPLACE VIEW bookbrainz.series_import AS
         series_data.annotation_id,
         series_data.disambiguation_id,
         alias_set.default_alias_id,
+		series_data.entity_type,
         series_data.ordering_type_id,
         series_data.alias_set_id,
         series_data.identifier_set_id,

--- a/sql/migrations/import/up.sql
+++ b/sql/migrations/import/up.sql
@@ -136,7 +136,8 @@ CREATE OR REPLACE VIEW bookbrainz.edition_import AS
         edition_data.identifier_set_id,
         import.type,
         edition_data.language_set_id,
-        edition_data.release_event_set_id
+        edition_data.release_event_set_id,
+        edition_data.edition_group_bbid
     FROM bookbrainz.import import
     LEFT JOIN bookbrainz.edition_import_header edition_import_header ON import.id = edition_import_header.import_id
     LEFT JOIN bookbrainz.edition_data edition_data ON edition_import_header.data_id = edition_data.id

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -1054,6 +1054,7 @@ CREATE VIEW bookbrainz.series_import AS
 		series_data.annotation_id,
 		series_data.disambiguation_id,
 		alias_set.default_alias_id,
+		series_data.entity_type,
 		series_data.ordering_type_id,
 		series_data.alias_set_id,
 		series_data.identifier_set_id,

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -998,7 +998,8 @@ CREATE VIEW bookbrainz.edition_import AS
 		import.type,
 		edition_data.language_set_id,
 		edition_data.release_event_set_id,
-		edition_data.edition_group_bbid
+		edition_data.edition_group_bbid,
+		edition_data.author_credit_id
 	FROM bookbrainz.import import
 	LEFT JOIN bookbrainz.edition_import_header edition_import_header ON import.id = edition_import_header.import_id
 	LEFT JOIN bookbrainz.edition_data edition_data ON edition_import_header.data_id = edition_data.id
@@ -1041,7 +1042,8 @@ CREATE VIEW bookbrainz.edition_group_import AS
 		edition_group_data.type_id,
 		edition_group_data.alias_set_id,
 		edition_group_data.identifier_set_id,
-		import.type
+		import.type,
+		edition_group_data.author_credit_id
 	FROM bookbrainz.import import
 	LEFT JOIN bookbrainz.edition_group_import_header edition_group_import_header ON import.id = edition_group_import_header.import_id
 	LEFT JOIN bookbrainz.edition_group_data edition_group_data ON edition_group_import_header.data_id = edition_group_data.id

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -983,6 +983,7 @@ CREATE VIEW bookbrainz.edition_import AS
 	SELECT
 		import.id AS import_id,
 		edition_data.id as data_id,
+		edition_data.annotation_id,
 		edition_data.disambiguation_id,
 		alias_set.default_alias_id,
 		edition_data.width,
@@ -1007,6 +1008,7 @@ CREATE VIEW bookbrainz.publisher_import AS
 	SELECT
 		import.id AS import_id,
 		publisher_data.id as data_id,
+		publisher_data.annotation_id,
 		publisher_data.disambiguation_id,
 		alias_set.default_alias_id,
 		publisher_data.begin_year,
@@ -1032,6 +1034,7 @@ CREATE VIEW bookbrainz.edition_group_import AS
 	SELECT
 		import.id AS import_id,
 		edition_group_data.id as data_id,
+		edition_group_data.annotation_id,
 		edition_group_data.disambiguation_id,
 		alias_set.default_alias_id,
 		edition_group_data.type_id,

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -997,7 +997,8 @@ CREATE VIEW bookbrainz.edition_import AS
 		edition_data.identifier_set_id,
 		import.type,
 		edition_data.language_set_id,
-		edition_data.release_event_set_id
+		edition_data.release_event_set_id,
+		edition_data.edition_group_bbid
 	FROM bookbrainz.import import
 	LEFT JOIN bookbrainz.edition_import_header edition_import_header ON import.id = edition_import_header.import_id
 	LEFT JOIN bookbrainz.edition_data edition_data ON edition_import_header.data_id = edition_data.id

--- a/src/client/components/pages/entities/series.js
+++ b/src/client/components/pages/entities/series.js
@@ -67,7 +67,7 @@ export function SeriesAttributes({series}) {
 				<Col lg={2}>
 					<dl>
 						<dt>Total Items</dt>
-						<dd>{series.seriesItems.length}</dd>
+						<dd>{series.seriesItems?.length ?? 0}</dd>
 					</dl>
 				</Col>
 				<Col lg={3}>

--- a/src/client/components/pages/entities/series.js
+++ b/src/client/components/pages/entities/series.js
@@ -36,7 +36,7 @@ import WikipediaExtract from './wikipedia-extract';
 const {deletedEntityMessage, getEntityUrl, ENTITY_TYPE_ICONS, getSortNameOfDefaultAlias} = entityHelper;
 const {Col, Row} = bootstrap;
 
-function SeriesAttributes({series}) {
+export function SeriesAttributes({series}) {
 	if (series.deleted) {
 		return deletedEntityMessage;
 	}

--- a/src/client/components/pages/import-entities/author.js
+++ b/src/client/components/pages/import-entities/author.js
@@ -21,6 +21,7 @@ import * as importHelper from '../../../helpers/import-entity';
 
 import {AuthorAttributes} from '../entities/author';
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -49,6 +50,7 @@ function ImportAuthorDisplayPage({importEntity, identifierTypes}) {
 					<AuthorAttributes author={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/components/pages/import-entities/edition-group.js
+++ b/src/client/components/pages/import-entities/edition-group.js
@@ -21,6 +21,7 @@ import * as importHelper from '../../../helpers/import-entity';
 
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
 import {EditionGroupAttributes} from '../entities/edition-group';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -49,6 +50,7 @@ function ImportEditionGroupDisplayPage({importEntity, identifierTypes}) {
 					<EditionGroupAttributes editionGroup={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/components/pages/import-entities/edition.js
+++ b/src/client/components/pages/import-entities/edition.js
@@ -21,6 +21,7 @@ import * as importHelper from '../../../helpers/import-entity';
 
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
 import {EditionAttributes} from '../entities/edition';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -50,6 +51,7 @@ function ImportEditionDisplayPage({importEntity, identifierTypes}) {
 					<EditionAttributes edition={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/components/pages/import-entities/index.js
+++ b/src/client/components/pages/import-entities/index.js
@@ -21,6 +21,7 @@ import DiscardImportEntityPage from './discard-import-entity';
 import Edition from './edition';
 import EditionGroup from './edition-group';
 import Publisher from './publisher';
+import Series from './series';
 import Work from './work';
 
 
@@ -30,6 +31,7 @@ const importEntityPages = {
 	Edition,
 	EditionGroup,
 	Publisher,
+	Series,
 	Work
 };
 

--- a/src/client/components/pages/import-entities/publisher.js
+++ b/src/client/components/pages/import-entities/publisher.js
@@ -20,6 +20,7 @@ import * as bootstrap from 'react-bootstrap';
 import * as importHelper from '../../../helpers/import-entity';
 
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -50,6 +51,7 @@ function ImportPublisherDisplayPage({importEntity, identifierTypes}) {
 					<PublisherAttributes publisher={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/components/pages/import-entities/series.js
+++ b/src/client/components/pages/import-entities/series.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018  Shivam Tripathi
+ *               2024  David Kellner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as bootstrap from 'react-bootstrap';
+import * as importHelper from '../../../helpers/import-entity';
+
+import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
+import EntityAnnotation from '../entities/annotation';
+import EntityImage from '../entities/image';
+import EntityLinks from '../entities/links';
+import ImportFooter from './footer';
+import ImportTitle from './title';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {SeriesAttributes} from '../entities/series';
+
+
+const {getImportUrl} = importHelper;
+const {Col, Row} = bootstrap;
+
+
+function ImportSeriesDisplayPage({importEntity, identifierTypes}) {
+	const urlPrefix = getImportUrl(importEntity);
+	return (
+		<div>
+			<Row className="entity-display-background">
+				<Col className="entity-display-image-box text-center" md={2}>
+					<EntityImage
+						backupIcon={ENTITY_TYPE_ICONS.Series}
+						imageUrl={importEntity.imageUrl}
+					/>
+				</Col>
+				<Col md={10}>
+					<ImportTitle importEntity={importEntity}/>
+					<SeriesAttributes series={importEntity}/>
+				</Col>
+			</Row>
+			<EntityAnnotation entity={importEntity}/>
+			<EntityLinks
+				entity={importEntity}
+				identifierTypes={identifierTypes}
+				urlPrefix={urlPrefix}
+			/>
+			<hr className="margin-top-d40"/>
+			<ImportFooter
+				hasVoted={importEntity.hasVoted}
+				importUrl={urlPrefix}
+				importedAt={importEntity.importedAt}
+				source={importEntity.source}
+				type={importEntity.type}
+			/>
+		</div>
+	);
+}
+ImportSeriesDisplayPage.displayName = 'ImportSeriesDisplayPage';
+ImportSeriesDisplayPage.propTypes = {
+	identifierTypes: PropTypes.array,
+	importEntity: PropTypes.object.isRequired
+};
+ImportSeriesDisplayPage.defaultProps = {
+	identifierTypes: []
+};
+
+export default ImportSeriesDisplayPage;

--- a/src/client/components/pages/import-entities/work.js
+++ b/src/client/components/pages/import-entities/work.js
@@ -20,6 +20,7 @@ import * as bootstrap from 'react-bootstrap';
 import * as importHelper from '../../../helpers/import-entity';
 
 import {ENTITY_TYPE_ICONS} from '../../../helpers/entity';
+import EntityAnnotation from '../entities/annotation';
 import EntityImage from '../entities/image';
 import EntityLinks from '../entities/links';
 import ImportFooter from './footer';
@@ -49,6 +50,7 @@ function ImportWorkDisplayPage({importEntity, identifierTypes}) {
 					<WorkAttributes work={importEntity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={importEntity}/>
 			<EntityLinks
 				entity={importEntity}
 				identifierTypes={identifierTypes}

--- a/src/client/entity-editor/series-section/series-section.tsx
+++ b/src/client/entity-editor/series-section/series-section.tsx
@@ -123,7 +123,7 @@ function SeriesSection({
 		disambiguation: _.get(entity, ['disambiguation', 'comment']),
 		type: _.upperFirst(entityType)
 	};
-	const seriesItemsObject = seriesItems.toJS();
+	const seriesItemsObject = seriesItems?.toJS() ?? {};
 
 	/* If one of the relationships is to a new entity (in creation),
 	update that new entity's name to replace "New Entity" */

--- a/src/client/helpers/import-entity.js
+++ b/src/client/helpers/import-entity.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {get} from 'lodash';
+import {get, kebabCase} from 'lodash';
 
 
 export function getImportLabel(importEntity) {
@@ -24,13 +24,13 @@ export function getImportLabel(importEntity) {
 }
 
 export function getImportUrl(importEntity) {
-	const type = importEntity.type.toLowerCase();
+	const type = kebabCase(importEntity.type);
 	const id = importEntity.importId;
 	return `/imports/${type}/${id}`;
 }
 
 export function getImportDiscardUrl(importEntity) {
-	const type = importEntity.type.toLowerCase();
+	const type = kebabCase(importEntity.type);
 	const id = importEntity.importId;
 	return `/imports/${type}/${id}/discard/handler`;
 }

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -3,6 +3,7 @@ import {EntityType, Relationship, RelationshipForDisplay} from '../../client/ent
 import {isFinite, isString, kebabCase, toString, upperFirst} from 'lodash';
 import {IdentifierType} from '../../client/unified-form/interface/type';
 import type {LazyLoadedEntityT} from 'bookbrainz-data/lib/types/entity';
+import {type ORM} from 'bookbrainz-data';
 
 /**
  * Regular expression for valid BookBrainz UUIDs (bbid)
@@ -32,10 +33,10 @@ export function isValidImportId(id: number): boolean {
 /**
  * Returns all entity models defined in bookbrainz-data-js
  *
- * @param {object} orm - the BookBrainz ORM, initialized during app setup
+ * @param {ORM} orm - the BookBrainz ORM, initialized during app setup
  * @returns {object} - Object mapping model name to the entity model
  */
-export function getEntityModels(orm: any) {
+export function getEntityModels(orm: ORM) {
 	const {Author, Edition, EditionGroup, Publisher, Series, Work} = orm;
 	return {
 		Author,
@@ -50,14 +51,14 @@ export function getEntityModels(orm: any) {
 /**
  * Retrieves the Bookshelf entity model with the given the model name
  *
- * @param {object} orm - the BookBrainz ORM, initialized during app setup
+ * @param {ORM} orm - the BookBrainz ORM, initialized during app setup
  * @param {string} type - Name or type of model
  * @throws {Error} Throws a custom error if the param 'type' does not
  * map to a model
  * @returns {object} - Bookshelf model object with the type specified in the
  * single param
  */
-export function getEntityModelByType(orm: any, type: string): any {
+export function getEntityModelByType(orm: ORM, type: string): any {
 	const entityModels = getEntityModels(orm);
 
 	if (!entityModels[type]) {
@@ -70,10 +71,10 @@ export function getEntityModelByType(orm: any, type: string): any {
 /**
  * Returns all import models defined in bookbrainz-data-js
  *
- * @param {object} orm - the BookBrainz ORM, initialized during app setup
+ * @param {ORM} orm - the BookBrainz ORM, initialized during app setup
  * @returns {object} - Object mapping model name to the import model
  */
-export function getImportModels(orm: any) {
+export function getImportModels(orm: ORM) {
 	const {AuthorImport, EditionImport, EditionGroupImport, PublisherImport, SeriesImport, WorkImport} = orm;
 
 	return {
@@ -89,14 +90,14 @@ export function getImportModels(orm: any) {
 /**
  * Retrieves the Bookshelf import model with the given the model name
  *
- * @param  {Object} orm - The BookBrainz ORM, initialized during app setup
+ * @param  {ORM} orm - The BookBrainz ORM, initialized during app setup
  * @param  {string} type - Name or type of model
  * @throws {Error} Throws a custom error if the param 'type' does not
  * map to a model
  * @returns {object} - Bookshelf model object with the type specified in the
  * single param
  */
-export function getImportModelByType(orm: any, type: string): any {
+export function getImportModelByType(orm: ORM, type: string): any {
 	const importModels = getImportModels(orm);
 
 	if (!importModels[type]) {

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -74,14 +74,14 @@ export function getEntityModelByType(orm: any, type: string): any {
  * @returns {object} - Object mapping model name to the import model
  */
 export function getImportModels(orm: any) {
-	const {AuthorImport, EditionImport, EditionGroupImport, PublisherImport,
-		WorkImport} = orm;
+	const {AuthorImport, EditionImport, EditionGroupImport, PublisherImport, SeriesImport, WorkImport} = orm;
 
 	return {
 		AuthorImport,
 		EditionGroupImport,
 		EditionImport,
 		PublisherImport,
+		SeriesImport,
 		WorkImport
 	};
 }

--- a/src/server/helpers/importEntityRouteUtils.ts
+++ b/src/server/helpers/importEntityRouteUtils.ts
@@ -19,9 +19,9 @@
 // @flow
 
 import * as utils from './utils';
+import {camelCase, kebabCase, partialRight} from 'lodash';
 import type express from 'express';
 import {generateProps} from './props';
-import {partialRight} from 'lodash';
 
 
 /**
@@ -39,7 +39,7 @@ export function generateImportEntityProps(
 ) {
 	const {importEntity} = res.locals;
 	const {type: importEntityName} = importEntity;
-	const importEntityType = importEntityName.toLowerCase();
+	const importEntityType = camelCase(importEntityName);
 
 	const getFilteredIdentifierTypes =
 		partialRight(utils.filterIdentifierTypesByEntity, importEntity);
@@ -48,7 +48,7 @@ export function generateImportEntityProps(
 	);
 
 	const submissionUrl =
-		`/imports/${importEntityType}/${importEntity.importId}/edit/approve`;
+		`/imports/${kebabCase(importEntityType)}/${importEntity.importId}/edit/approve`;
 
 	const props = Object.assign({
 		entityType: importEntityType,

--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -328,6 +328,7 @@ export function makeEntityLoader(modelName: string, additionalRels: Array<string
 export function makeImportLoader(modelName, additionalRels, errMessage) {
 	const relations = [
 		'aliasSet.aliases.language',
+		'annotation',
 		'defaultAlias',
 		'disambiguation',
 		'identifierSet.identifiers.type'

--- a/src/server/routes/import-entity/edition-group.js
+++ b/src/server/routes/import-entity/edition-group.js
@@ -32,9 +32,10 @@ router.param(
 		'EditionGroupImport',
 		[
 			'editionGroupType',
-			'editions.defaultAlias',
-			'editions.disambiguation',
-			'editions.releaseEventSet.releaseEvents'
+			// TODO: Reenable edition rels once imports have BBIDs
+			// 'editions.defaultAlias',
+			// 'editions.disambiguation',
+			// 'editions.releaseEventSet.releaseEvents'
 		],
 		'Edition Group Import not found'
 	)

--- a/src/server/routes/import-entity/import-routes.tsx
+++ b/src/server/routes/import-entity/import-routes.tsx
@@ -169,7 +169,7 @@ export async function approveImportPostEditing(req, res) {
 	const {importId, type} = importEntity;
 	const formData = req.body;
 
-	const validateForm = getValidator(type.toLowerCase());
+	const validateForm = getValidator(type);
 
 	if (!validateForm(formData)) {
 		const err = new error.FormSubmissionError();

--- a/src/server/routes/import-entity/index.js
+++ b/src/server/routes/import-entity/index.js
@@ -21,6 +21,7 @@ import ImportEditionGroupRouter from './edition-group';
 import ImportEditionRouter from './edition';
 import ImportPublisherRouter from './publisher';
 import ImportRecentRouter from './recent';
+import ImportSeriesRouter from './series';
 import ImportWorkRouter from './work';
 import express from 'express';
 
@@ -31,6 +32,7 @@ importRouter.use('/author', ImportAuthorRouter);
 importRouter.use('/edition', ImportEditionRouter);
 importRouter.use('/edition-group', ImportEditionGroupRouter);
 importRouter.use('/publisher', ImportPublisherRouter);
+importRouter.use('/series', ImportSeriesRouter);
 importRouter.use('/work', ImportWorkRouter);
 importRouter.use('/recent', ImportRecentRouter);
 

--- a/src/server/routes/import-entity/series.js
+++ b/src/server/routes/import-entity/series.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2018  Shivam Tripathi
+ *               2024  David Kellner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as auth from '../../helpers/auth';
+import * as importRoutes from './import-routes';
+import * as middleware from '../../helpers/middleware';
+import * as utils from '../../helpers/utils';
+import express from 'express';
+
+
+const router = express.Router();
+
+/* If the route specifies an importId, load the importEntity for it. */
+router.param(
+	'importId',
+	middleware.makeImportLoader(
+		'SeriesImport',
+		['seriesOrderingType'],
+		'Series Import not found'
+	)
+);
+
+
+function _setSeriesTitle(res) {
+	res.locals.title = utils.createEntityPageTitle(
+		res.locals.entity,
+		'Series (Import)',
+		utils.template`Series (Import) “${'name'}”`
+	);
+}
+
+router.get('/:importId', (req, res) => {
+	_setSeriesTitle(res);
+	importRoutes.displayImport(req, res);
+});
+
+router.get('/:importId/discard', auth.isAuthenticated, (req, res) => {
+	_setSeriesTitle(res);
+	importRoutes.displayDiscardImportEntity(req, res);
+});
+
+router.post(
+	'/:importId/discard/handler',
+	auth.isAuthenticatedForHandler,
+	importRoutes.handleDiscardImportEntity
+);
+
+router.get(
+	'/:importId/approve',
+	auth.isAuthenticatedForHandler,
+	importRoutes.approveImportEntity
+);
+
+router.get(
+	'/:importId/edit',
+	auth.isAuthenticated, middleware.loadIdentifierTypes,
+	middleware.loadSeriesOrderingTypes, middleware.loadLanguages,
+	importRoutes.editImportEntity
+);
+
+router.post(
+	'/:importId/edit/approve',
+	auth.isAuthenticatedForHandler,
+	importRoutes.approveImportPostEditing
+);
+
+export default router;

--- a/src/server/routes/import-entity/transform-form.js
+++ b/src/server/routes/import-entity/transform-form.js
@@ -27,6 +27,7 @@ export function formToAuthorState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		beginAreaId: data.authorSection.beginArea &&
 			data.authorSection.beginArea.id,
 		beginDate: data.authorSection.beginDate,
@@ -55,6 +56,7 @@ export function formToEditionState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		depth: data.editionSection.depth &&
 			parseInt(data.editionSection.depth, 10),
 		disambiguation: data.nameSection.disambiguation,
@@ -88,6 +90,7 @@ export function formToEditionGroupState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		disambiguation: data.nameSection.disambiguation,
 		identifiers,
 		note: data.submissionSection.note,
@@ -102,6 +105,7 @@ export function formToPublisherState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		areaId: data.publisherSection.area && data.publisherSection.area.id,
 		beginDate: data.publisherSection.beginDate,
 		disambiguation: data.nameSection.disambiguation,
@@ -122,6 +126,7 @@ export function formToWorkState(data) {
 
 	return {
 		aliases,
+		annotation: data.annotationSection.content,
 		disambiguation: data.nameSection.disambiguation,
 		identifiers,
 		languages,

--- a/src/server/routes/import-entity/transform-form.js
+++ b/src/server/routes/import-entity/transform-form.js
@@ -119,6 +119,22 @@ export function formToPublisherState(data) {
 	};
 }
 
+export function formToSeriesState(data) {
+	const aliases = constructAliases(data.aliasEditor, data.nameSection);
+	const identifiers = constructIdentifiers(data.identifierEditor);
+
+	return {
+		aliases,
+		annotation: data.annotationSection.content,
+		disambiguation: data.nameSection.disambiguation,
+		entityType: data.seriesSection.seriesType,
+		identifiers,
+		note: data.submissionSection.note,
+		seriesOrderingTypeId: data.seriesSection.orderType,
+		type: 'Series',
+	};
+}
+
 export function formToWorkState(data) {
 	const aliases = constructAliases(data.aliasEditor, data.nameSection);
 	const identifiers = constructIdentifiers(data.identifierEditor);
@@ -141,5 +157,6 @@ export const transformForm = {
 	Edition: formToEditionState,
 	EditionGroup: formToEditionGroupState,
 	Publisher: formToPublisherState,
+	Series: formToSeriesState,
 	Work: formToWorkState
 };

--- a/src/server/routes/import-entity/transform-import.js
+++ b/src/server/routes/import-entity/transform-import.js
@@ -116,7 +116,7 @@ function getAuthorSection(authorImport) {
 }
 
 function getEditionSection(editionImport) {
-	const physicalVisible = !(
+	const physicalEnable = !(
 		isNull(editionImport.depth) && isNull(editionImport.height) &&
 		isNull(editionImport.pages) && isNull(editionImport.weight) &&
 		isNull(editionImport.width)
@@ -137,7 +137,7 @@ function getEditionSection(editionImport) {
 					({id, name}) => ({label: name, value: id})
 				) : [],
 		pages: editionImport.pages,
-		physicalVisible,
+		physicalEnable,
 		releaseDate,
 		status: editionImport.editionStatus && editionImport.editionStatus.id,
 		weight: editionImport.weight,

--- a/src/server/routes/import-entity/transform-import.js
+++ b/src/server/routes/import-entity/transform-import.js
@@ -184,6 +184,7 @@ export function entityToFormState(importEntity) {
 	const entitySection = `${importEntity.type.toLowerCase()}Section`;
 	return {
 		aliasEditor: getAliasEditor(importEntity),
+		annotationSection: importEntity.annotation ?? {},
 		buttonBar: getButtonBar(importEntity),
 		[entitySection]: entitySectionMap[importEntity.type](importEntity),
 		identifierEditor: getIdentifierEditor(importEntity),

--- a/src/server/routes/import-entity/transform-import.js
+++ b/src/server/routes/import-entity/transform-import.js
@@ -28,7 +28,7 @@
 	the form layout as described in the `client/entity-editor`
 */
 
-import {isEmpty, isNull} from 'lodash';
+import {camelCase, isEmpty, isNull} from 'lodash';
 
 
 export function areaToOption(area) {
@@ -181,7 +181,7 @@ export const entitySectionMap = {
 };
 
 export function entityToFormState(importEntity) {
-	const entitySection = `${importEntity.type.toLowerCase()}Section`;
+	const entitySection = `${camelCase(importEntity.type)}Section`;
 	return {
 		aliasEditor: getAliasEditor(importEntity),
 		annotationSection: importEntity.annotation ?? {},

--- a/src/server/routes/import-entity/transform-import.js
+++ b/src/server/routes/import-entity/transform-import.js
@@ -162,6 +162,13 @@ function getPublisherSection(publisherImport) {
 	};
 }
 
+function getSeriesSection(seriesImport) {
+	return {
+		orderType: seriesImport.seriesOrderingType?.id,
+		seriesType: seriesImport.entityType,
+	};
+}
+
 function getWorkSection(workImport) {
 	return {
 		languages:
@@ -177,6 +184,7 @@ export const entitySectionMap = {
 	Edition: getEditionSection,
 	EditionGroup: getEditionGroupSection,
 	Publisher: getPublisherSection,
+	Series: getSeriesSection,
 	Work: getWorkSection
 };
 

--- a/src/server/routes/import-entity/transform-import.js
+++ b/src/server/routes/import-entity/transform-import.js
@@ -29,6 +29,7 @@
 */
 
 import {camelCase, isEmpty, isNull} from 'lodash';
+import {entityToOption} from '../../helpers/utils';
 
 
 export function areaToOption(area) {
@@ -129,6 +130,7 @@ function getEditionSection(editionImport) {
 
 	return {
 		depth: editionImport.depth,
+		editionGroup: entityToOption(editionImport.editionGroup),
 		format: editionImport.editionFormat && editionImport.editionFormat.id,
 		height: editionImport.height,
 		languages:


### PR DESCRIPTION
On top of #1107 (diff: https://github.com/kellnerd/bookbrainz-site/compare/import-annotation...import-series)

Adds the missing routes, pages and data transformation functions for imported series.
Since imported entities can't have relationships yet, we have to handle the case that a series has no defined items (which wasn't necessary for regular series).
And I forgot to add the item entity type to the SQL view in one of my previous PRs.

----

Since the necessary changes to make editing and approval of edition imports work are very minor, I have included these here as well.