### PR TITLE
Use epoch timestamp as default for active_at column

### DIFF
--- a/sql/migrations/2026-06-active-at-epoch/down.sql
+++ b/sql/migrations/2026-06-active-at-epoch/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bookbrainz.editor
+	ALTER COLUMN active_at SET DEFAULT timezone('UTC'::TEXT, now());

--- a/sql/migrations/2026-06-active-at-epoch/up.sql
+++ b/sql/migrations/2026-06-active-at-epoch/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bookbrainz.editor
+	ALTER COLUMN active_at SET DEFAULT TIMESTAMP 'epoch';

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -39,7 +39,7 @@ CREATE TABLE bookbrainz.editor (
 	reputation INT NOT NULL DEFAULT 0,
 	bio TEXT NOT NULL DEFAULT '',
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
-	active_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT timezone('UTC'::TEXT, now()),
+	active_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT TIMESTAMP 'epoch',
 	type_id INT NOT NULL,
 	gender_id INT,
 	area_id INT,


### PR DESCRIPTION
This is related to the new OAuth workflow where a user row will be created in BB when created in MetaBrainz, but marked as "active" only after first login on BB. The way to mark this is by using the epoch timestamp to initially mark the account as inactive
See also #1307 