### PR TITLE
Review database dumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN touch /etc/service/cron/down
 
 ADD ./docker/services/cron/crontab /etc/cron.d/bookbrainz
 RUN chmod 0644 /etc/cron.d/bookbrainz && crontab -u bookbrainz /etc/cron.d/bookbrainz
+RUN mkdir -p /tmp/logs
 
 # Build JS project and assets
 RUN ["yarn", "run", "build"]

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -1,7 +1,4 @@
 # m h d m w
 
-# Database backup creation
-10 01 * * 1 root /home/bookbrainz/bookbrainz-site/scripts/create-dumps.sh >> /tmp/logs/create-dumps-logs 2>&1
-
-# Copy dumps over to MusicBrainz FTP
-30 01 * * 1 root /home/bookbrainz/bookbrainz-site/scripts/rsync-dump-files.sh >> /tmp/logs/rsync-dumps-logs 2>&1
+# Database backup creation and copy to MusicBrainz FTP
+01 00 * * 1 root /home/bookbrainz/bookbrainz-site/scripts/create-and-rsync-dumps.sh >> /tmp/logs/create-and-rsync-dumps-logs 2>&1

--- a/scripts/create-and-rsync-dumps.sh
+++ b/scripts/create-and-rsync-dumps.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+/home/bookbrainz/bookbrainz-site/scripts/create-dumps.sh
+/home/bookbrainz/bookbrainz-site/scripts/rsync-dump-files.sh

--- a/scripts/create-dumps.sh
+++ b/scripts/create-dumps.sh
@@ -8,19 +8,110 @@ source /home/bookbrainz/bookbrainz-site/scripts/config.sh
 pushd /home/bookbrainz/data/dumps
 
 
-DUMP_FILE=bookbrainz-dump-`date -I`.sql
+DUMP_FILE=bookbrainz-dump-$(date -I).sql
+
+# Explicit allowlist for public database dumps. Keep this in sync with the
+# tables that are safe to export.
+EXPORTED_TABLES=(
+	musicbrainz.gender
+	musicbrainz.language
+	musicbrainz.area_type
+	musicbrainz.area
+	musicbrainz.l_area_area
+	musicbrainz.country_area
+	bookbrainz.editor_type
+	bookbrainz.editor
+	bookbrainz.editor__language
+	bookbrainz.admin_log
+	bookbrainz.entity
+	bookbrainz.entity_redirect
+	bookbrainz.author_header
+	bookbrainz.edition_group_header
+	bookbrainz.edition_header
+	bookbrainz.publisher_header
+	bookbrainz.work_header
+	bookbrainz.revision_parent
+	bookbrainz.revision
+	bookbrainz.author_revision
+	bookbrainz.edition_group_revision
+	bookbrainz.edition_revision
+	bookbrainz.publisher_revision
+	bookbrainz.work_revision
+	bookbrainz.note
+	bookbrainz.author_type
+	bookbrainz.author_data
+	bookbrainz.release_event
+	bookbrainz.release_event_set
+	bookbrainz.release_event_set__release_event
+	bookbrainz.author_credit
+	bookbrainz.author_credit_name
+	bookbrainz.publisher_set
+	bookbrainz.publisher_set__publisher
+	bookbrainz.edition_format
+	bookbrainz.edition_status
+	bookbrainz.edition_data
+	bookbrainz.edition_group_type
+	bookbrainz.edition_group_data
+	bookbrainz.publisher_type
+	bookbrainz.publisher_data
+	bookbrainz.work_type
+	bookbrainz.work_data
+	bookbrainz.annotation
+	bookbrainz.disambiguation
+	bookbrainz.alias
+	bookbrainz.identifier_type
+	bookbrainz.identifier
+	bookbrainz.relationship_type
+	bookbrainz.alias_set
+	bookbrainz.alias_set__alias
+	bookbrainz.identifier_set
+	bookbrainz.identifier_set__identifier
+	bookbrainz.relationship_set
+	bookbrainz.relationship_set__relationship
+	bookbrainz.relationship
+	bookbrainz.relationship_attribute_set
+	bookbrainz.relationship_attribute_type
+	bookbrainz.relationship_type__attribute_type
+	bookbrainz.relationship_attribute
+	bookbrainz.relationship_attribute_text_value
+	bookbrainz.relationship_attribute_set__relationship_attribute
+	bookbrainz.language_set
+	bookbrainz.language_set__language
+	bookbrainz.series_header
+	bookbrainz.series_ordering_type
+	bookbrainz.series_data
+	bookbrainz.series_revision
+	bookbrainz.title_type
+	bookbrainz.title_unlock
+	bookbrainz.achievement_type
+	bookbrainz.achievement_unlock
+	# Imports - TODO: evaluate whether we wwant those exported in the dumps
+	bookbrainz.import
+	bookbrainz.author_import_header
+	bookbrainz.edition_import_header
+	bookbrainz.edition_group_import_header
+	bookbrainz.publisher_import_header
+	bookbrainz.work_import_header
+	bookbrainz.discard_votes
+	bookbrainz.origin_source
+	bookbrainz.link_import
+)
+
+PG_DUMP_TABLE_ARGS=()
+for table_name in "${EXPORTED_TABLES[@]}"; do
+	PG_DUMP_TABLE_ARGS+=("--table=$table_name")
+done
 
 echo "Creating data dump..."
 
 # Dump new backup to /tmp
-pg_dump\
-	-h $POSTGRES_HOST \
-	-p $POSTGRES_PORT \
+pg_dump \
+	-h "$POSTGRES_HOST" \
+	-p "$POSTGRES_PORT" \
 	-U bookbrainz \
-	-T _editor_entity_visits\
-	-T user_collection*\
-	 --serializable-deferrable\
-	 bookbrainz > /tmp/$DUMP_FILE
+	"${PG_DUMP_TABLE_ARGS[@]}" \
+	--serializable-deferrable \
+	bookbrainz > "/tmp/$DUMP_FILE"
 echo "Dump created!"
 
 # Compress new backup and move to dump dir

--- a/scripts/create-dumps.sh
+++ b/scripts/create-dumps.sh
@@ -107,6 +107,7 @@ for table_name in "${EXPORTED_TABLES[@]}"; do
 done
 
 append_copy_from_query() {
+	#  Allows us to append a COPY FROM query to the dump file for exporting filtered data.
 	local table_name=$1
 	local columns=$2
 	local query=$3
@@ -160,9 +161,42 @@ append_public_collection_data() {
 		"
 }
 
+append_editor_data() {
+	#  Specifically ignore the columns that contain OAuth tokens
+	#  postgres will fill them with NULLs when importing
+	local editor_columns="id, name, metabrainz_user_id, cached_metabrainz_name, reputation, bio, "
+	editor_columns+="created_at, active_at, type_id, gender_id, area_id, privs, "
+	editor_columns+="revisions_applied, revisions_reverted, total_revisions, title_unlock_id"
+
+	append_copy_from_query \
+		bookbrainz.editor \
+		"$editor_columns" \
+		"
+			SELECT
+				id,
+				name,
+				metabrainz_user_id,
+				cached_metabrainz_name,
+				reputation,
+				bio,
+				created_at,
+				active_at,
+				type_id,
+				gender_id,
+				area_id,
+				privs,
+				revisions_applied,
+				revisions_reverted,
+				total_revisions,
+				title_unlock_id
+			FROM bookbrainz.editor
+		"
+}
+
 echo "Creating data dump..."
 
-# We do the dump in 3 steps because --table used for allowlisting does not create schema objects, indexes, constraints etc..
+# We do the dump in multiple steps because --table used for allowlisting does not create schema objects, indexes, constraints etc.
+# Furthermore we want to filter out sensitive data from some tables, which is not possible with pg_dump's --table option.
 # So we first dump the schema objects, then the allowlisted table data, and finally the indexes, constraints and triggers.
 
 # Dump schema objects that must exist before data.
@@ -182,6 +216,8 @@ pg_dump \
 	-p "$POSTGRES_PORT" \
 	-U bookbrainz \
 	"${PG_DUMP_TABLE_ARGS[@]}" \
+	# We process some tables separately to filter out sensitive or private data
+	--exclude-table-data=bookbrainz.editor \
 	--exclude-table-data=bookbrainz.user_collection \
 	--exclude-table-data=bookbrainz.user_collection_item \
 	--exclude-table-data=bookbrainz.user_collection_collaborator \
@@ -189,6 +225,10 @@ pg_dump \
 	--serializable-deferrable \
 	bookbrainz >> "/tmp/$DUMP_FILE"
 echo "Main dump created"
+
+echo "Exporting editor data without OAuth tokens..."
+append_editor_data
+echo "Editor data exported"
 
 echo "Exporting public collections..."
 append_public_collection_data

--- a/scripts/create-dumps.sh
+++ b/scripts/create-dumps.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-source /home/bookbrainz/bookbrainz-site/scripts/config.sh
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+source /home/monkey/Work/BookBrainz/bookbrainz-site-test/scripts/config.sh
 
 # Switch directory
 pushd /home/bookbrainz/data/dumps
@@ -95,12 +97,70 @@ EXPORTED_TABLES=(
 	bookbrainz.discard_votes
 	bookbrainz.origin_source
 	bookbrainz.link_import
+	# User collections are processed to only export public collections info
+	bookbrainz.user_collection
+	bookbrainz.user_collection_item
+	bookbrainz.user_collection_collaborator
 )
 
 PG_DUMP_TABLE_ARGS=()
 for table_name in "${EXPORTED_TABLES[@]}"; do
 	PG_DUMP_TABLE_ARGS+=("--table=$table_name")
 done
+
+append_copy_from_query() {
+	local table_name=$1
+	local columns=$2
+	local query=$3
+
+	{
+		echo
+		echo "COPY $table_name ($columns) FROM stdin;"
+		psql \
+			-h "$POSTGRES_HOST" \
+			-p "$POSTGRES_PORT" \
+			-U bookbrainz \
+			-d bookbrainz \
+			-v ON_ERROR_STOP=1 \
+			--tuples-only \
+			--no-align \
+			--command "COPY ($query) TO STDOUT;"
+		echo "\\."
+	} >> "/tmp/$DUMP_FILE"
+}
+
+append_public_collection_data() {
+	append_copy_from_query \
+		bookbrainz.user_collection \
+		"id, owner_id, name, description, entity_type, public, created_at, last_modified" \
+		"
+			SELECT
+				id,
+				owner_id,
+				name,
+				description,
+				entity_type,
+				public,
+				created_at,
+				last_modified
+			FROM bookbrainz.user_collection
+			WHERE public = TRUE
+		"
+
+	append_copy_from_query \
+		bookbrainz.user_collection_item \
+		"collection_id, bbid, added_at" \
+		"
+			SELECT
+				item.collection_id,
+				item.bbid,
+				item.added_at
+			FROM bookbrainz.user_collection_item item
+			JOIN bookbrainz.user_collection collection
+				ON collection.id = item.collection_id
+			WHERE collection.public = TRUE
+		"
+}
 
 echo "Creating data dump..."
 
@@ -110,11 +170,19 @@ pg_dump \
 	-p "$POSTGRES_PORT" \
 	-U bookbrainz \
 	"${PG_DUMP_TABLE_ARGS[@]}" \
+	--exclude-table-data=bookbrainz.user_collection \
+	--exclude-table-data=bookbrainz.user_collection_item \
+	--exclude-table-data=bookbrainz.user_collection_collaborator \
 	--serializable-deferrable \
-	bookbrainz > "/tmp/$DUMP_FILE"
-echo "Dump created!"
+	bookbrainz >> "/tmp/$DUMP_FILE"
+echo "Main dump created"
+
+echo "Exporting public collections..."
+append_public_collection_data
+echo "Public collections exported"
 
 # Compress new backup and move to dump dir
+echo "Successfully created public dump: $DUMP_FILE"
 echo "Compressing..."
 rm -f /tmp/$DUMP_FILE.bz2
 bzip2 /tmp/$DUMP_FILE

--- a/scripts/create-dumps.sh
+++ b/scripts/create-dumps.sh
@@ -211,12 +211,12 @@ pg_dump \
 	bookbrainz > "/tmp/$DUMP_FILE"
 
 # Dump allowlisted table data to /tmp.
+# We process some tables separately (exclude-table-data) to filter out sensitive or private data
 pg_dump \
 	-h "$POSTGRES_HOST" \
 	-p "$POSTGRES_PORT" \
 	-U bookbrainz \
 	"${PG_DUMP_TABLE_ARGS[@]}" \
-	# We process some tables separately to filter out sensitive or private data
 	--exclude-table-data=bookbrainz.editor \
 	--exclude-table-data=bookbrainz.user_collection \
 	--exclude-table-data=bookbrainz.user_collection_item \

--- a/scripts/create-dumps.sh
+++ b/scripts/create-dumps.sh
@@ -2,9 +2,7 @@
 
 set -e
 
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-
-source /home/monkey/Work/BookBrainz/bookbrainz-site-test/scripts/config.sh
+source /home/bookbrainz/bookbrainz-site/scripts/config.sh
 
 # Switch directory
 pushd /home/bookbrainz/data/dumps

--- a/scripts/create-dumps.sh
+++ b/scripts/create-dumps.sh
@@ -164,7 +164,21 @@ append_public_collection_data() {
 
 echo "Creating data dump..."
 
-# Dump new backup to /tmp
+# We do the dump in 3 steps because --table used for allowlisting does not create schema objects, indexes, constraints etc..
+# So we first dump the schema objects, then the allowlisted table data, and finally the indexes, constraints and triggers.
+
+# Dump schema objects that must exist before data.
+pg_dump \
+	-h "$POSTGRES_HOST" \
+	-p "$POSTGRES_PORT" \
+	-U bookbrainz \
+	--schema=bookbrainz \
+	--schema=musicbrainz \
+	--exclude-table=bookbrainz._editor_entity_visits \
+	--section=pre-data \
+	bookbrainz > "/tmp/$DUMP_FILE"
+
+# Dump allowlisted table data to /tmp.
 pg_dump \
 	-h "$POSTGRES_HOST" \
 	-p "$POSTGRES_PORT" \
@@ -173,6 +187,7 @@ pg_dump \
 	--exclude-table-data=bookbrainz.user_collection \
 	--exclude-table-data=bookbrainz.user_collection_item \
 	--exclude-table-data=bookbrainz.user_collection_collaborator \
+	--data-only \
 	--serializable-deferrable \
 	bookbrainz >> "/tmp/$DUMP_FILE"
 echo "Main dump created"
@@ -180,6 +195,18 @@ echo "Main dump created"
 echo "Exporting public collections..."
 append_public_collection_data
 echo "Public collections exported"
+
+echo "Adding indexes, constraints and triggers..."
+pg_dump \
+	-h "$POSTGRES_HOST" \
+	-p "$POSTGRES_PORT" \
+	-U bookbrainz \
+	--schema=bookbrainz \
+	--schema=musicbrainz \
+	--exclude-table=bookbrainz._editor_entity_visits \
+	--section=post-data \
+	bookbrainz >> "/tmp/$DUMP_FILE"
+echo "Indexes, constraints and triggers added"
 
 # Compress new backup and move to dump dir
 echo "Successfully created public dump: $DUMP_FILE"

--- a/scripts/create-test-db.sh
+++ b/scripts/create-test-db.sh
@@ -9,7 +9,7 @@
 export PGPASSWORD=$POSTGRES_PASSWORD
 
 psql -c "CREATE DATABASE ${POSTGRES_DB};" -U $POSTGRES_USER -h $POSTGRES_HOST
-psql -c 'CREATE EXTENSION "uuid-ossp"; CREATE SCHEMA musicbrainz; CREATE SCHEMA bookbrainz;' -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST
+psql -c 'CREATE SCHEMA musicbrainz; CREATE SCHEMA bookbrainz;' -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST
 psql -f sql/schemas/musicbrainz.sql -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST
 psql -f sql/schemas/bookbrainz.sql -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST
 psql -f sql/scripts/create_triggers.sql -d $POSTGRES_DB -U $POSTGRES_USER -h $POSTGRES_HOST

--- a/scripts/download-import-dump.sh
+++ b/scripts/download-import-dump.sh
@@ -30,13 +30,3 @@ fi
 
 # Clean up the dump file if it imported correctly.
 rm -f $DUMP_FILE
-
-# Dumps do not include user_collection_* tables, so we need to run the migration script to create them.
-echo "Running user_collection tables script"
-psql -h $DB_HOSTNAME -p $DB_PORT -U $DB_USER -d $DB_NAME -f sql/migrations/user-collection/up.sql
-if [ $? -ne 0 ]
-then
-    echo "Failed to run sql/migrations/user-collection/up.sql"
-    exit $?
-fi
-

--- a/scripts/download-import-dump.sh
+++ b/scripts/download-import-dump.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
-DB_HOSTNAME=postgres
-DB_PORT=5432
-DB_USER=bookbrainz
-DB_NAME=bookbrainz
+# set up variables with defaults
+: "${POSTGRES_USER:=bookbrainz}"
+: "${POSTGRES_PASSWORD:=}"
+: "${POSTGRES_DB:=bookbrainz}"
+: "${POSTGRES_HOST:=postgres}"
+: "${POSTGRES_PORT:=5432}"
 
 DUMP_DIR=/tmp/bookbrainz-dumps
 DUMP_FILE=$DUMP_DIR/latest.sql.bz2
+
+# Create the DB before restoring the dump
+export PGPASSWORD=$POSTGRES_PASSWORD
+psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d postgres \
+-c "CREATE DATABASE $POSTGRES_DB;"
 
 if [ -f $DUMP_FILE ]; then
     echo "A bookbrainz dump file, already exists. Using that to import."
@@ -21,7 +28,7 @@ else
     fi
 fi
 
-bzcat $DUMP_FILE | psql -h $DB_HOSTNAME -p $DB_PORT -U $DB_USER -d $DB_NAME
+bzcat $DUMP_FILE | psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -d $POSTGRES_DB
 if [ $? -ne 0 ]
 then
     echo "Importing the bookbrainz database failed."

--- a/scripts/download-import-dump.sh
+++ b/scripts/download-import-dump.sh
@@ -2,7 +2,7 @@
 
 # set up variables with defaults
 : "${POSTGRES_USER:=bookbrainz}"
-: "${POSTGRES_PASSWORD:=}"
+: "${POSTGRES_PASSWORD:=""}"
 : "${POSTGRES_DB:=bookbrainz}"
 : "${POSTGRES_HOST:=postgres}"
 : "${POSTGRES_PORT:=5432}"

--- a/sql/migrations/2026-08-03-uuid-generation/down.sql
+++ b/sql/migrations/2026-08-03-uuid-generation/down.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
+
+ALTER TABLE bookbrainz.entity
+	ALTER COLUMN bbid SET DEFAULT public.uuid_generate_v4();
+
+ALTER TABLE bookbrainz.user_collection
+	ALTER COLUMN id SET DEFAULT public.uuid_generate_v4();

--- a/sql/migrations/2026-08-03-uuid-generation/up.sql
+++ b/sql/migrations/2026-08-03-uuid-generation/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE bookbrainz.entity
+	ALTER COLUMN bbid SET DEFAULT gen_random_uuid();
+
+ALTER TABLE bookbrainz.user_collection
+	ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+DROP EXTENSION IF EXISTS "uuid-ossp";

--- a/sql/migrations/user-collection/up.sql
+++ b/sql/migrations/user-collection/up.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE TABLE IF NOT EXISTS bookbrainz.user_collection (
-	id UUID PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 	owner_id INT NOT NULL,
 	name VARCHAR(80) NOT NULL CHECK (name <> ''),
 	description TEXT NOT NULL DEFAULT '',

--- a/sql/schemas/bookbrainz.sql
+++ b/sql/schemas/bookbrainz.sql
@@ -78,7 +78,7 @@ ALTER TABLE bookbrainz.admin_log ADD FOREIGN KEY (admin_id) REFERENCES bookbrain
 ALTER TABLE bookbrainz.admin_log ADD FOREIGN KEY (target_user_id) REFERENCES bookbrainz.editor (id);
 
 CREATE TABLE bookbrainz.entity (
-	bbid UUID PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+	bbid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 	type bookbrainz.entity_type NOT NULL
 );
 ALTER TABLE bookbrainz.entity ADD FOREIGN KEY (bbid) REFERENCES bookbrainz.entity (bbid);
@@ -805,7 +805,7 @@ ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (import_id) REFERENCES bookbr
 ALTER TABLE bookbrainz.link_import ADD FOREIGN KEY (origin_source_id) REFERENCES bookbrainz.origin_source (id);
 
 CREATE TABLE bookbrainz.user_collection (
-	id UUID PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 	owner_id INT NOT NULL,
 	name VARCHAR(80) NOT NULL CHECK (name <> ''),
 	description TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
# Problem
1. We were leaking OAuth tokens in the DB dumps :facepalm: both critiquebrainz ~and metabrainz oauth tokens~ (the new MeB tokens were not dumped, see point 3)
2. We were not dumping collections, as we needed some changes to dump only public ones (see also #1187 and #513 ) 
3. Dumps seem to have been broken since May

# Solution

We needed to implement a few changes to the dump generation:
1. make the table denylist into an allowlist, listing each table that we wanmt to see exported
2. for some tables, we want to filter the data and only export what should be public (no oauth tokens, no private collections)

We have to create dumps in multiple parts, to allow for exporting:
- the schema and other DB objects (not exported when using `--table`, the allowlist mechanism)
  - Don't export `_editor_entity_visits` table
- the data we need using `--table` allowlist
- the filtered data (excluded from the previous section with `--exclude-table-data`)
  - editor table without OAuth tokens
  - user_collection and associated tables, filtered for public collections only
- finally the triggers, indices, constraints, etc.


I also removed the uuid-ossp extension, as UUID generation is now supported natively by postgres. Restoring the dumps was problematic with that extension, as the extension needed to be created before the import.


* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

Used Codex to help with the dump creation script, specifically how to break it down into multiple parts
Manually tested everything from A to Z, both locally and in production to create a new dump with no private data

# Action

* [x] Create a new database dump without private data, synced to public FTP 
* [ ] Create a full dump with all the data, synced to our private backup server