### PR TITLE
(CI): Update elasticsearch action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Runs Elasticsearch
         uses: elastic/elastic-github-actions/elasticsearch@master
         with:
-          stack-version: 5.6.8
+          stack-version: 6.8.23
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,17 +38,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes postgresql-client
 
-      #Set up ElasticSearch
-      - name: Run Elasticsearch
-      # Replace this with official elastic-github-actions/elasticsearch once they are ready for prod
-        uses: getong/elasticsearch-action@v1.2
+      - name: Configure sysctl limits for ElasticSearch
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Runs Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
         with:
-          elasticsearch version: '5.6.8'
-          host port: 9200
-          container port: 9200
-          host node port: 9300
-          node port: 9300
-          discovery type: 'single-node'
+          stack-version: 5.6.8
 
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Getting node version error starting today with getong/elasticsearch-action@v1.2 :
> docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.

v1.3 is available and could maybe fix, but we might as well try out the official ES github action
