### PR TITLE
GNU Terry Pratchett

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -64,6 +64,10 @@ if (app.get('env') !== 'testing') {
 	app.use(logger('dev'));
 }
 
+server.use(function (req, res, next) {
+  res.set('X-Clacks-Overhead', 'GNU Terry Pratchet');
+  next();
+});
 app.use(express.json({
 	limit: '10mb',
 	verify: (req, res, buffer) => {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -68,6 +68,7 @@ server.use(function (req, res, next) {
   res.set('X-Clacks-Overhead', 'GNU Terry Pratchet');
   next();
 });
+
 app.use(express.json({
 	limit: '10mb',
 	verify: (req, res, buffer) => {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -64,7 +64,7 @@ if (app.get('env') !== 'testing') {
 	app.use(logger('dev'));
 }
 
-server.use(function (req, res, next) {
+app.use(function (req, res, next) {
   res.set('X-Clacks-Overhead', 'GNU Terry Pratchet');
   next();
 });

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -67,7 +67,7 @@ if (app.get('env') !== 'testing') {
 app.use(function (req, res, next) {
   // "A man is not dead while his name is still spoken."
   // - Going Postal, Terry Pratchett
-  res.set('X-Clacks-Overhead', 'GNU Terry Pratchet, Robert "mayhem" Kaye');
+  res.set('X-Clacks-Overhead', 'GNU Terry Pratchett, Robert "mayhem" Kaye');
   next();
 });
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -65,7 +65,9 @@ if (app.get('env') !== 'testing') {
 }
 
 app.use(function (req, res, next) {
-  res.set('X-Clacks-Overhead', 'GNU Terry Pratchet');
+  // "A man is not dead while his name is still spoken."
+  // - Going Postal, Terry Pratchett
+  res.set('X-Clacks-Overhead', 'GNU Terry Pratchet, Robert "mayhem" Kaye');
   next();
 });
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -64,11 +64,11 @@ if (app.get('env') !== 'testing') {
 	app.use(logger('dev'));
 }
 
-app.use(function (req, res, next) {
-  // "A man is not dead while his name is still spoken."
-  // - Going Postal, Terry Pratchett
-  res.set('X-Clacks-Overhead', 'GNU Terry Pratchett, Robert "mayhem" Kaye');
-  next();
+app.use((req, res, next) => {
+	// "A man is not dead while his name is still spoken."
+	// - Going Postal, Terry Pratchett
+	res.set('X-Clacks-Overhead', 'GNU Terry Pratchett, Robert "mayhem" Kaye');
+	next();
 });
 
 app.use(express.json({


### PR DESCRIPTION
GNU Terry Pratchett - http://www.gnuterrypratchett.com/#nodejs

discussed with Monkey. first time trying this !

adding GNU Terry Pratchett clacks overhead to BookBrainz, as described in the link http://www.gnuterrypratchett.com/#nodejs
