### PR TITLE
docs: replaced deprecated jsdoc link leading to spam site with updated jsdoc homepage link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ to BookBrainz:
  * Use tabs for indenting, and spaces for aligning (http://lea.verou.me/2012/01/why-tabs-are-clearly-superior/).
  * Variable names should be camelCase
  * Use ES6/ES7 features - they make life easier and result in cleaner code
- * Use [JSDoc](http://usejsdoc.org/) for commenting code
+ * Use [JSDoc](https://jsdoc.app/) for commenting code
  * Use [TypeScript](https://www.typescriptlang.org/) everywhere - static type checking is useful
 
 ## Pull requests


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->
BB-834
The link to the jsdoc homepage (http://usejsdoc.org) is deprecated and leads to a spam site.

### Solution
<!-- What does this PR do to fix the problem? -->
Updated the link to the new jsdoc homepage (https://jsdoc.app)

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
./CONTRIBUTING.md file changed
