### PR TITLE
fix(auth): replaced authentication middleware with one intended for post requests. (Note: docker node 18 -> 20)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/node:18 as bookbrainz-base
+FROM metabrainz/node:20 as bookbrainz-base
 
 ARG DEPLOY_ENV
 ARG GIT_COMMIT_SHA

--- a/src/client/components/pages/externalService.js
+++ b/src/client/components/pages/externalService.js
@@ -47,35 +47,34 @@ class ExternalServices extends React.Component {
 						alertDetails: 'Something went wrong. Please try again.',
 						alertType: 'danger'
 					});
-				}				
+				}
 			}
-			catch (err){
+			catch (err) {
 				this.setState({
-					alertDetails: "Something went wrong. Please try again.",
-					alertType: "danger",
+					alertDetails: 'Something went wrong. Please try again.',
+					alertType: 'danger'
 				});
 			}
-
 		}
 		else {
 			try {
 				const data = await request.post(
-					"/external-service/critiquebrainz/disconnect"
+					'/external-service/critiquebrainz/disconnect'
 				);
 				this.setState({
 					alertDetails: data.body.alertDetails,
-					alertType: data.body.alertType,
+					alertType: data.body.alertType
 				});
 				if (data.statusCode === 200) {
 					this.setState({
-						cbPermission: "disable",
+						cbPermission: 'disable'
 					});
 				}
 			}
-			catch(err) {
+			catch (err) {
 				this.setState({
-					alertDetails: "Something went wrong. Please try again.",
-					alertType: "danger",
+					alertDetails: 'Something went wrong. Please try again.',
+					alertType: 'danger'
 				});
 			}
 		}

--- a/src/client/components/pages/externalService.js
+++ b/src/client/components/pages/externalService.js
@@ -37,26 +37,45 @@ class ExternalServices extends React.Component {
 
 	handleClick = async (event) => {
 		if (event.target.value === 'review') {
-			const data = await request.post('/external-service/critiquebrainz/connect');
-			if (data.statusCode === 200) {
-				window.location.href = data.text;
+			try {
+				const data = await request.post('/external-service/critiquebrainz/connect');
+				if (data.statusCode === 200) {
+					window.location.href = data.text;
+				}
+				else {
+					this.setState({
+						alertDetails: 'Something went wrong. Please try again.',
+						alertType: 'danger'
+					});
+				}				
 			}
-			else {
+			catch (err){
 				this.setState({
-					alertDetails: 'Something went wrong. Please try again.',
-					alertType: 'danger'
+					alertDetails: "Something went wrong. Please try again.",
+					alertType: "danger",
 				});
 			}
+
 		}
 		else {
-			const data = await request.post('/external-service/critiquebrainz/disconnect');
-			this.setState({
-				alertDetails: data.body.alertDetails,
-				alertType: data.body.alertType
-			});
-			if (data.statusCode === 200) {
+			try {
+				const data = await request.post(
+					"/external-service/critiquebrainz/disconnect"
+				);
 				this.setState({
-					cbPermission: 'disable'
+					alertDetails: data.body.alertDetails,
+					alertType: data.body.alertType,
+				});
+				if (data.statusCode === 200) {
+					this.setState({
+						cbPermission: "disable",
+					});
+				}
+			}
+			catch(err) {
+				this.setState({
+					alertDetails: "Something went wrong. Please try again.",
+					alertType: "danger",
 				});
 			}
 		}

--- a/src/server/routes/collection.js
+++ b/src/server/routes/collection.js
@@ -278,7 +278,7 @@ router.post(
 /* eslint-disable no-await-in-loop */
 router.post(
 	'/:collectionId/add',
-	auth.isAuthenticated, auth.isCollectionOwnerOrCollaborator, middleware.validateBBIDsForCollectionAdd,
+	auth.isAuthenticatedForHandler, auth.isCollectionOwnerOrCollaborator, middleware.validateBBIDsForCollectionAdd,
 	async (req, res, next) => {
 		const {bbids} = req.body;
 		const {collection} = res.locals;
@@ -314,7 +314,7 @@ router.post(
 
 router.post(
 	'/:collectionId/collaborator/remove',
-	auth.isAuthenticated, middleware.validateCollaboratorIdsForCollectionRemove,
+	auth.isAuthenticatedForHandler, middleware.validateCollaboratorIdsForCollectionRemove,
 	async (req, res, next) => {
 		try {
 			const {collection} = res.locals;

--- a/src/server/routes/collection.js
+++ b/src/server/routes/collection.js
@@ -252,7 +252,7 @@ router.post('/:collectionId/delete/handler', auth.isAuthenticatedForHandler, aut
 
 router.post(
 	'/:collectionId/remove',
-	auth.isAuthenticated, auth.isCollectionOwnerOrCollaborator, middleware.validateBBIDsForCollectionRemove,
+	auth.isAuthenticatedForHandler, auth.isCollectionOwnerOrCollaborator, middleware.validateBBIDsForCollectionRemove,
 	async (req, res, next) => {
 		const {bbids = []} = req.body;
 		const {collection} = res.locals;

--- a/src/server/routes/editor.tsx
+++ b/src/server/routes/editor.tsx
@@ -618,7 +618,7 @@ async function rankUpdate(orm, editorId, bodyRank, rank) {
 }
 
 
-router.post('/:id/achievements/', auth.isAuthenticated, async (req, res) => {
+router.post('/:id/achievements/', auth.isAuthenticatedForHandler, async (req, res) => {
 	const {orm} = req.app.locals;
 	const userId = parseInt(req.params.id, 10);
 	if (!isCurrentUser(userId, req.user)) {

--- a/src/server/routes/externalService.js
+++ b/src/server/routes/externalService.js
@@ -132,7 +132,7 @@ router.post('/critiquebrainz/refresh', auth.isAuthenticatedForHandler, async (re
 });
 
 
-router.post('/critiquebrainz/connect', auth.isAuthenticated, async (req, res) => {
+router.post('/critiquebrainz/connect', auth.isAuthenticatedForHandler, async (req, res) => {
 	const editorId = req.user.id;
 	const {orm} = req.app.locals;
 
@@ -157,7 +157,7 @@ router.post('/critiquebrainz/connect', auth.isAuthenticated, async (req, res) =>
 });
 
 
-router.post('/critiquebrainz/disconnect', auth.isAuthenticated, async (req, res) => {
+router.post('/critiquebrainz/disconnect', auth.isAuthenticatedForHandler, async (req, res) => {
 	const editorId = req.user.id;
 	const {orm} = req.app.locals;
 

--- a/src/server/routes/externalService.js
+++ b/src/server/routes/externalService.js
@@ -107,7 +107,7 @@ router.get('/critiquebrainz/callback', auth.isAuthenticated, async (req, res, ne
 });
 
 
-router.post('/critiquebrainz/refresh', auth.isAuthenticated, async (req, res, next) => {
+router.post('/critiquebrainz/refresh', auth.isAuthenticatedForHandler, async (req, res, next) => {
 	const editorId = req.user.id;
 	const {orm} = req.app.locals;
 	let token = await orm.func.externalServiceOauth.getOauthToken(

--- a/src/server/routes/reviews.ts
+++ b/src/server/routes/reviews.ts
@@ -34,7 +34,7 @@ router.get('/:entityType/:bbid/reviews', async (req, res) => {
 	res.json(reviews);
 });
 
-router.post('/:entityType/:bbid/reviews', auth.isAuthenticated, auth.isAuthorized(ENTITY_EDITOR), async (req, res) => {
+router.post('/:entityType/:bbid/reviews', auth.isAuthenticatedForHandler, auth.isAuthorized(ENTITY_EDITOR), async (req, res) => {
 	const editorId = req.user.id;
 	const {orm} = req.app.locals;
 

--- a/src/server/routes/type-editor/identifier-type.tsx
+++ b/src/server/routes/type-editor/identifier-type.tsx
@@ -54,7 +54,7 @@ router.get('/create', auth.isAuthenticated, auth.isAuthorized(IDENTIFIER_TYPE_ED
 		}));
 	});
 
-router.post('/create/handler', auth.isAuthenticated, auth.isAuthorized(IDENTIFIER_TYPE_EDITOR), identifierTypeCreateOrEditHandler);
+router.post('/create/handler', auth.isAuthenticatedForHandler, auth.isAuthorized(IDENTIFIER_TYPE_EDITOR), identifierTypeCreateOrEditHandler);
 
 router.param(
 	'id',
@@ -94,6 +94,6 @@ router.get('/:id/edit', auth.isAuthenticated, auth.isAuthorized(IDENTIFIER_TYPE_
 		}
 	});
 
-router.post('/:id/edit/handler', auth.isAuthenticated, auth.isAuthorized(IDENTIFIER_TYPE_EDITOR), identifierTypeCreateOrEditHandler);
+router.post('/:id/edit/handler', auth.isAuthenticatedForHandler, auth.isAuthorized(IDENTIFIER_TYPE_EDITOR), identifierTypeCreateOrEditHandler);
 
 export default router;

--- a/src/server/routes/type-editor/relationship-type.tsx
+++ b/src/server/routes/type-editor/relationship-type.tsx
@@ -54,7 +54,7 @@ router.get('/create', auth.isAuthenticated, auth.isAuthorized(RELATIONSHIP_TYPE_
 		}));
 	});
 
-router.post('/create/handler', auth.isAuthenticated, auth.isAuthorized(RELATIONSHIP_TYPE_EDITOR), relationshipTypeCreateOrEditHandler);
+router.post('/create/handler', auth.isAuthenticatedForHandler, auth.isAuthorized(RELATIONSHIP_TYPE_EDITOR), relationshipTypeCreateOrEditHandler);
 
 router.param(
 	'id',
@@ -99,6 +99,6 @@ router.get('/:id/edit', auth.isAuthenticated, auth.isAuthorized(RELATIONSHIP_TYP
 		}
 	});
 
-router.post('/:id/edit/handler', auth.isAuthenticated, auth.isAuthorized(RELATIONSHIP_TYPE_EDITOR), relationshipTypeCreateOrEditHandler);
+router.post('/:id/edit/handler', auth.isAuthenticatedForHandler, auth.isAuthorized(RELATIONSHIP_TYPE_EDITOR), relationshipTypeCreateOrEditHandler);
 
 export default router;


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->
[BB-813](https://tickets.metabrainz.org/browse/BB-813)
The cbReviewModal is triggering a post request whose URL is being 
stored and used as a redirection link later on during authentication.
This creates a redirection bug when a user attempts to sign in on any of the pages with said cbReviewModal.
- work
- edition groups
- authors
- series

### Solution
<!-- What does this PR do to fix the problem? -->
The route handler for /critiquebrainz/refresh has been updated to use
isAuthenticatedForHandler (which authenticates without redirecting) instead of isAuthenticated which was filling in the redirect link.

4 Additional Route Handlers have been updated to protect against the same bug.
Here's a [Google Document with images](https://docs.google.com/document/d/1rCKs1Yp_Gs5eRJKHCpbxsojq6M2adevqOMN5y6Ksj-Q/edit?tab=t.0#heading=h.tn1b6d5bh6w0) of user testing showing that each of the updated endpoints is fully functional.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
 - Server `/critiquebrainz/refresh`  post endpoint has been updated.
 - Docker Node Version updated from 18->20 due to version 18 Node's incompatibility with new Mocha Version.
