### PR TITLE
CI: fix workflows for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,15 @@ name: CI
 on:
   push:
     branches: [master]
-  # Triggers the workflow on pull request events in the context of the fork
-  # trying to sidestep limitations here: https://github.com/wearerequired/lint-action/issues/13
+  # Triggers the workflow on pull request events with fork-safe permissions.
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build-test:
+    name: Build and run tests
     runs-on: ubuntu-latest
 
     services:
@@ -51,7 +54,7 @@ jobs:
           security-enabled: false
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       # Set up the test dabatase
       - name: Set up test database in PostgreSQL
@@ -63,10 +66,10 @@ jobs:
           POSTGRES_HOST: localhost
 
       - name: Set up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v7
         with:
           # We could also test on multiple Node versions if needed: https://github.com/actions/setup-node#matrix-testing
-          node-version: "20"
+          node-version: "24"
           # Enables caching NPM dependencies (uses https://github.com/actions/cache under the hood)
           cache: "yarn"
 
@@ -79,7 +82,7 @@ jobs:
         run: yarn run test-ci # run tests (configured to use mocha's json reporter)
 
       - name: Export test results
-        uses: actions/upload-artifact@v4 # upload test results
+        uses: actions/upload-artifact@v7 # upload test results
         if: success() || failure() # run this step even if previous step failed
         with:
           name: test-results

--- a/.github/workflows/lint-pull-requests.yml
+++ b/.github/workflows/lint-pull-requests.yml
@@ -4,19 +4,17 @@ name: Lint pull requests
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on pull request events in the context of the fork
-  # trying to sidestep limitations here: https://github.com/wearerequired/lint-action/issues/13
-  pull_request_target:
+  # Triggers the workflow on pull request events with fork-safe permissions.
+  pull_request:
 
 # Limit permissions of the token
 # When running an untrusted fork, we don't want to give write permissions
 # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 permissions:
-  checks: write # Allows the creation of annotations on forks
-  contents: read # Don't allow untrusted forks write access
+  contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -26,19 +24,29 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          
-      - name: NPM install
-        uses: bahmutov/npm-install@v1
+        uses: actions/checkout@v7
 
-      - name: Run linters
-        uses: wearerequired/lint-action@v1
+      - name: Set up node
+        uses: actions/setup-node@v7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          eslint: true
-          # Auto-fix requires write permissions to commit changes, which we don't want to allow
-          # See https://github.com/wearerequired/lint-action/issues/13
-          auto_fix: false
-          
+          node-version: "24"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run ESLint
+        id: eslint
+        run: yarn run lint --format json --output-file eslint_report.json
+        continue-on-error: true
+
+      - name: Upload ESLint report
+        uses: actions/upload-artifact@v7
+        if: success() || failure()
+        with:
+          name: eslint-report
+          path: eslint_report.json
+
+      - name: Fail on ESLint errors
+        if: steps.eslint.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -1,0 +1,43 @@
+name: Lint Report
+
+on:
+  workflow_run:
+    workflows: ['Lint pull requests']
+    types:
+      - completed
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  report:
+    name: Report linter results
+    if: >-
+      ${{
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion != 'cancelled' &&
+        github.event.workflow_run.conclusion != 'skipped' &&
+        github.event.workflow_run.pull_requests[0].number
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download ESLint report
+        uses: actions/download-artifact@v8
+        with:
+          name: eslint-report
+          path: lint-results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Publish ESLint check
+        uses: ataylorme/eslint-annotate-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          report-json: lint-results/eslint_report.json
+          check-name: ESLint
+          post-comment: false
+          only-pr-files: true
+          markdown-report-on-step-summary: true

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -4,11 +4,25 @@ on:
     workflows: ['CI']                     # runs after CI workflow
     types:
       - completed
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+
 jobs:
   report:
+    if: >-
+      ${{
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion != 'cancelled' &&
+        github.event.workflow_run.conclusion != 'skipped' &&
+        github.event.workflow_run.pull_requests[0].number
+      }}
     runs-on: ubuntu-latest
     steps:
-    - uses: dorny/test-reporter@v1
+    - name: Publish test report
+      uses: dorny/test-reporter@v3
       with:
         artifact: test-results            # artifact name
         name: Mocha Tests                  # Name of the check run which will be created


### PR DESCRIPTION
See for context https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/
Lint checks are currently failing since July 20th.

We need to move away from `pull_request_target` trigger, which is considered unsafe as it exposes github tokens to arbitrary fork PR code. This requires some more changes to our general CI setup.

- Separate the report flows (consume report files, publish results as checks on the PR and workflow summary) in order to separate permissions (code from PR can publish report file but does not have read or write perms for PR checks).
- Separated lint report from test suite report workflows.
- Also updates actions versions and sets node version to 24 (20 is deprecated, results in warnings in CI currently)

# AI usage

* [x] I did not use any AI


# Action

I guess check that the workflows are working fine in CI, and check how that lookls like for fork PRs also