### PR TITLE
BB-842: Display full BookBrainz logo on Home Page

### DIFF
--- a/src/client/containers/layout.js
+++ b/src/client/containers/layout.js
@@ -72,24 +72,14 @@ class Layout extends React.Component {
 	}
 
 	renderNavHeader() {
-		const {homepage} = this.props;
-
 		return (
 			<Navbar.Brand className="logo">
 				<a href="/">
-					{homepage ? (
-						<img
-							alt="BookBrainz icon"
-							src="/images/BookBrainz_logo_icon.svg"
-							title="BookBrainz"
-						/>
-					) : (
-						<img
-							alt="BookBrainz icon"
-							src="/images/BookBrainz_logo_mini.svg"
-							title="BookBrainz"
-						/>
-					)}
+					<img
+						alt="BookBrainz icon"
+						src="/images/BookBrainz_logo_mini.svg"
+						title="BookBrainz"
+					/>
 				</a>
 			</Navbar.Brand>
 		);


### PR DESCRIPTION
### Problem  
[BB-842](https://tickets.metabrainz.org/browse/BB-842):  
The full "**BookBrainz**" logo is missing on the Home Page. Instead of the full logo, only the logo icon appears in the top-left corner.  

### Solution  
Resolved **BB-842** by updating the Navbar brand image to display the full "BookBrainz" logo on the Home Page, ensuring consistency across all pages.  

### Before  

#### Desktop View  
<img src="https://github.com/user-attachments/assets/0d15da83-cff9-451f-8e09-dd671557d112" width="90%">

#### Tablet & Mobile View  
<div>
  <img src="https://github.com/user-attachments/assets/4fb7930d-2fac-4ca6-a0bb-fea0868279ee" width="47%">&nbsp;
  <img src="https://github.com/user-attachments/assets/88fc5f74-e6fb-4eec-a9d7-2a8dc97a0e39" width="49%">
</div>

### After  

#### Desktop View  
<img src="https://github.com/user-attachments/assets/5f96fbfe-ec9f-4271-9a7d-de6199dba286" width="90%">

#### Tablet & Mobile View  
<div>
  <img src="https://github.com/user-attachments/assets/91ddeac3-e3e3-4150-af80-13d92c070b09" width="47%">
  <img src="https://github.com/user-attachments/assets/aebbc8e7-974b-435d-9136-69ed968f124b" width="49%">
</div>

### Areas of Impact  
- Navbar brand image  
