### PR TITLE
development: Use native healthchecks in Docker compose

### DIFF
--- a/develop-api.sh
+++ b/develop-api.sh
@@ -12,6 +12,4 @@ else
     DOCKER_COMPOSE_CMD="docker-compose"
 fi
 
-
-$DOCKER_COMPOSE_CMD -f docker-compose.api.yml run --rm startup &&
 $DOCKER_COMPOSE_CMD -f docker-compose.api.yml up --build bookbrainz-api

--- a/develop.sh
+++ b/develop.sh
@@ -12,5 +12,4 @@ else
     DOCKER_COMPOSE_CMD="docker-compose"
 fi
 
-
 $DOCKER_COMPOSE_CMD up --build bookbrainz-site

--- a/develop.sh
+++ b/develop.sh
@@ -13,5 +13,4 @@ else
 fi
 
 
-$DOCKER_COMPOSE_CMD run --rm startup &&
 $DOCKER_COMPOSE_CMD up --build bookbrainz-site

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -11,9 +11,12 @@ services:
     ports:
       - "9098:9098"
     depends_on:
-      # - elasticsearch
-      - redis
-      - postgres
+      # elasticsearch:
+      #   condition: service_healthy
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     volumes:
       - "./config/config.json:/home/bookbrainz/bookbrainz-site/config/config.json:ro"
   
@@ -29,6 +32,12 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -c 'SELECT 1'"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
 
   # elasticsearch:
   #   container_name: elasticsearch
@@ -42,6 +51,12 @@ services:
   #     - "9200:9200"
   #   volumes:
   #     - elasticsearch-data:/usr/share/elasticsearch/data
+  #   healthcheck:
+  #     test: ["CMD-SHELL", "curl -fsS 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s' || exit 1"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 20
+  #     start_period: 20s
 
   redis:
     container_name: redis
@@ -51,18 +66,12 @@ services:
     ports:
       - "6379:6379"
       - "3600:3600"
-
-  startup:
-    image: waisbrot/wait
-    container_name: startup
-    restart: "no"
-    environment:
-      - TARGETS=redis:6379,postgres:5432 #,elasticsearch:9200
-      - TIMEOUT=60
-    depends_on:
-      # - elasticsearch
-      - redis
-      - postgres
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
 
 volumes:
   postgres-data:

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -28,12 +28,11 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -c 'SELECT 1'"]
+      test: ["CMD-SHELL", "pg_isready -U bookbrainz -d bookbrainz"]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,11 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     environment:
-      - POSTGRES_DB=bookbrainz
-      - POSTGRES_USER=bookbrainz
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB -c 'SELECT 1'"]
+      test: ["CMD-SHELL", "pg_isready -U bookbrainz -d bookbrainz"]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,12 @@ services:
     ports:
       - "9099:9099"
     depends_on:
-      - elasticsearch
-      - redis
-      - postgres
+      elasticsearch:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     volumes:
       - "./config/config.json:/home/bookbrainz/bookbrainz-site/config/config.json:ro"
 
@@ -31,6 +34,12 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bookbrainz -d bookbrainz"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
 
   elasticsearch:
     container_name: elasticsearch
@@ -45,6 +54,12 @@ services:
       - "127.0.0.1:9200:9200"
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
 
   redis:
     container_name: redis
@@ -54,18 +69,12 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
       - "127.0.0.1:3600:3600"
-
-  startup:
-    image: waisbrot/wait
-    container_name: startup
-    restart: "no"
-    environment:
-      - TARGETS=redis:6379,postgres:5432,elasticsearch:9200
-      - TIMEOUT=60
-    depends_on:
-      - elasticsearch
-      - redis
-      - postgres
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bookbrainz -d bookbrainz"]
+      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB -c 'SELECT 1'"]
       interval: 5s
       timeout: 3s
       retries: 20


### PR DESCRIPTION
### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->
Docker compose used external image (waisbrot/wait) to delay startup until postgres, elasticsearch and redis were ready. This is an outdated method of doing this.

### Solution
<!-- What does this PR do to fix the problem? -->
I've updated the docker compose to use the docker native health check commands for all three postgres, elasticsearch and redis services.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
This makes the docker compose file more maintainable.

### TESTING
- [x]     I have run the code and manually tested the changes

### AI usage
- [ ]  I have used AI in this PR (add more details below)
- [ ]   I understand all the changes made in this PR