### PR TITLE
Funding: add .well-known/funding-manifest-urls  file and URL

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://metabrainz.org/funding.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY --chown=bookbrainz .babelrc .eslintrc.js .eslintignore webpack.client.js pa
 RUN yarn install
 
 COPY --chown=bookbrainz static/ static/
+COPY --chown=bookbrainz .well-known/ .well-known/
 COPY --chown=bookbrainz config/ config/
 COPY --chown=bookbrainz sql/ sql/
 COPY --chown=bookbrainz src/ src/

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -89,6 +89,7 @@ else {
 	app.use(serveStatic(path.join(rootDir, 'static/js')));
 }
 app.use(express.static(path.join(rootDir, 'static')));
+app.use('/.well-known', express.static(path.join(rootDir, '.well-known')));
 
 app.use(session(process.env.NODE_ENV));
 


### PR DESCRIPTION
See https://github.com/metabrainz/metabrainz.org/pull/487/files, https://floss.fund/funding-manifest/ and https://en.wikipedia.org/wiki/Well-known_URI

This link back to the MeB.org funding.json can be accessed two ways:
1. In the github repo, for use with repositoryUrl.wellKnown using "https://github.com/metabrainz/bookbrainz-site/blob/main/.well-known/funding-manifest-urls"
2. for use with webpageUrl.wellKnown, point to the new path "https://bookbrainz.org/.well-known/funding-manifest-urls"