### PR TITLE
BB-542: Create a tab view for entities 

### DIFF
--- a/src/client/components/pages/entities/author.js
+++ b/src/client/components/pages/entities/author.js
@@ -40,7 +40,7 @@ import {labelsForAuthor} from '../../../helpers/utils';
 
 const {deletedEntityMessage, extractAttribute, getTypeAttribute, getEntityUrl,
 	ENTITY_TYPE_ICONS, getSortNameOfDefaultAlias, transformISODateForDisplay} = entityHelper;
-const {Button, Col, Row} = bootstrap;
+const {Button, Col, Row, Tabs, Tab} = bootstrap;
 
 function AuthorAttributes({author}) {
 	if (author.deleted) {
@@ -137,6 +137,81 @@ function AuthorDisplayPage({entity, identifierTypes, user, wikipediaExtract}) {
 			editions.push(...authorCredit.editions);
 		});
 	}
+	const tabs = [
+		{
+			id: "overview",
+			label: "Overview",
+			content: (
+				<WikipediaExtract
+					articleExtract={wikipediaExtract}
+					entity={entity}
+				/>
+			),
+		},
+		{
+			id: "annotation",
+			label: "Annotation",
+			content: <EntityAnnotation entity={entity} />,
+		},
+		{
+			id: "editions",
+			label: "Editions",
+			content: !entity.deleted && (
+				<EditionTable editions={editions} entity={entity} />
+			),
+		},
+		{
+			id: "entityLinks",
+			label: "Relationships",
+			content: !entity.deleted && (
+				<EntityLinks
+					entity={entity}
+					identifierTypes={identifierTypes}
+					urlPrefix={urlPrefix}
+				/>
+			),
+		},
+		{
+			id: "entityRelatedCollections",
+			label: "Related Collections",
+			content: !entity.deleted && (
+				<EntityRelatedCollections collections={entity.collections} />
+			),
+		},
+		{
+			id: "addWork",
+			label: "Add Work",
+			content: !entity.deleted && (
+				<Button
+					className="margin-top-d15"
+					href={`/work/create?${_kebabCase(entity.type)}=${
+						entity.bbid
+					}`}
+					variant="success"
+				>
+					<FontAwesomeIcon
+						className="margin-right-0-5"
+						icon={faPlus}
+					/>
+					Add Work
+				</Button>
+			),
+		},
+		{
+			id: "addReview",
+			label: "Add Review",
+			content: !entity.deleted && (
+				<EntityReviews
+					entityBBID={entity.bbid}
+					entityReviews={entity.reviews}
+					entityType={entity.type}
+					handleModalToggle={handleModalToggle}
+					ref={reviewsRef}
+				/>
+			),
+		},
+	];
+	const [activeTab, setActiveTab] = React.useState(tabs[0].id);
 	return (
 		<div>
 			<Row className="entity-display-background">
@@ -157,38 +232,23 @@ function AuthorDisplayPage({entity, identifierTypes, user, wikipediaExtract}) {
 					/>
 				</Col>
 			</Row>
-			<WikipediaExtract articleExtract={wikipediaExtract} entity={entity}/>
-			<EntityAnnotation entity={entity}/>
-			{!entity.deleted &&
-				<React.Fragment>
-					<Row>
-						<Col lg={8}>
-							<EditionTable editions={editions} entity={entity}/>
-							<EntityLinks
-								entity={entity}
-								identifierTypes={identifierTypes}
-								urlPrefix={urlPrefix}
-							/>
-							<EntityRelatedCollections collections={entity.collections}/>
-							<Button
-								className="margin-top-d15"
-								href={`/work/create?${_kebabCase(entity.type)}=${entity.bbid}`}
-								variant="success"
-							>
-								<FontAwesomeIcon className="margin-right-0-5" icon={faPlus}/>Add Work
-							</Button>
-						</Col>
-						<Col lg={4}>
-							<EntityReviews
-								entityBBID={entity.bbid}
-								entityReviews={entity.reviews}
-								entityType={entity.type}
-								handleModalToggle={handleModalToggle}
-								ref={reviewsRef}
-							/>
-						</Col>
-					</Row>
-				</React.Fragment>}
+			<Tabs
+				id="entity-tabs"
+				activeKey={activeTab}
+				onSelect={(tabId) => setActiveTab(tabId)}
+				className="mb-3 w-100"
+				fill
+			>
+				{tabs.map((tab) => (
+					<Tab
+						key={tab.id}
+						eventKey={tab.id}
+						title={tab.label}
+					>
+						{tab.content}
+					</Tab>
+				))}
+			</Tabs>
 			<hr className="margin-top-d40"/>
 			<EntityFooter
 				bbid={entity.bbid}


### PR DESCRIPTION
### Problem
[BB-542](https://tickets.metabrainz.org/browse/BB-542) : Create a tab view for entities 

### Solution
use react bootsrap's tab viewed components to create a clean and organized space for showing entity data.

### Screenshots:
#### Before
Url: https://bookbrainz.org/author/128d9490-ee19-4270-a070-32e0a36847f5

[Screencast from 2025-04-05 15-30-30.webm](https://github.com/user-attachments/assets/fc871e4d-7da7-4c4c-b4a1-09375cc5bf27)

#### After

Desktop View:

[Screencast from 2025-04-05 15-54-14.webm](https://github.com/user-attachments/assets/1c7df668-712d-48fb-adc2-4302b6888eb5)

Mobile View:

[Screencast from 2025-04-05 15-55-21.webm](https://github.com/user-attachments/assets/73aa09fb-1377-4d3a-9be5-b63246155123)
