### PR TITLE
chore: Update Postgres version to 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:16
+        image: postgres:18
         # Provide the password for postgres
         env:
           POSTGRES_USER: postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
 
 # PostgreSQL client
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-ENV PG_MAJOR=16
+ENV PG_MAJOR=18
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -26,9 +26,11 @@ services:
     image: postgres:16
     user: postgres
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_DB=bookbrainz
+      - POSTGRES_USER=bookbrainz
+      - POSTGRES_PASSWORD=bookbrainz
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -23,7 +23,7 @@ services:
   postgres:
     container_name: postgres
     restart: unless-stopped
-    image: postgres:16
+    image: postgres:18
     user: postgres
     ports:
       - "127.0.0.1:5432:5432"
@@ -32,7 +32,7 @@ services:
       - POSTGRES_USER=bookbrainz
       - POSTGRES_PASSWORD=bookbrainz
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U bookbrainz -d bookbrainz"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   postgres:
     container_name: postgres
     restart: unless-stopped
-    image: postgres:16
+    image: postgres:18
     user: postgres
     ports:
       - "127.0.0.1:5432:5432"
@@ -33,7 +33,7 @@ services:
       - POSTGRES_USER=bookbrainz
       - POSTGRES_PASSWORD=bookbrainz
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U bookbrainz -d bookbrainz"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,9 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_DB=bookbrainz
+      - POSTGRES_USER=bookbrainz
+      - POSTGRES_PASSWORD=bookbrainz
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
On Monday May 11th we will be upgrading our MetaBrainz-wide database cluster to version 18.

Relatively few changes needed for BookBrainz, in theory.  