### PR TITLE
BB-683: Cannot use HOME and END keyboard keys in text/select type/search fields

### DIFF
--- a/src/client/stylesheets/style.scss
+++ b/src/client/stylesheets/style.scss
@@ -286,6 +286,15 @@ a.contact-text:visited {
 		background-color: #deebff !important;
 		color: #333;
 	}
+	&.react-select__option--is-focused {
+		background-color: #deebff !important;
+		color: #333 !important;
+	}
+
+	&.react-select__option--is-selected {
+		background-color: #0056b3 !important;
+		color: white !important;
+	}
 }
 .react-select__menu {
 	z-index: 100 !important;


### PR DESCRIPTION
### Problem
- **Issue BB-683**: Users cannot use arrow keyboard keys in language/select/search fields
- Two specific problems were identified:
 1. PgUp and PgDn keys appeared non-functional when focused in the text input
 2. HOME and END keys stopped working after language selection was made



### Solution
  Added necessary styling improvements to fix the following:
 - PgUp and PgDn keys now work properly when navigating options
 - Added background highlighting for the selected language option
 - Added visual focus indicator when using PgUp/PgDn to navigate through language options
 
  Regarding HOME and END keys:
 - These keys are reserved by React-Select library for specific functions
 - HOME and END still work correctly when typing (before selection)
 - After selection, users can still use Delete and Backspace for editing
 - Decided not to override React-Select's reserved key functionality as it could cause other issues


### Areas of Impact
- Modified: `src/client/stylesheets/style.scss`

## Screenshots
### Before
![Screenshot 2025-03-08 193237](https://github.com/user-attachments/assets/38ce900f-adaa-4aad-bdf4-70158e925bfb)

### After
![Screenshot 2025-03-08 193258](https://github.com/user-attachments/assets/90999f2b-d7ad-4d1c-9a08-6c485dca6956)


