### PR TITLE
Fix OAuth issues for new accounts

### DIFF
--- a/src/server/helpers/auth.ts
+++ b/src/server/helpers/auth.ts
@@ -69,7 +69,7 @@ class MetaBrainzOAuth2Strategy extends OAuth2Strategy {
 	}
 }
 
-async function _updateMetaBrainzUser(orm:ORM, bbUserJSON, mbUserJSON, accessToken, refreshToken) {
+async function _updateMetaBrainzUser(orm:ORM, bbUserJSON, mbUserJSON) {
 	const {Editor} = orm;
 	const bbUserId = _.get(bbUserJSON, 'id');
 	let fetchedEditor;
@@ -86,8 +86,8 @@ async function _updateMetaBrainzUser(orm:ORM, bbUserJSON, mbUserJSON, accessToke
 	}
 	return fetchedEditor.save({
 		cachedMetabrainzName: mbUserJSON.sub,
-		metabrainzOauthAccessToken: accessToken,
-		metabrainzOauthRefreshToken: refreshToken,
+		metabrainzOauthAccessToken: mbUserJSON.metabrainzOauthAccessToken,
+		metabrainzOauthRefreshToken: mbUserJSON.metabrainzOauthRefreshToken,
 		metabrainzUserId: mbUserJSON.metabrainz_user_id
 	}, {patch: true});
 }
@@ -128,12 +128,20 @@ export function init(app) {
 			strategy = new MetaBrainzOAuth2Strategy(
 				options,
 				async (req: any, accessToken:string, refreshToken:string, profile, done:OAuth2Strategy.VerifyCallback) => {
+					const mbProfile = {
+						...profile,
+						metabrainzOauthAccessToken: accessToken,
+						metabrainzOauthRefreshToken: refreshToken
+					};
 					try {
-						const updatedUser = await _updateMetaBrainzUser(orm, req.user, profile, accessToken, refreshToken);
+						const updatedUser = await _updateMetaBrainzUser(orm, req.user, mbProfile);
+						if (!updatedUser) {
+							return done(null, false, mbProfile);
+						}
 						return done(null, updatedUser.toJSON());
 					}
 					catch (err) {
-						return done(err, false, profile);
+						return done(err, false, mbProfile);
 					}
 				}
 			);

--- a/src/server/helpers/auth.ts
+++ b/src/server/helpers/auth.ts
@@ -79,7 +79,10 @@ async function _updateMetaBrainzUser(orm:ORM, bbUserJSON, mbUserJSON, accessToke
 	}
 	else {
 		fetchedEditor = await new Editor({metabrainzUserId: mbUserJSON.metabrainz_user_id})
-			.fetch({require: true});
+			.fetch({require: false});
+		if (!fetchedEditor) {
+			return null;
+		}
 	}
 	return fetchedEditor.save({
 		cachedMetabrainzName: mbUserJSON.sub,

--- a/src/server/routes/register.js
+++ b/src/server/routes/register.js
@@ -114,6 +114,8 @@ router.post('/handler', async (req, res) => {
 		const editor = await new Editor({
 			cachedMetabrainzName: req.session.mbProfile.sub,
 			genderId: req.body.gender,
+			metabrainzOauthAccessToken: req.session.mbProfile.metabrainzOauthAccessToken,
+			metabrainzOauthRefreshToken: req.session.mbProfile.metabrainzOauthRefreshToken,
 			metabrainzUserId: req.session.mbProfile.metabrainz_user_id,
 			name: req.body.displayName,
 			typeId: editorType.id


### PR DESCRIPTION
Changes in #1306 broke the registration flow.
Specifically, it was previously set up to catch any error (including "this user does not exist" type of errors) and return `null` instead of the error in the catch block. https://github.com/metabrainz/bookbrainz-site/pull/1306/changes#diff-43fe4dfbbf6aa06c58574973dedc78e46a697d88383f88266081cdfa6be53f74R133
This would cause a redirection to the register page when the callback is called with null.

After some of the changes I made, this was not the case anymore.
I refactored the code so that it is a bit clearer, returning `null` early if no user with this metabrainz ID exists in the DB, abnd returning null in the callback.