### PR TITLE
BB-770: Add stay-on-beta cookie preference

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "classnames": "^2.3.2",
     "compression": "^1.7.4",
     "connect-redis": "^7.0.0",
+    "cookie-parser": "^1.4.7",
     "core-js": "^3.20.3",
     "cross-env": "^7.0.3",
     "date-fns": "^2.15.0",

--- a/src/client/components/footer.tsx
+++ b/src/client/components/footer.tsx
@@ -28,7 +28,21 @@ type FooterProps = {
     repositoryUrl: string;
     siteRevision: string;
 };
-function Footer({repositoryUrl, siteRevision}: Props) {
+function Footer({repositoryUrl, siteRevision}: FooterProps) {
+
+    const isBrowser = typeof window !== 'undefined';
+
+    let betaHref = '/set-beta-preference?returnto=/';
+    let betaText = 'Use beta site';
+
+    if (isBrowser) {
+        const currentPath = window.location.pathname + window.location.search;
+        betaHref = `/set-beta-preference?returnto=${encodeURIComponent(currentPath)}`;
+        betaText = window.location.hostname === 'beta.bookbrainz.org' 
+            ? 'Stop using beta site' 
+            : 'Use beta site';
+    }
+
 	return (
 		<footer className="footer">
 			<Container fluid>
@@ -80,7 +94,11 @@ function Footer({repositoryUrl, siteRevision}: Props) {
 							</a> —&nbsp;
 							<a href="https://tickets.metabrainz.org/projects/BB/issues/">
 								Report a Bug
-							</a>
+							</a>         
+                            {' '}—&nbsp;
+                            <a href={betaHref}>
+                                {betaText}
+                            </a>
 						</small>
 					</Col>
 				</Row>

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -29,8 +29,10 @@ import {repositoryUrl, siteRevision, userAgent} from './info';
 import BookBrainzData from 'bookbrainz-data';
 import Debug from 'debug';
 import appCleanup from '../common/helpers/appCleanup';
+import {betaMiddleware} from './helpers/middleware';
 import compression from 'compression';
 import config from '../common/helpers/config';
+import cookieParser from 'cookie-parser';
 import express from 'express';
 import favicon from 'serve-favicon';
 import initInflux from './influx';
@@ -40,7 +42,6 @@ import path from 'path';
 import routes from './routes';
 import serveStatic from 'serve-static';
 import session from '../common/helpers/session';
-
 
 // Initialize log-to-stdout  writer
 logNode({
@@ -69,6 +70,8 @@ app.use(express.urlencoded({
 	extended: false
 }));
 app.use(compression());
+app.use(cookieParser());
+app.use(betaMiddleware());
 
 // Set up serving of static assets
 if (process.env.NODE_ENV === 'development') {

--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -451,3 +451,32 @@ export function validateCollaboratorIdsForCollectionRemove(req, res, next) {
 
 	return next();
 }
+export function betaMiddleware() {
+	const BETA_HOST = process.env.BETA_REDIRECT_HOSTNAME || 'beta.bookbrainz.org';
+
+	return (req, res, next) => {
+		const isBeta = process.env.DEPLOY_ENV === 'beta';
+		const unsetBeta = req.query.unset_beta === '1' && !isBeta;
+		const betaCookie = req.cookies?.beta;
+
+		if (unsetBeta) {
+			res.cookie('beta', '', {
+				path: '/',
+				expires: new Date(Date.now() - 86400000),
+				...(req.secure && { sameSite: 'None', secure: true })
+			});
+		}
+
+		const shouldRedirectToBeta =
+			!isBeta &&
+			betaCookie === 'on' &&
+			!req.originalUrl.includes('/set-beta-preference');
+
+		if (shouldRedirectToBeta) {
+			const newUrl = `${req.protocol}://${BETA_HOST}${req.originalUrl}`;
+			return res.redirect(307, newUrl);
+		}
+
+		next();
+	};
+}

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -21,6 +21,7 @@ import adminLogsRouter from './routes/adminLogs';
 import adminPanelRouter from './routes/adminPanel';
 import authRouter from './routes/auth';
 import authorRouter from './routes/entity/author';
+import betaRouter from './routes/beta';
 import collectionRouter from './routes/collection';
 import collectionsRouter from './routes/collections';
 import editionGroupRouter from './routes/entity/edition-group';
@@ -68,6 +69,7 @@ function initRootRoutes(app) {
 	app.use('/relationship-types', relationshipTypesRouter);
 	app.use('/identifier-type', identifierTypeRouter);
 	app.use('/identifier-types', identifierTypesRouter);
+	app.use('/', betaRouter);
 }
 
 function initEditionGroupRoutes(app) {

--- a/src/server/routes/beta.js
+++ b/src/server/routes/beta.js
@@ -1,0 +1,39 @@
+/* eslint-disable node/no-process-env */
+
+import express from 'express';
+
+const router = express.Router();
+
+router.get('/set-beta-preference', (req, res) => {
+	const isBeta = process.env.DEPLOY_ENV === 'beta';
+	const BETA_HOST = process.env.BETA_REDIRECT_HOSTNAME || 'beta.bookbrainz.org';
+	const PROD_HOST = 'bookbrainz.org';
+
+	if (!isBeta) {
+		res.cookie('beta', 'on', {
+			maxAge: 31536000000,
+			path: '/',
+			...req.secure && {sameSite: 'None', secure: true}
+		});
+	}
+
+	let returnTo = req.query.returnto || '/';
+
+	if (typeof returnTo !== 'string' || !returnTo.startsWith('/') || returnTo.includes('//') || returnTo.includes(':')) {
+		returnTo = '/';
+	}
+
+	const targetHost = isBeta ? PROD_HOST : BETA_HOST;
+	let newUrl = `${req.protocol}://${targetHost}${returnTo}`;
+
+	if (isBeta) {
+		const urlObj = new URL(newUrl);
+		urlObj.searchParams.set('unset_beta', '1');
+		newUrl = urlObj.toString();
+	}
+
+	res.redirect(307, newUrl);
+});
+
+export default router;
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -3618,6 +3618,19 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie-parser@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.7.tgz#e2125635dfd766888ffe90d60c286404fa0e7b26"
+  integrity sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==
+  dependencies:
+    cookie "0.7.2"
+    cookie-signature "1.0.6"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
+
 cookie-signature@1.0.7, cookie-signature@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.7.tgz#ab5dd7ab757c54e60f37ef6550f481c426d10454"


### PR DESCRIPTION
Added the ability for users to stay on the beta site using a cookie (same as MusicBrainz and ListenBrainz).

- New modular beta route + middleware
- Added cookie-parser dependency
- Added the link in the footer
- Fixed open redirect protection and the redirect loop when switching sites

# Problem
Users on `beta.bookbrainz.org` often get redirected back to the production site when they click links or refresh the page. There was no easy way to "stay on beta".

Implements [BB-770](https://tickets.metabrainz.org/browse/BB-770)

# Solution
Implemented a cookie-based system (`beta=on`) with:
- Automatic redirect from production to beta when the cookie is set
- Toggle link in the footer
- Proper cookie clearing when leaving beta
- Open redirect protection

# AI usage
* [x] I did not use AI.

### Testing
Tested locally using `yarn run debug` with two separate ports (9099 for production mode and 9199 for beta mode).
The homepage was quite slow and showed Redis & Elasticsearch connection errors (as expected when running without Docker).  

I verified the “Use beta site” link and the redirect flow.  
Full testing of the “Stop using beta site” flow was limited due to local environment issues.

_I’d really appreciate any recommendations on how to test this more cleanly locally (especially with Docker), or if there’s anything I should change before merging._

* [x] I have run the code and manually tested the changes