### PR TITLE
feat: support HTML relationship type descriptions

### DIFF
--- a/src/client/components/forms/type-editor/relationship-type.tsx
+++ b/src/client/components/forms/type-editor/relationship-type.tsx
@@ -274,8 +274,9 @@ function RelationshipTypeEditor({relationshipTypeData, parentTypes, attributeTyp
 								<Form.Label>Description</Form.Label>
 								<Form.Control
 									required
+									as="textarea"
 									name="description"
-									type="text"
+									rows={3}
 									value={formData.description}
 									onChange={handleInputChange}
 								/>

--- a/src/client/components/pages/parts/relationship-types-tree.tsx
+++ b/src/client/components/pages/parts/relationship-types-tree.tsx
@@ -20,6 +20,7 @@ import {Button} from 'react-bootstrap';
 import {RelationshipTypeDataT} from '../../forms/type-editor/typeUtils';
 import {orderBy as _orderBy} from 'lodash';
 import {genEntityIconHTMLElement} from '../../../helpers/entity';
+import {sanitize} from 'isomorphic-dompurify';
 
 
 type RelationshipTypeTreePropsT = {
@@ -57,6 +58,8 @@ function RelationshipTypeTree({relationshipTypes, parentId, indentLevel}: Relati
 				}
 				const sourceIconElement = genEntityIconHTMLElement(relType.sourceEntityType);
 				const targetIconElement = genEntityIconHTMLElement(relType.targetEntityType);
+				/* eslint-disable react/no-danger */
+				// We are disabling this rule because we are already sanitizing the html here
 				return (
 					<li className={relOuterClass} key={relType.id}>
 						<p>
@@ -81,7 +84,7 @@ function RelationshipTypeTree({relationshipTypes, parentId, indentLevel}: Relati
 								<div><strong>Reverse link phrase: </strong>{relType.reverseLinkPhrase}</div>
 								<div><strong>Source Entity Type: </strong>{relType.sourceEntityType}</div>
 								<div><strong>Target Entity Type: </strong>{relType.targetEntityType}</div>
-								<div><strong>Description: </strong>{relType.description}</div>
+								<div><strong>Description: </strong><span dangerouslySetInnerHTML={{__html: sanitize(relType.description)}}/></div>
 								<div><strong>Child Order: </strong>{relType.childOrder}</div>
 								<div><strong>Deprecated: </strong>{relType.deprecated ? 'Yes' : 'No'}</div>
 								<div>

--- a/src/client/components/pages/parts/relationship-types-tree.tsx
+++ b/src/client/components/pages/parts/relationship-types-tree.tsx
@@ -48,7 +48,6 @@ function RelationshipTypeTree({relationshipTypes, parentId, indentLevel}: Relati
 
 	let filteredRelationshipTypes = relationshipTypes.filter((relType) => relType.parentId === parentId);
 	filteredRelationshipTypes = _orderBy(filteredRelationshipTypes, ['childOrder', 'id']);
-
 	return (
 		<ul>
 			{filteredRelationshipTypes.map(relType => {
@@ -60,6 +59,7 @@ function RelationshipTypeTree({relationshipTypes, parentId, indentLevel}: Relati
 				const targetIconElement = genEntityIconHTMLElement(relType.targetEntityType);
 				/* eslint-disable react/no-danger */
 				// We are disabling this rule because we are already sanitizing the html here
+				const sanitizedDescription = sanitize(relType.description);
 				return (
 					<li className={relOuterClass} key={relType.id}>
 						<p>
@@ -75,7 +75,7 @@ function RelationshipTypeTree({relationshipTypes, parentId, indentLevel}: Relati
 								{expandedRelationshipTypeIds.includes(relType.id) ? '(Less)' : '(More)'}
 							</Button>
 							<p>
-								<small>{relType.description}</small>
+								<small><span dangerouslySetInnerHTML={{__html: sanitizedDescription}}/></small>
 							</p>
 						</p>
 						{expandedRelationshipTypeIds.includes(relType.id) && (
@@ -84,7 +84,7 @@ function RelationshipTypeTree({relationshipTypes, parentId, indentLevel}: Relati
 								<div><strong>Reverse link phrase: </strong>{relType.reverseLinkPhrase}</div>
 								<div><strong>Source Entity Type: </strong>{relType.sourceEntityType}</div>
 								<div><strong>Target Entity Type: </strong>{relType.targetEntityType}</div>
-								<div><strong>Description: </strong><span dangerouslySetInnerHTML={{__html: sanitize(relType.description)}}/></div>
+								<div><strong>Description: </strong><span dangerouslySetInnerHTML={{__html: sanitizedDescription}}/></div>
 								<div><strong>Child Order: </strong>{relType.childOrder}</div>
 								<div><strong>Deprecated: </strong>{relType.deprecated ? 'Yes' : 'No'}</div>
 								<div>

--- a/src/client/components/pages/relationshipTypes.tsx
+++ b/src/client/components/pages/relationshipTypes.tsx
@@ -15,10 +15,12 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-import {Card} from 'react-bootstrap';
+import {Button, Card} from 'react-bootstrap';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import React from 'react';
 import {RelationshipTypeDataT} from '../forms/type-editor/typeUtils';
 import RelationshipTypeTree from './parts/relationship-types-tree';
+import {faArrowLeft} from '@fortawesome/free-solid-svg-icons';
 
 
 type Props = {
@@ -31,6 +33,9 @@ function RelationshipTypesPage({heading, relationshipTypes}: Props) {
 		<Card>
 			<Card.Header as="h2">
 				{heading}
+				<Button className="float-right" href="/relationship-types" variant="link">
+					<FontAwesomeIcon icon={faArrowLeft}/> All relationships
+				</Button>
 			</Card.Header>
 			<Card.Body>
 				{

--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -46,7 +46,7 @@ import ReactSelect from 'react-select';
 import {RecentlyUsed} from '../../unified-form/common/recently-used';
 import RelationshipSelect from './relationship-select';
 import _ from 'lodash';
-import {getEntityLink} from '../../../common/helpers/utils';
+import {getEntityLink, sanitize} from '../../../common/helpers/utils';
 
 
 function isValidRelationship(relationship: _Relationship) {
@@ -418,6 +418,8 @@ class RelationshipModal
 			// Name of the attribute type belonging to the relationship type. EX: ['position', 'number]
 			attributes = attributeTypes.map(attribute => attribute.name);
 		}
+		/* eslint-disable react/no-danger */
+		// We are disabling this rule because we are already sanitizing the html here
 		return (
 			<Form.Group>
 				<Form.Label>Relationship</Form.Label>
@@ -433,7 +435,7 @@ class RelationshipModal
 				/>
 				{this.state.relationshipType &&
 					<Form.Text muted>
-						{this.state.relationshipType.description}
+						<span dangerouslySetInnerHTML={{__html: sanitize(this.state.relationshipType.description)}}/>
 					</Form.Text>
 				}
 				{


### PR DESCRIPTION
Allows us to add links (amongst other things) in the descriptions stored in the database.

Part of the work being done on the user guide in https://github.com/metabrainz/bookbrainz-user-guide/pull/29

Also adds a "All relationships" button to take you back to the relationship type matrix.

Changed the description input to a textarea:
<img width="689" height="280" alt="image" src="https://github.com/user-attachments/assets/39d00d16-0300-419a-9b22-6d6e94ae3884" />

See the resulting link in this rel type description:
<img width="1297" height="487" alt="image" src="https://github.com/user-attachments/assets/55824240-ae96-4366-a0ad-ecce984071c8" />


If we end up needing to improve the editing experience, we could use markdown syntax instead of HTML, and add a WYSIWYG editor?