### PR TITLE
fix: cbReviewModal star rating now sets on the first click (Note: Docker Node 18->20)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/node:18 as bookbrainz-base
+FROM metabrainz/node:20 as bookbrainz-base
 
 ARG DEPLOY_ENV
 ARG GIT_COMMIT_SHA

--- a/src/client/components/pages/entities/cbReviewModal.tsx
+++ b/src/client/components/pages/entities/cbReviewModal.tsx
@@ -404,7 +404,7 @@ class CBReviewModal extends React.Component<
 					<Rating
 						transition
 						className="rating-stars"
-						ratingValue={rating}
+						value={rating}
 						size={20}
 						onClick={this.handleRatingsChange}
 					/>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->
[BB-838](https://tickets.metabrainz.org/browse/BB-838)

### Solution
<!-- What does this PR do to fix the problem? -->
The "react-simple-star-rating" does not appear to reflect immediate state changes.
The Rating component has been updated to directly set "value" in response to state changes instead of the "ratingValue" prop, now immediately displaying the star value selected by the user.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
- cbReviewModal.tsx altered. 
- Ratings show correctly on CritiqueBrainz and in the ReviewCard displayed on the work.