### PR TITLE
BB-737: fix: work ordering in unified form's content tab

### DIFF
--- a/src/client/unified-form/content-tab/reducer.ts
+++ b/src/client/unified-form/content-tab/reducer.ts
@@ -3,9 +3,10 @@ import {Action, State} from '../interface/type';
 import Immutable from 'immutable';
 
 
-const initialState = Immutable.Map({});
+const initialState = Immutable.OrderedMap<string, any>();
 
-export function worksReducer(state = initialState, {type, payload}:Action):State {
+export function worksReducer(inputState = initialState, {type, payload}:Action):State {
+	const state = Immutable.OrderedMap.isOrderedMap(inputState) ? inputState : inputState.toOrderedMap();
 	switch (type) {
 		case ADD_WORK:
 			return state.set(payload.id, Immutable.fromJS(payload.value));


### PR DESCRIPTION


# Problem

Ticket: [BB-737](https://tickets.metabrainz.org/browse/BB-737)
When adding works in the unified form's content tab, the order gets messed up after adding the 9th work. For example, the 9th work jumps to position 2 instead of staying at the end.

# Solution

The `worksReducer` was using `Immutable.Map` which doesn't guarantee insertion order. Switched to `Immutable.OrderedMap` which preserves insertion order.
Just changing the initial state wasn't enough because during SSR hydration, `Immutable.fromJS()` in `controller.js` converts everything back to a regular Map. So the reducer also checks and converts it back to OrderedMap if needed.

* [x] I have run the code and manually tested the changes

# Areas of Impact
- `content-tab/reducer.ts` - Used `OrderedMap` instead of `Map` for works to keep the insertion order

# Screen Recordings
### Before
- Here IACTE (9th work) jumps to 2nd position and Jager (10th work) also moves right below it instead of the end

https://github.com/user-attachments/assets/20910346-df09-43d9-946f-367178528f57

### After
- Here IACTE (9th work) stays at the end in correct order after being added

https://github.com/user-attachments/assets/8a5ee2df-03be-4256-80ba-8509ff0e92ef



# AI usage

* [x] I did not use any AI
* [ ] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [ ] I used AI tools for coding
* [ ] I understand all the changes made in this PR


Let me know if you have any suggestions or changes.