### PR TITLE
chore: Remove dependency to array-move package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@fortawesome/free-brands-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "array-move": "^3.0.1",
     "bookbrainz-data": "5.1.1",
     "chart.js": "^2.9.4",
     "chartjs-adapter-date-fns": "^1.0.0",

--- a/src/client/entity-editor/series-section/actions.ts
+++ b/src/client/entity-editor/series-section/actions.ts
@@ -18,7 +18,6 @@
 /* eslint-disable no-inline-comments */
 
 import type {Attribute, Relationship, RelationshipForDisplay} from '../relationship-editor/types';
-import arrayMove from 'array-move';
 import {attachAttribToRelForDisplay} from '../helpers';
 import {sortRelationshipOrdinal} from '../../../common/helpers/utils';
 
@@ -119,7 +118,9 @@ export function sortSeriesItems(oldIndex, newIndex):any {
 			delete seriesItem.number;
 			delete seriesItem.position;
 		});
-		const sortedSeriesItems = arrayMove(seriesItemsArray, oldIndex, newIndex);
+		const sortedSeriesItems = [...seriesItemsArray];
+		const [itemToMove] = sortedSeriesItems.splice(oldIndex, 1);
+		sortedSeriesItems.splice(newIndex, 0, itemToMove);
 		sortedSeriesItems.forEach((seriesItem: RelationshipForDisplay, index: number) => {
 			seriesItem.attributes.forEach((attribute: Attribute) => {
 				if (attribute.attributeType === 1) { // Attribute type 1 for position

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,11 +2535,6 @@ array-includes@^3.1.3, array-includes@^3.1.4, array-includes@^3.1.7:
     get-intrinsic "^1.2.4"
     is-string "^1.0.7"
 
-array-move@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/array-move/-/array-move-3.0.1.tgz#179645cc0987b65953a4fc06b6df9045e4ba9618"
-  integrity sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg==
-
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"


### PR DESCRIPTION
An unnecessary package that is causing trouble when dependabot tried to update it (See #1039).
Considering it is used only in this one case in one file and only saves one whole line of code, I am removing the dependency.