### PR TITLE
fix(auth): Use epoch timestamp as default for active_at column

### DIFF
--- a/sql/migrations/2026-06-active-at-epoch/down.sql
+++ b/sql/migrations/2026-06-active-at-epoch/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bookbrainz.editor
+	ALTER COLUMN active_at SET DEFAULT timezone('UTC'::TEXT, now());

--- a/sql/migrations/2026-06-active-at-epoch/up.sql
+++ b/sql/migrations/2026-06-active-at-epoch/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bookbrainz.editor
+	ALTER COLUMN active_at SET DEFAULT TIMESTAMP 'epoch';

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -39,7 +39,7 @@ CREATE TABLE bookbrainz.editor (
 	reputation INT NOT NULL DEFAULT 0,
 	bio TEXT NOT NULL DEFAULT '',
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
-	active_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
+	active_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT TIMESTAMP 'epoch',
 	type_id INT NOT NULL,
 	gender_id INT,
 	area_id INT,


### PR DESCRIPTION
Changes the default value of the editor.active_at column from timezone('UTC'::text, now()) to TIMESTAMP 'epoch'.

Previously, new editors were created with active_at defaulting to the current timestamp, implying they were "active" at the moment of account creation. This was incorrect — a brand new user has no activity yet. Using epoch (1970-01-01 00:00:00 UTC) as the default provides a proper sentinel value, so the "last active" display only shows a meaningful date after the user has performed their first action.

Changes:

sql/migrations/2026-06-active-at-epoch/up.sql — new migration
sql/migrations/2026-06-active-at-epoch/down.sql — rollback migration
sql/schemas/bookbrainz.sql — updated schema default