### PR TITLE
Invalidate deleted users' sessions

### DIFF
--- a/src/server/helpers/auth.ts
+++ b/src/server/helpers/auth.ts
@@ -19,6 +19,7 @@
 
 import * as error from '../../common/helpers/error';
 
+import {DELETED_EDITOR_CACHED_METABRAINZ_NAME} from './editor';
 import OAuth2Strategy from 'passport-oauth2';
 import type {ORM} from 'bookbrainz-data';
 import {PrivilegeType} from '../../common/helpers/privileges-utils';
@@ -92,6 +93,30 @@ async function _updateMetaBrainzUser(orm:ORM, bbUserJSON, mbUserJSON) {
 	}, {patch: true});
 }
 
+function getSerializedUserId(user) {
+	return _.isObject(user) ? _.get(user, 'id') : user;
+}
+
+export async function deserializeEditor(orm: ORM, serializedUser) {
+	const editorId = getSerializedUserId(serializedUser);
+	if (!editorId) {
+		return false;
+	}
+
+	const {Editor} = orm;
+	const editor = await new Editor({id: editorId}).fetch({require: false});
+	if (!editor) {
+		return false;
+	}
+
+	const editorJSON = editor.toJSON();
+	if (editorJSON.cachedMetabrainzName === DELETED_EDITOR_CACHED_METABRAINZ_NAME) {
+		return false;
+	}
+
+	return editorJSON;
+}
+
 export function init(app) {
 	const {orm} = app.locals as {orm: ORM};
 	try {
@@ -149,11 +174,17 @@ export function init(app) {
 		passport.use(strategy);
 
 		passport.serializeUser((user, done) => {
-			done(null, user);
+			const userId = getSerializedUserId(user);
+			if (!userId) {
+				return done(new Error('Cannot serialize user without an editor ID'));
+			}
+			return done(null, userId);
 		});
 
-		passport.deserializeUser((user, done) => {
-			done(null, user);
+		passport.deserializeUser((serializedUser, done) => {
+			deserializeEditor(orm, serializedUser)
+				.then(user => done(null, user))
+				.catch(err => done(err));
 		});
 
 		app.use(passport.initialize());

--- a/src/server/helpers/editor.ts
+++ b/src/server/helpers/editor.ts
@@ -2,6 +2,8 @@
 import type {ORM} from 'bookbrainz-data';
 
 
+export const DELETED_EDITOR_CACHED_METABRAINZ_NAME = '<deleted>';
+
 export function fetchEditorByMetaBrainzUserId(orm: ORM, metabrainzUserId: number) {
 	const {Editor} = orm;
 
@@ -16,7 +18,7 @@ function clearEditorByID(trx, editorID) {
 		.update({
 			area_id: null,
 			bio: '',
-			cached_metabrainz_name: '<deleted>',
+			cached_metabrainz_name: DELETED_EDITOR_CACHED_METABRAINZ_NAME,
 			gender_id: null,
 			metabrainz_oauth_access_token: null,
 			metabrainz_oauth_refresh_token: null,

--- a/src/server/routes/entity/entity.tsx
+++ b/src/server/routes/entity/entity.tsx
@@ -267,7 +267,7 @@ function _createNote(orm, content, editorID, revision, transacting) {
 export function addNoteToRevision(req: PassportRequest, res: $Response) {
 	const {orm}: {orm?: any} = req.app.locals;
 	const {Revision, bookshelf} = orm;
-	const editorJSON = req.session.passport.user;
+	const editorJSON = req.user;
 	const revision = Revision.forge({id: req.params.id});
 	const {body}: {body: any} = req;
 	const revisionNotePromise = bookshelf.transaction(
@@ -425,7 +425,7 @@ export function handleDelete(
 		throw new error.ConflictError('This entity has already been deleted');
 	}
 	const {Revision, bookshelf} = orm;
-	const editorJSON = req.session.passport.user;
+	const editorJSON = req.user;
 	const {body}: {body: any} = req;
 	const entityDeletePromise = bookshelf.transaction(async (transacting) => {
 		if (!body.note || !body.note.length) {

--- a/test/src/server/helpers/auth.js
+++ b/test/src/server/helpers/auth.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 MetaBrainz Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {createEditor, truncateEntities} from '../../../test-helpers/create-entities';
+
+import chai from 'chai';
+import {deserializeEditor} from '../../../../src/server/helpers/auth';
+import orm from '../../../bookbrainz-data';
+
+
+const {expect} = chai;
+
+describe('auth helpers', () => {
+	afterEach(truncateEntities);
+
+	describe('deserializeEditor', () => {
+		it('should fetch an active editor from a serialized editor ID', async () => {
+			const editor = await createEditor(123456);
+
+			const deserializedEditor = await deserializeEditor(orm, editor.id);
+
+			expect(deserializedEditor.id).to.equal(editor.id);
+			expect(deserializedEditor.name).to.equal(editor.get('name'));
+		});
+
+		it('should support legacy sessions serialized with full editor JSON', async () => {
+			const editor = await createEditor(123456);
+
+			const deserializedEditor = await deserializeEditor(orm, editor.toJSON());
+
+			expect(deserializedEditor.id).to.equal(editor.id);
+		});
+
+		it('should reject missing editors', async () => {
+			const deserializedEditor = await deserializeEditor(orm, 999999);
+
+			expect(deserializedEditor).to.equal(false);
+		});
+
+		it('should reject deleted editors', async () => {
+			const editor = await createEditor(123456);
+			await editor.save({
+				cachedMetabrainzName: '<deleted>',
+				name: `Deleted Editor #${editor.id}`
+			}, {patch: true});
+
+			const deserializedEditor = await deserializeEditor(orm, editor.id);
+
+			expect(deserializedEditor).to.equal(false);
+		});
+	});
+});


### PR DESCRIPTION
When deleting a user from the MetaBrainz.org account page, the logged-in user never got logged out resulting in a weird state where a deleted user may make some edits.
Changed the auth session strategy to check for an existing active user, and return no session if the user is deleted.