### PR TITLE
chore: Update serve-static to 1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "redux-immutable": "^4.0.0",
     "redux-thunk": "^2.2.0",
     "serve-favicon": "^2.4.3",
-    "serve-static": "^1.16.0",
+    "serve-static": "1.16.1",
     "superagent": "^8.0.8",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8228,25 +8228,6 @@ semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.8, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
-send@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
-  integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
-  dependencies:
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    mime "1.6.0"
-    ms "2.1.3"
-    on-finished "2.4.1"
-    range-parser "~1.2.1"
-    statuses "2.0.1"
-
 send@0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.19.0.tgz#bbc5a388c8ea6c048967049dbeac0e4a3f09d7f8"
@@ -8291,6 +8272,16 @@ serve-favicon@^2.4.3:
     parseurl "~1.3.2"
     safe-buffer "5.1.1"
 
+serve-static@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.1.tgz#ef5b5e8c045446a12e0efe1cb2bc2246dbcf4b66"
+  integrity sha512-lQEnvznm+LlIN7a5B/LdKGFt1b/a+L/DNojweniJHyoBxqQlAVnv0QC5UuRbQC4udn3n4Tj2pcvbJa3Wiqwxtw==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.19.0"
+
 serve-static@1.16.2:
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.2.tgz#b6a5343da47f6bdd2673848bf45754941e803296"
@@ -8300,16 +8291,6 @@ serve-static@1.16.2:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.19.0"
-
-serve-static@^1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.0.tgz#2bf4ed49f8af311b519c46f272bf6ac3baf38a92"
-  integrity sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==
-  dependencies:
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    parseurl "~1.3.3"
-    send "0.18.0"
 
 set-function-length@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
Updates the dependency `send` to 0.19.0, which fixes a vulnerability that dependabot can't seem to find the update for: https://github.com/metabrainz/bookbrainz-site/security/dependabot/65