### PR TITLE
chore: Update upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: yarn run test-ci                    # run tests (configured to use mocha's json reporter)
       
       - name: Export test results
-        uses: actions/upload-artifact@v2  # upload test results
+        uses: actions/upload-artifact@v4  # upload test results
         if: success() || failure()        # run this step even if previous step failed
         with:
           name: test-results


### PR DESCRIPTION
upload-artifact v2 is now deprecated and fails the workflows.
See https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
