### PR TITLE
Private database dumps

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -2,4 +2,4 @@
 
 # Database backup creation and copy to MusicBrainz FTP
 00 00 * * 1 root /home/bookbrainz/bookbrainz-site/scripts/create-private-dumps.sh >> /tmp/logs/create-private-dumps-logs 2>&1
-01 00 * * 1 root /home/bookbrainz/bookbrainz-site/scripts/create-and-rsync-dumps.sh >> /tmp/logs/create-and-rsync-dumps-logs 2>&1
+01 00 * * 1 root /home/bookbrainz/bookbrainz-site/scripts/create-and-rsync-public-dumps.sh >> /tmp/logs/create-and-rsync-dumps-logs 2>&1

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -1,4 +1,5 @@
 # m h d m w
 
 # Database backup creation and copy to MusicBrainz FTP
+00 00 * * 1 root /home/bookbrainz/bookbrainz-site/scripts/create-private-dumps.sh >> /tmp/logs/create-private-dumps-logs 2>&1
 01 00 * * 1 root /home/bookbrainz/bookbrainz-site/scripts/create-and-rsync-dumps.sh >> /tmp/logs/create-and-rsync-dumps-logs 2>&1

--- a/scripts/config.sh.ctmpl
+++ b/scripts/config.sh.ctmpl
@@ -15,3 +15,6 @@ RSYNC_FULLEXPORT_HOST="{{template "KEY" "rsync_fullexport_host"}}"
 RSYNC_FULLEXPORT_PORT="{{template "KEY" "rsync_fullexport_port"}}"
 RSYNC_FULLEXPORT_DIR="/home/bookbrainz/data/dumps"
 RSYNC_FULLEXPORT_KEY='/home/bookbrainz/.ssh/rsync-bookbrainz-dumps'
+
+#Private dumps
+PRIVATE_BACKUP_FOLDER="{{template "KEY" "private_backup_dir"}}"

--- a/scripts/create-and-rsync-dumps.sh
+++ b/scripts/create-and-rsync-dumps.sh
@@ -2,5 +2,6 @@
 
 set -e
 
-/home/bookbrainz/bookbrainz-site/scripts/create-dumps.sh
+/home/bookbrainz/bookbrainz-site/scripts/create-private-dumps.sh
+/home/bookbrainz/bookbrainz-site/scripts/create-public-dumps.sh
 /home/bookbrainz/bookbrainz-site/scripts/rsync-dump-files.sh

--- a/scripts/create-and-rsync-public-dumps.sh
+++ b/scripts/create-and-rsync-public-dumps.sh
@@ -2,6 +2,5 @@
 
 set -e
 
-/home/bookbrainz/bookbrainz-site/scripts/create-private-dumps.sh
 /home/bookbrainz/bookbrainz-site/scripts/create-public-dumps.sh
 /home/bookbrainz/bookbrainz-site/scripts/rsync-dump-files.sh

--- a/scripts/create-private-dumps.sh
+++ b/scripts/create-private-dumps.sh
@@ -2,13 +2,20 @@
 
 set -e
 
-source /home/bookbrainz/bookbrainz-site/scripts/config.sh
+BB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 
-PRIVATE_BACKUP_FOLDER=/mnt/private_backup
+source $BB_SERVER_ROOT/scripts/config.sh
+source $BB_SERVER_ROOT/scripts/functions.sh
+
 PRIVATE_DUMP_FILE=bookbrainz-full-dump-$(date -I).sql
 
-# Switch directory
-pushd $PRIVATE_BACKUP_FOLDER
+# Check that the directory exists
+if [ -d $PRIVATE_BACKUP_FOLDER ]; then
+    echo "Private backup folder exists at $PRIVATE_BACKUP_FOLDER"
+else
+    echo "Private backup folder does not exist at $PRIVATE_BACKUP_FOLDER, aborting"
+	exit 1
+fi
 
 echo "Creating full private dump..."
 pg_dump \
@@ -32,8 +39,6 @@ if [ "$(find "$PRIVATE_BACKUP_FOLDER" -maxdepth 1 -name '*.sql.bz2' -type f | se
 fi
 echo "Done!"
 
-chmod 600 ./*
-
-popd
+chmod 600 $PRIVATE_BACKUP_FOLDER/*
 
 exit 0

--- a/scripts/create-private-dumps.sh
+++ b/scripts/create-private-dumps.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+
+source /home/bookbrainz/bookbrainz-site/scripts/config.sh
+
+PRIVATE_BACKUP_FOLDER=/mnt/private_backup
+PRIVATE_DUMP_FILE=bookbrainz-full-dump-$(date -I).sql
+
+# Switch directory
+pushd $PRIVATE_BACKUP_FOLDER
+
+echo "Creating full private dump..."
+pg_dump \
+	-h "$POSTGRES_HOST" \
+	-p "$POSTGRES_PORT" \
+	-U bookbrainz \
+	--serializable-deferrable \
+	bookbrainz > "/tmp/$PRIVATE_DUMP_FILE"
+echo "Full private dump created"
+
+echo "Compressing and moving full private dump"
+bzip2 /tmp/$PRIVATE_DUMP_FILE
+mv /tmp/$PRIVATE_DUMP_FILE.bz2 $PRIVATE_BACKUP_FOLDER
+echo "Full private dump compressed and moved"
+
+
+echo "Removing old private dumps..."
+# Remove private backups older than 14 days, provided there are at least 2 full dumps in there 
+if [ "$(find "$PRIVATE_BACKUP_FOLDER" -maxdepth 1 -name '*.sql.bz2' -type f | sed -n '2p')" ]; then
+	find "$PRIVATE_BACKUP_FOLDER" -maxdepth 1 -name '*.sql.bz2' -type f -mtime +14 -delete
+fi
+echo "Done!"
+
+chmod 600 ./*
+
+popd
+
+exit 0

--- a/scripts/create-public-dumps.sh
+++ b/scripts/create-public-dumps.sh
@@ -224,7 +224,7 @@ pg_dump \
 	--data-only \
 	--serializable-deferrable \
 	bookbrainz >> "/tmp/$DUMP_FILE"
-echo "Main dump created"
+echo "Main public dump created"
 
 echo "Exporting editor data without OAuth tokens..."
 append_editor_data
@@ -254,9 +254,9 @@ bzip2 /tmp/$DUMP_FILE
 mv /tmp/$DUMP_FILE.bz2 .
 echo "Compressed!"
 
-echo "Removing old dumps..."
+echo "Removing old public dumps..."
 rm -f /tmp/*.sql
-# Remove backups older than 8 days
+# Remove public backups older than 8 days
 find ./ -name '*.sql.bz2' -type f -mtime +7 -print | xargs /bin/rm -f
 echo "Done!"
 


### PR DESCRIPTION
Generate full private dumps and store them in new docker volume mounted at mnt/private_backup (see https://github.com/metabrainz/docker-server-configs/pull/380)

The volume is configured to be backed up automatically by borg backup (see https://github.com/metabrainz/metabrainz-ansible/pull/102)

* [x] I have run the code and manually tested the changes

# AI usage

* [x] I did not use any AI

# Action

Tested locally, but considering the various moving parts and configuration pulled from consul, this also needs to be tested end-to-end in production