### PR TITLE
BB-895: fix: filter recently used to match search text instead of blocking results

### DIFF
--- a/src/client/entity-editor/common/entity-search-field-option.tsx
+++ b/src/client/entity-editor/common/entity-search-field-option.tsx
@@ -199,11 +199,14 @@ class EntitySearchFieldOption extends React.Component<Props> {
 		);
 		const filteredOptions = response.body.filter(combinedFilters);
 		const searchResults = filteredOptions.map(this.entityToOption);
-		if (recentOptions.length > 0) {
+		const filteredRecent = recentOptions.filter(
+			option => option.text.toLowerCase().includes(query.toLowerCase())
+		);
+		if (filteredRecent.length > 0) {
 			return [
 				{
 					label: 'Recently Used',
-					options: recentOptions
+					options: filteredRecent
 				},
 				{
 					label: 'Search Results',
@@ -264,7 +267,6 @@ class EntitySearchFieldOption extends React.Component<Props> {
 			<SelectWrapper
 				{...this.props}
 				blurInputOnSelect
-				cacheOptions
 				isClearable
 				className={`Select${this.props.className ? ` ${this.props.className}` : ''}`}
 				classNamePrefix="react-select"


### PR DESCRIPTION

# Problem

The recently used section in entity search dropdowns shows all recently used items even when the user is typing a search query. This pushes the actual search results down and the user has to scroll to see them.

Ticket: [BB-895](https://tickets.metabrainz.org/browse/BB-895)


# Solution

Filter the recently used section to only show items that match what the user is typing. If nothing matches, only search results are shown without the recently used header. Also removed `cacheOptions` because it was returning old search results and preventing recently used from showing up when searching the same text again.

* [x] I have run the code and manually tested the changes

# Screenshot
### Before
<img width="650" height="503" alt="image" src="https://github.com/user-attachments/assets/d213ffee-d00f-495d-8666-25f771c7bd14" />

### After

Recently used shows when search box is empty
<img width="650" height="480" alt="image" src="https://github.com/user-attachments/assets/a9fe9ef6-da4c-4134-9876-bacecec424b7" />

Only matching recently used entities shown when typing
<img width="650" height="480" alt="image" src="https://github.com/user-attachments/assets/8114e833-3163-46b6-ad2b-c5f7151b6740" />
# AI usage

* [x] I did not use any AI
* [ ] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [ ] I used AI tools for coding
* [ ] I understand all the changes made in this PR


# Action

No action needed.