### PR TITLE
BB-855: Add author and publisher information in edition API

### DIFF
--- a/src/api/helpers/formatEntityData.ts
+++ b/src/api/helpers/formatEntityData.ts
@@ -100,6 +100,82 @@ export function getWorkBasicInfo(work: Record<string, unknown> | null | undefine
 }
 
 /**
+ * A function to extract structured author credit details from an Edition ORM entity.
+ * @function
+ * @param {object} edition - an edition ORM entity
+ * @returns {object|null} an object containing the author credit data, or null if not available.
+ *
+ * @example
+ * 		const edition = await orm.func.entity.getEntity(orm, 'Edition', bbid, relations);
+ *		filterAuthorCredit(edition);
+ *		/* => {
+ *			"authorCount": 1,
+ *			"id": 135,
+ *			"names": [
+ *				{
+ *					"authorBBID": "e5c4e68b-bfce-4c77-9ca2-0f0a2d4d09f0",
+ *					"authorCreditID": 135,
+ *					"name": "J. K. Rowling"
+ *				}
+ *			]
+ *		}
+ */
+
+export function filterAuthorCredit(edition: any) {
+	if (_.isNil(edition) || _.isNil(edition.authorCredit)) { return null; }
+
+	const credit = edition.authorCredit;
+	return {
+		authorCount: credit.authorCount || null,
+		id: credit.id || null,
+		names: (credit.names || []).map(({authorCreditID, authorBBID, name}) => ({
+			authorBBID,
+			authorCreditID,
+			name
+		}))
+	};
+}
+
+/**
+ * A function to extract basic publisher information from an Edition ORM entity.
+ * @function
+ * @param {object} edition - an edition ORM entity
+ * @returns {object|null} an object containing publisher set data, or null if not available.
+ *
+ * @example
+ * 		const edition = await orm.func.entity.getEntity(orm, 'Edition', bbid, relations);
+ *		filterPublisherSet(edition);
+ *		/* => {
+ *			"id": 2217,
+ *			"publishers": [
+ *				{
+ *					"bbid": "d30d7df9-eb6f-4bd5-a69f-a9a3362a6f4a",
+ *					"ended": false,
+ *					"name": "Bloomsbury",
+ *					"publisherType": "Publisher",
+ *					"sortName": "Bloomsbury"
+ *				}
+ *			]
+ *		}
+ */
+
+export function filterPublisherSet(edition: any) {
+	if (_.isNil(edition) || _.isNil(edition.authorCredit)) { return null; }
+
+	const {publisherSet} = edition;
+	return {
+		id: publisherSet.id || null,
+		publishers: (publisherSet.publishers || []).map(({bbid, name, sortName, ended, publisherType}) => ({
+			bbid,
+			ended,
+			name,
+			publisherType,
+			sortName
+		}))
+	};
+}
+
+/**
  * A function to extract the basic details of an Edition ORM entity
  * @function
  * @param {object} edition - an edition ORM entity
@@ -137,6 +213,7 @@ export function getWorkBasicInfo(work: Record<string, unknown> | null | undefine
 export function getEditionBasicInfo(edition: any) {
 	return _.isNil(edition) ? null :
 		{
+			authorCredit: filterAuthorCredit(edition),
 			bbid: _.get(edition, 'bbid', null),
 			defaultAlias: getDefaultAlias(edition),
 			depth: _.get(edition, 'depth', null),
@@ -145,6 +222,7 @@ export function getEditionBasicInfo(edition: any) {
 			height: _.get(edition, 'height', null),
 			languages: getLanguages(edition),
 			pages: _.get(edition, 'pages', null),
+			publisherSet: filterPublisherSet(edition),
 			releaseEventDates: _.get(edition, 'releaseEventSet.releaseEvents', []).map((event) => event.date),
 			status: _.get(edition, 'editionStatus.label', null),
 			weight: _.get(edition, 'weight', null),

--- a/src/api/helpers/formatEntityData.ts
+++ b/src/api/helpers/formatEntityData.ts
@@ -107,7 +107,7 @@ export function getWorkBasicInfo(work: Record<string, unknown> | null | undefine
  *
  * @example
  * 		const edition = await orm.func.entity.getEntity(orm, 'Edition', bbid, relations);
- *		filterAuthorCredit(edition);
+ *		getAuthorCredits(edition);
  *		/* => {
  *			"authorCount": 1,
  *			"id": 135,
@@ -121,18 +121,15 @@ export function getWorkBasicInfo(work: Record<string, unknown> | null | undefine
  *		}
  */
 
-export function filterAuthorCredit(edition: any) {
-	if (_.isNil(edition) || _.isNil(edition.authorCredit)) { return null; }
+export function getAuthorCredits(edition: any) {
+	if (_.isNil(edition?.authorCredit)) { return null; }
 
-	const credit = edition.authorCredit;
+	const {authorCredit} = edition;
+	const {id, authorCount, names} = authorCredit;
 	return {
-		authorCount: credit.authorCount || null,
-		id: credit.id || null,
-		names: (credit.names || []).map(({authorCreditID, authorBBID, name}) => ({
-			authorBBID,
-			authorCreditID,
-			name
-		}))
+		authorCount: authorCount ?? null,
+		id: id ?? null,
+		names: names ?? []
 	};
 }
 
@@ -140,39 +137,26 @@ export function filterAuthorCredit(edition: any) {
  * A function to extract basic publisher information from an Edition ORM entity.
  * @function
  * @param {object} edition - an edition ORM entity
- * @returns {object|null} an object containing publisher set data, or null if not available.
+ * @returns {Array<object>} an array of objects containing publisher set data, or null if not available.
  *
  * @example
  * 		const edition = await orm.func.entity.getEntity(orm, 'Edition', bbid, relations);
- *		filterPublisherSet(edition);
- *		/* => {
- *			"id": 2217,
- *			"publishers": [
- *				{
- *					"bbid": "d30d7df9-eb6f-4bd5-a69f-a9a3362a6f4a",
- *					"ended": false,
- *					"name": "Bloomsbury",
- *					"publisherType": "Publisher",
- *					"sortName": "Bloomsbury"
- *				}
- *			]
- *		}
+ *		filterPublishers(edition);
+ *		/* => [
+ *    		{
+ *      	  "bbid": "d30d7df9-eb6f-4bd5-a69f-a9a3362a6f4a",
+ *      	  "name": "Bloomsbury",
+ *     	 	  "sortName": "Bloomsbury"
+ *    		}
+ * 		]
  */
 
-export function filterPublisherSet(edition: any) {
-	if (_.isNil(edition) || _.isNil(edition.authorCredit)) { return null; }
-
-	const {publisherSet} = edition;
-	return {
-		id: publisherSet.id || null,
-		publishers: (publisherSet.publishers || []).map(({bbid, name, sortName, ended, publisherType}) => ({
-			bbid,
-			ended,
-			name,
-			publisherType,
-			sortName
-		}))
-	};
+export function filterPublishers(edition: any) {
+	return _.isNil(edition?.publisherSet) ? null : (edition.publisherSet.publishers ?? []).map(({bbid, name, sortName}) => ({
+		bbid,
+		name,
+		sortName
+	}));
 }
 
 /**
@@ -186,34 +170,52 @@ export function filterPublisherSet(edition: any) {
  * 		const work = await orm.func.entity.getEntity(orm, 'Edition', bbid, relations);
  *		getEditionBasicInfo(work);
  *		/* => {
-			"bbid": "442ab642-985a-4957-9d61-8a1d9e82de1f",
+			"authorCredits": {
+				"authorCount": 1,
+				"id": 135,
+				"names": [
+				{
+					"authorCreditID": 135,
+					"position": 0,
+					"authorBBID": "e5c4e68b-bfce-4c77-9ca2-0f0a2d4d09f0",
+					"name": "J. K. Rowling",
+					"joinPhrase": ""
+				}
+				]
+			},
+			"bbid": "ceb76296-45a4-44fe-a1da-8ae6ff341f96",
 			"defaultAlias": {
 				"language": "eng",
-				"name": "A Monster Calls",
+				"name": "Harry Potter and the Deathly Hallows",
 				"primary": true,
-				"sortName": "Monster Calls, A"
+				"sortName": "Harry Potter and the Deathly Hallows"
 			},
-			"depth": null,
+			"depth": 45,
 			"disambiguation": null,
-			"editionFormat": "eBook",
-			"height": null,
+			"editionFormat": "Hardcover",
+			"height": 205,
 			"languages": [
 				"eng"
 			],
-			"pages": 214,
-			"releaseEventDates": [
-				"2011-01-01"
+			"pages": 607,
+			"publishers": [
+				{
+				"bbid": "d30d7df9-eb6f-4bd5-a69f-a9a3362a6f4a",
+				"name": "Bloomsbury",
+				"sortName": "Bloomsbury"
+				}
 			],
+			"releaseEventDate": "+002007-07-21",
 			"status": "Official",
 			"weight": null,
-			"width": null
+			"width": 135
 		}
  */
 
 export function getEditionBasicInfo(edition: any) {
 	return _.isNil(edition) ? null :
 		{
-			authorCredit: filterAuthorCredit(edition),
+			authorCredits: getAuthorCredits(edition),
 			bbid: _.get(edition, 'bbid', null),
 			defaultAlias: getDefaultAlias(edition),
 			depth: _.get(edition, 'depth', null),
@@ -222,7 +224,7 @@ export function getEditionBasicInfo(edition: any) {
 			height: _.get(edition, 'height', null),
 			languages: getLanguages(edition),
 			pages: _.get(edition, 'pages', null),
-			publisherSet: filterPublisherSet(edition),
+			publishers: filterPublishers(edition),
 			releaseEventDate: _.get(edition, 'releaseEventSet.releaseEvents[0].date', ''),
 			status: _.get(edition, 'editionStatus.label', null),
 			weight: _.get(edition, 'weight', null),

--- a/src/api/helpers/formatEntityData.ts
+++ b/src/api/helpers/formatEntityData.ts
@@ -223,7 +223,7 @@ export function getEditionBasicInfo(edition: any) {
 			languages: getLanguages(edition),
 			pages: _.get(edition, 'pages', null),
 			publisherSet: filterPublisherSet(edition),
-			releaseEventDates: _.get(edition, 'releaseEventSet.releaseEvents', []).map((event) => event.date),
+			releaseEventDate: _.get(edition, 'releaseEventSet.releaseEvents[0].date', ''),
 			status: _.get(edition, 'editionStatus.label', null),
 			weight: _.get(edition, 'weight', null),
 			width: _.get(edition, 'width', null)

--- a/src/api/routes/edition.js
+++ b/src/api/routes/edition.js
@@ -121,32 +121,20 @@ const editionError = 'Edition not found';
  *                   name:
  *                     type: string
  *                     example: 'J. K. Rowling'
- *        publisherSet:
- *          type: object
- *          properties:
- *            id:
- *              type: integer
- *              example: 2217
- *            publishers:
- *              type: array
- *              items:
- *                type: object
- *                properties:
- *                  bbid:
- *                    type: string
- *                    example: 'd30d7df9-eb6f-4bd5-a69f-a9a3362a6f4a'
- *                  name:
- *                    type: string
- *                    example: 'Bloomsbury'
- *                  sortName:
- *                    type: string
- *                    example: 'Bloomsbury'
- *                  ended:
- *                    type: boolean
- *                    example: false
- *                  publisherType:
- *                    type: string
- *                    example: 'Publisher'
+ *        publishers:
+ *          type: array
+ *          items:
+ * 			  type: object
+ *            properties:
+ *              bbid:
+ *               type: string
+ *               example: 'd30d7df9-eb6f-4bd5-a69f-a9a3362a6f4a'
+ *              name:
+ *               type: string
+ *               example: 'Bloomsbury'
+ *              sortName:
+ *               type: string
+ *               example: 'Bloomsbury'
  */
 
 

--- a/src/api/routes/edition.js
+++ b/src/api/routes/edition.js
@@ -41,7 +41,9 @@ const editionBasicRelations = [
 	'disambiguation',
 	'editionFormat',
 	'editionStatus',
-	'releaseEventSet.releaseEvents'
+	'releaseEventSet.releaseEvents',
+	'authorCredit.names',
+	'publisherSet.publishers'
 ];
 
 const editionError = 'Edition not found';
@@ -96,32 +98,55 @@ const editionError = 'Edition not found';
  *          type: integer
  *          description: 'width in mm'
  *          example: 80
- *    BrowsedEditions:
- *      type: object
- *      properties:
- *        bbid:
- *          type: string
- *          format: uuid
- *          example: 'f94d74ce-c748-4130-8d59-38b290af8af3'
- *        editions:
- *          type: array
- *          items:
- *            type: object
- *            properties:
- *              entity:
- *                $ref: '#/components/schemas/EditionDetail'
- *              relationships:
- *                type: array
- *                items:
- *                  type: object
- *                  properties:
- *                     relationshipTypeID:
- *                       type: number
- *                       example: 4
- *                     relationshipType:
- *                       type: string
- *                       example: 'Publisher'
- *
+ *        authorCredit:
+ *          type: object
+ *          properties:
+ *             authorCount:
+ *               type: integer
+ *               example: 1
+ *             id:
+ *               type: integer
+ *               example: 135
+ *             names:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   authorBBID:
+ *                     type: string
+ *                     example: 'e5c4e68b-bfce-4c77-9ca2-0f0a2d4d09f0'
+ *                   authorCreditID:
+ *                     type: integer
+ *                     example: 135
+ *                   name:
+ *                     type: string
+ *                     example: 'J. K. Rowling'
+ *        publisherSet:
+ *          type: object
+ *          properties:
+ *            id:
+ *              type: integer
+ *              example: 2217
+ *            publishers:
+ *              type: array
+ *              items:
+ *                type: object
+ *                properties:
+ *                  bbid:
+ *                    type: string
+ *                    example: 'd30d7df9-eb6f-4bd5-a69f-a9a3362a6f4a'
+ *                  name:
+ *                    type: string
+ *                    example: 'Bloomsbury'
+ *                  sortName:
+ *                    type: string
+ *                    example: 'Bloomsbury'
+ *                  ended:
+ *                    type: boolean
+ *                    example: false
+ *                  publisherType:
+ *                    type: string
+ *                    example: 'Publisher'
  */
 
 

--- a/src/api/routes/edition.js
+++ b/src/api/routes/edition.js
@@ -124,7 +124,7 @@ const editionError = 'Edition not found';
  *        publishers:
  *          type: array
  *          items:
- * 			  type: object
+ *            type: object
  *            properties:
  *              bbid:
  *               type: string

--- a/test/src/api/helpers.js
+++ b/test/src/api/helpers.js
@@ -112,6 +112,7 @@ export function browseEditionBasicTests(res) {
 			'relationship'
 		);
 		expect(work.entity).to.have.all.keys(
+			'authorCredits',
 			'bbid',
 			'defaultAlias',
 			'depth',
@@ -120,7 +121,8 @@ export function browseEditionBasicTests(res) {
 			'height',
 			'languages',
 			'pages',
-			'releaseEventDates',
+			'publishers',
+			'releaseEventDate',
 			'status',
 			'weight',
 			'width'

--- a/test/src/api/routes/test-edition.js
+++ b/test/src/api/routes/test-edition.js
@@ -52,6 +52,7 @@ describe('GET /Edition', () => {
 		expect(res.status).to.equal(200);
 		expect(res.body).to.be.an('object');
 		expect(res.body).to.have.all.keys(
+			'authorCredit',
 			'bbid',
 			'defaultAlias',
 			'languages',
@@ -61,6 +62,7 @@ describe('GET /Edition', () => {
 			'width',
 			'depth',
 			'pages',
+			'publisherSet',
 			'status',
 			'releaseEventDates',
 			'weight'

--- a/test/src/api/routes/test-edition.js
+++ b/test/src/api/routes/test-edition.js
@@ -64,7 +64,7 @@ describe('GET /Edition', () => {
 			'pages',
 			'publisherSet',
 			'status',
-			'releaseEventDates',
+			'releaseEventDate',
 			'weight'
 		);
 	 });

--- a/test/src/api/routes/test-edition.js
+++ b/test/src/api/routes/test-edition.js
@@ -52,7 +52,7 @@ describe('GET /Edition', () => {
 		expect(res.status).to.equal(200);
 		expect(res.body).to.be.an('object');
 		expect(res.body).to.have.all.keys(
-			'authorCredit',
+			'authorCredits',
 			'bbid',
 			'defaultAlias',
 			'languages',
@@ -62,7 +62,7 @@ describe('GET /Edition', () => {
 			'width',
 			'depth',
 			'pages',
-			'publisherSet',
+			'publishers',
 			'status',
 			'releaseEventDate',
 			'weight'


### PR DESCRIPTION
### Problem
[BB-855](https://tickets.metabrainz.org/browse/BB-855) Add author and publisher information in edition API


### Solution
Update the `/edition/{bbid}` endpoint to share the author and publisher information as well.


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
