### PR TITLE
BB-780 and BB-862:  Update ASIN validation/detection regex and add SQL migration

### DIFF
--- a/sql/migrations/2026-03/fix-asin-regex.sql
+++ b/sql/migrations/2026-03/fix-asin-regex.sql
@@ -1,0 +1,8 @@
+BEGIN;
+UPDATE "bookbrainz"."identifier_type"
+SET
+    "validation_regex" = '^(?:B0[A-Z0-9]{8}|\d{9}[X\d])$',
+    "detection_regex" = '(?:https?://)?(?:www\.)?amazon\.(?:com|co\.uk|ca|de|fr|es|it|co\.jp|com\.au|com\.br|nl|in)/.+?/(?:dp|gp/product)/(B0[A-Z0-9]{8}|\d{9}[X\d])'
+WHERE "id" = '5';
+
+COMMIT;

--- a/test/src/client/entity-editor/validators/data.js
+++ b/test/src/client/entity-editor/validators/data.js
@@ -47,7 +47,7 @@ export const VALID_IDENTIFIERS = {
 
 export const IDENTIFIER_TYPES = [{
 	id: 1,
-	validationRegex: /^(?:B\d{2}\w{7}|\d{9}[X\d])$/
+	validationRegex: /^(?:B0[A-Z0-9]{8}|\d{9}[X\d])$/
 }];
 
 export const INVALID_IDENTIFIER = {...VALID_IDENTIFIERS, value: 'B076QRJV1'};

--- a/test/src/client/entity-editor/validators/test-identifier.js
+++ b/test/src/client/entity-editor/validators/test-identifier.js
@@ -41,14 +41,14 @@ function describeValidateIdentifierValueNoIdentifierTypes() {
 }
 
 function describeValidateIdentifierValueWithIdentifierTypes() {
-	it('should pass a valid newer-format ASIN (B0CQKH14BB)', () => {
+	it('should pass a valid newer-format ASIN', () => {
 		const result = validateIdentifierValue(
 			'B0CQKH14BB', 1, IDENTIFIER_TYPES
 		);
 		expect(result).to.be.true;
 	});
 
-	it('should pass a valid older-format ASIN (B076KQRJV1)', () => {
+	it('should pass a valid older-format ASIN', () => {
 		const result = validateIdentifierValue(
 			'B076KQRJV1', 1, IDENTIFIER_TYPES
 		);

--- a/test/src/client/entity-editor/validators/test-identifier.js
+++ b/test/src/client/entity-editor/validators/test-identifier.js
@@ -41,6 +41,26 @@ function describeValidateIdentifierValueNoIdentifierTypes() {
 }
 
 function describeValidateIdentifierValueWithIdentifierTypes() {
+	it('should pass a valid newer-format ASIN (B0CQKH14BB)', () => {
+		const result = validateIdentifierValue(
+			'B0CQKH14BB', 1, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should pass a valid older-format ASIN (B076KQRJV1)', () => {
+		const result = validateIdentifierValue(
+			'B076KQRJV1', 1, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.true;
+	});
+
+	it('should reject an ASIN that does not start with B0', () => {
+		const result = validateIdentifierValue(
+			'C0CQKH14BB', 1, IDENTIFIER_TYPES
+		);
+		expect(result).to.be.false;
+	});
 	it('should pass a non-empty string value that matches the validation regular expression', () => {
 		const result = validateIdentifierValue(
 			'B076KQRJV1', 1, IDENTIFIER_TYPES


### PR DESCRIPTION
## Update 
Amazon ASIN validation and detection regex to support newer formats such as B0CQKH14BB.
Migration script updates production regex in the database
Test data and test cases updated to match new pattern
Ensures both frontend and backend correctly validate new and old ASIN formats

<img width="1680" height="1050" alt="Screenshot 2026-03-03 at 7 24 02 PM" src="https://github.com/user-attachments/assets/f376e363-e37c-4922-ba83-c9a61f531ec9" />

 ### TESTING
---
- [x] I have run the code and manually tested the changes
## AI usage
---
- [ ]  I have used AI in this PR (add more details below)
- [ ] I understand all the changes made in this PR
