### PR TITLE
Funding: Add .well-known file for funding.json

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://metabrainz.org/funding.json


### PR DESCRIPTION
See https://github.com/metabrainz/metabrainz.org/pull/487 and https://floss.fund/funding-manifest/

This is required because the funding.json file will be hosted on metabrainz.org.
Repo URLs need to be validated using this .well-known file

Originally implemented in #1133 but serving the file will be handled at the gateway level instead: https://github.com/metabrainz/openresty-gateways/pull/13