### PR TITLE
i18n : refactoring the namespace json to translation json

### DIFF
--- a/i18next.config.js
+++ b/i18next.config.js
@@ -1,11 +1,11 @@
 /** @type {import('i18next-cli').I18nextToolkitConfig} */
 export default {
 	extract: {
-		defaultNS: 'common',
+		defaultNS: 'translation',
 		input: ['src/**/*.{js,jsx,ts,tsx}'],
-		keySeparator: false,
-		nsSeparator: ':',
-		output: 'public/locales/{{language}}/{{namespace}}.json',
+		keySeparator: '.',
+		nsSeparator: false,
+		output: 'public/locales/{{language}}/translation.json',
 		removeUnusedKeys: false,
 		sort: true
 	},

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -290,7 +290,8 @@
     "achievements": {
       "lockedHeading": "Locked Achievements",
       "unlockedHeading": "Unlocked Achievements",
-      "unsetInstructions": "click badge to unset"
+      "unsetInstructions": "click badge to unset",
+       "updateButton": "Update"
     },
     "callToAction": {
       "helpPage": "help page",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -30,7 +30,6 @@
     "displayName": "Display Name",
     "entities": "Entities",
     "entityType": {
-      "_self": "Entity Type",
       "area": "Area",
       "author": "Author",
       "collection": "Collection",
@@ -41,6 +40,7 @@
       "series": "Series",
       "work": "Work"
     },
+    "entityTypeLabel": "Entity Type",
     "format": "Format",
     "gender": "Gender",
     "languages": "Languages",
@@ -64,7 +64,7 @@
     "privileges": "Privileges",
     "public": "Public",
     "publisher": "Publisher",
-    "Relationship": "Relationship",
+    "relationship": "Relationship",
     "role": "Collaborator/Owner",
     "searchResults": "Search Results",
     "status": "Status",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,0 +1,369 @@
+{
+  "common": {
+    "about": {
+      "accessingData": "Accessing the data",
+      "contactUs": "Contact Us",
+      "lead": "BookBrainz is an online encyclopaedia which contains information about published literature. Our aim is to collect and store data about every book, magazine, journal or other publication ever written.",
+      "ourStory": "Our Story",
+      "title": "About BookBrainz"
+    },
+    "allEntities": "All Entities",
+    "annotation": "Annotation",
+    "area": "Area",
+    "authorCredit": "Author Credit",
+    "button": {
+      "add": "Add",
+      "cancel": "Cancel",
+      "close": "Close",
+      "copy": "Copy",
+      "discard": "Discard changes",
+      "edit": "Edit",
+      "guess": "Guess",
+      "remove": "Remove",
+      "search": "Search",
+      "submit": "Submit",
+      "update": "Update"
+    },
+    "collaborator": "Collaborator",
+    "date": "Date",
+    "description": "Description",
+    "displayName": "Display Name",
+    "entities": "Entities",
+    "entityType": {
+      "_self": "Entity Type",
+      "area": "Area",
+      "author": "Author",
+      "collection": "Collection",
+      "edition": "Edition",
+      "editionGroup": "Edition Group",
+      "editor": "Editor",
+      "publisher": "Publisher",
+      "series": "Series",
+      "work": "Work"
+    },
+    "format": "Format",
+    "gender": "Gender",
+    "languages": "Languages",
+    "lastModified": "Last Modified",
+    "name": "Name",
+    "no": "no",
+    "number": "Number",
+    "openNewTab": "Open in a new tab",
+    "owner": "Owner",
+    "pageCount": "Page Count",
+    "pages": "Pages",
+    "pagination": {
+      "next": "Next Page →",
+      "perPage": "{{count}} per page",
+      "previous": "← Previous Page",
+      "results": "Results {{from}} — {{to}}"
+    },
+    "preview": "Preview",
+    "privacy": "Privacy",
+    "private": "Private",
+    "privileges": "Privileges",
+    "public": "Public",
+    "publisher": "Publisher",
+    "Relationship": "Relationship",
+    "role": "Collaborator/Owner",
+    "searchResults": "Search Results",
+    "status": "Status",
+    "type": "Type",
+    "unnamed": "(unnamed)",
+    "yes": "yes"
+  },
+  "entities": {},
+  "entityEditor": {
+    "aliasButton": {
+      "editAliases_zero": "Add aliases…",
+      "editAliases_one": "Edit 1 alias…",
+      "editAliases_other": "Edit {{count}} aliases…"
+    },
+    "aliasEditor": {
+      "helpText": "Variant names for an entity such as alternate spelling, different script, stylistic representation, acronyms, etc. Refer to the help page for more details and examples.",
+      "title": "Alias Editor"
+    },
+    "annotationSection": {
+      "copyrightWarning": "Do not submit any copyrighted text here.",
+      "helpText": "Annotations allow you to enter freeform data that does not otherwise fit in the above form.",
+      "lastModified": "Last modified: {{date}}",
+      "openLicenseNoticeLink": "open licenses",
+      "openLicenseNoticePost": ".",
+      "openLicenseNoticePre": "The contents will be made available to the public under ",
+      "tooltip": "Additional freeform data that does not fit in the above form"
+    },
+    "authorCreditEditor": {
+      "addAuthor": "Add Author",
+      "introText": "Author credits indicate who is the main credited Author (or Authors) for Editions, and how they are credited. They consist of Authors, with (optionally) their names as credited in the specific Edition (i.e. on the cover), and join phrases between them. Keep in mind that join phrases should include spaces before and after if you want any to appear in the final credit.",
+      "joinPhraseLabel": "Join Phrase",
+      "previewText": "Preview of the final Author credit:"
+    },
+    "authorCreditRow": {
+      "creditedAsLabel": "Author as credited"
+    },
+    "authorCreditSection": {
+      "noAuthorLabel": "This Edition doesn't have an Author",
+      "noAuthorTooltip": "Select this checkbox if this Edition doesn't have an Author or if you don't know the Author(s)",
+      "placeholder": "Type to search or paste a BBID",
+      "tooltip": "Who wrote this work? You can add multiple authors."
+    },
+    "authorSection": {
+      "beginAreaLabel": {
+        "group": "Place founded",
+        "person": "Place of birth"
+      },
+      "beginDateLabel": {
+        "group": "Date founded",
+        "person": "Date of birth"
+      },
+      "endAreaLabel": {
+        "group": "Place of dissolution",
+        "person": "Place of death"
+      },
+      "endDateLabel": {
+        "group": "Date of dissolution",
+        "person": "Date of death"
+      },
+      "endedLabel": {
+        "person": "Died?"
+      }
+    },
+    "dateField": {
+      "datePickerTitle": "Date picker",
+      "futureDateWarning": "Are you sure? You entered a date in the future!"
+    },
+    "disambiguationField": {
+      "label": "Disambiguation",
+      "tooltip": "If a different entity with the same name already exists or if there is a need for clarification"
+    },
+    "editionGroupSection": {
+      "typeTooltip": "Physical format of the Edition Group"
+    },
+    "editionSection": {
+      "autoCreateEditionGroup": "Automatically create an Edition Group",
+      "autoCreateMessage": "A new Edition Group with the same name will be created automatically.",
+      "belowFieldsOptional": "Below fields are optional — leave something blank if you don't know it",
+      "clickIconToOpen": "Click on the <icon /> icon open in a new tab, and click an item to select.",
+      "editionGroupHelp": "Group with other Editions of the same book",
+      "editionGroupRequired": "Edition Group is required — this cannot be blank. You can search for and choose an existing Edition Group, or choose to automatically create one instead.",
+      "editionGroupTooltip": "Group together different Editions of the same book.",
+      "editionGroupTooltipExample": "For example paperback, hardcover and e-book editions.",
+      "formatTooltip": "The type of printing and binding of the edition, or digital equivalent",
+      "languageTooltip": "Main language used for the content of the edition",
+      "matchingEditionGroups_one": "An existing Edition Group with the same name as this Edition already exists",
+      "matchingEditionGroups_other": "Edition Groups with the same name as this Edition already exist",
+      "noSelectionAutoCreate": "If no Edition Group is selected, a new one will be created automatically.",
+      "releaseDateTooltip": "The date this specific edition was published (not the first publication date of the work). If unsure, leave empty.",
+      "reviewEditionGroups": "Please review the Edition Groups below and select the one that corresponds to your Edition.",
+      "searchExistingEditionGroup": "Search for an existing Edition Group",
+      "statusTooltip": "Has the work been published, or is it in a draft stage?"
+    },
+    "editionSectionMerge": {
+      "noLanguages": "No languages"
+    },
+    "entityType": {
+      "author_plural": "Authors",
+      "publisher_plural": "Publishers"
+    },
+    "identifierButton": {
+      "addIdentifiersUnified": "Add Identifiers",
+      "editIdentifiers_one": "Edit 1 identifier (eg. ISBN, Wikidata ID)…",
+      "editIdentifiers_other": "Edit {{count}} identifiers (eg. ISBN, Wikidata ID)…",
+      "editIdentifiersUnified": "Edit identifiers"
+    },
+    "identifierEditor": {
+      "helpText": "identity of the entity in other databases and services, such as ISBN, barcode, MusicBrainz ID, WikiData ID, OpenLibrary ID, etc. You can enter either the identifier only (Q2517049) or a full link (https://www.wikidata.org/wiki/Q2517049).",
+      "title": "Identifier Editor"
+    },
+    "identifierModalBody": {
+      "addButton": "Add identifier",
+      "noIdentifiers": "This entity has no identifiers"
+    },
+    "identifierRow": {
+      "previewLink": "Preview Link: ",
+      "typeLabel": "Type"
+    },
+    "languageField": {
+      "frequentlyUsed": "Frequently Used",
+      "label": "Language",
+      "other": "Other",
+      "placeholder": "Search language",
+      "recentlyUsed": "Recently Used"
+    },
+    "nameSection": {
+      "clickToOpen": "Click on a name to open it (Ctrl/Cmd + click to open in a new tab)",
+      "ctrlClick": "Ctrl/Cmd + click to open in a new tab",
+      "duplicateSuggestion": "If the {{entityType}} you want to add appears in the results below, click on it to inspect it before adding a possible duplicate.",
+      "duplicateWarning_one": "We found the following {{entityType}} with exactly the same name or alias:",
+      "duplicateWarning_other": "We found the following {{entityType}}s with exactly the same name or alias:",
+      "fillDisambiguation": "If you are sure your entry is different, please fill the disambiguation field below to help us differentiate between them.",
+      "heading": "What is the {{entityType}} called?",
+      "languageTooltip": "Language used for the above name",
+      "nameTooltip": "Official name of the {{entityType}} in its original language. Names in other languages should be added as aliases."
+    },
+    "publisherSection": {
+      "areaTooltip": "Country or place the publisher is registered in",
+      "dateDissolved": "Date Dissolved",
+      "dateFounded": "Date Founded"
+    },
+    "relationship": {
+      "newEntity": "New Entity"
+    },
+    "relationshipAttribute": {
+      "numberPlaceholder": "Enter a value"
+    },
+    "relationshipEditor": {
+      "heading": "Relationships",
+      "noRelationships": "No relationships have been added yet.",
+      "relationshipType": "Relationship Type",
+      "sourceEntity": "Source Entity",
+      "targetEntity": "Target Entity",
+      "undoLastAction": "Undo last action"
+    },
+    "relationshipModal": {
+      "beginDate": "Begin Date",
+      "editTitle": "Edit relationship",
+      "endDate": "End Date",
+      "exampleText": "For example, you can link an author to a work, or a work to another work to show translation or derivation.",
+      "introText": "Use this form to add links between this {{entityType}} and other entities.",
+      "noRelationshipsPossible": "{{entityType}}s have no possible relationships with other entities at the moment.",
+      "searchPlaceholder": "Search for an entity…",
+      "selectTarget": "Please select a target entity",
+      "selectType": "Please select a relationship type",
+      "sourceLabel": "This entity",
+      "targetLabel": "Other entity",
+      "targetLabelList": "Other entity ({{types}})",
+      "typeLabel": "Relationship type"
+    },
+    "relationshipSection": {
+      "heading": "How are other entities related to this {{entityType}}?"
+    },
+    "seriesEditor": {
+      "addButton": "Add {{seriesType}}",
+      "addEntityPrompt": "Add an entity to the series:",
+      "heading": "What {{seriesType}} are part of this Series?",
+      "placeholder": "Enter value..."
+    },
+    "seriesSection": {
+      "allFieldsMandatory": "All fields are mandatory — select the option from dropdown",
+      "orderingTypeLabel": "Ordering Type",
+      "orderingTypeTooltip": "Ordering Type of the Series Entity",
+      "seriesTypeLabel": "Series Type",
+      "seriesTypeTooltip": "Entity Type of the Series"
+    },
+    "shared": {
+      "addIdentifiers": "Add identifiers (eg. ISBN, Wikidata ID)…",
+      "addRelationship": "Add a relationship",
+      "allFieldsOptional": "All fields optional — leave something blank if you don't know it",
+      "authorCreditLabel": "Edit Author Credit",
+      "depthLabel": "Depth",
+      "dissolvedLabel": "Dissolved?",
+      "entityHeading": "What else do you know about the {{entity}}?",
+      "heightLabel": "Height",
+      "optionalLabel": "(optional)",
+      "releaseDateLabel": "Release Date",
+      "weightLabel": "Weight",
+      "widthLabel": "Width"
+    },
+    "sortNameField": {
+      "label": "Sort Name",
+      "tooltip": "Alphabetical sorting name. Examples: 'Dickens, Charles', 'Christmas Carol, A'. You can try to fill it automatically with the guess button"
+    },
+    "submissionSection": {
+      "editNoteHelp": "An edit note will make your entries more credible. Reply to one or more of these questions in the textarea below:\n- Where did you get your info from? A link is worth a thousand words.\n- What kind of information did you provide? If you made any changes, what are they and why?\n- Do you have any questions concerning the editing process you want to ask?",
+      "editNoteLabel": "Edit Note",
+      "editNoteTooltip": "Cite your sources or an explanation of your edit",
+      "heading": "Submit Your Edit",
+      "submissionError": "Submission Error: {{errorText}}",
+      "submitButton": "Submit"
+    },
+    "valueField": {
+      "label": "Value"
+    },
+    "workSection": {
+      "languageTooltip": "Main language used for the content of the work",
+      "typeTooltip": "Literary form or structure of the work"
+    }
+  },
+  "errors": {},
+  "pages": {
+    "achievements": {
+      "lockedHeading": "Locked Achievements",
+      "unlockedHeading": "Unlocked Achievements",
+      "unsetInstructions": "click badge to unset"
+    },
+    "callToAction": {
+      "helpPage": "help page",
+      "helpText": "Help us and click on the right entity below to create a new entry.",
+      "notSure": "Not sure what to do? Visit the ",
+      "toGetStarted": " to get started."
+    },
+    "collections": {
+      "allTypes": "All Types",
+      "createButton": "Create Collection",
+      "headerDescription": "Description",
+      "headerEntities": "Entities",
+      "headerEntityType": "Entity Type",
+      "headerLastModified": "Last Modified",
+      "headerPrivacy": "Privacy",
+      "headerRole": "Collaborator/Owner",
+      "myCollectionsButton": "My Collections",
+      "noCollections": "No collections to show"
+    },
+    "profile": {
+      "badges": "Badges",
+      "basicInfo": "Basic Info",
+      "bio": "Bio",
+      "editInfoTitle": "Edit basic editor info",
+      "editProfile": "Edit Profile",
+      "joined": "Joined",
+      "lastLogin": "Last login",
+      "linkMB": "Link My MusicBrainz Account",
+      "musicbrainzAccount": "MusicBrainz Account",
+      "noBadges": "No badge to show, use the achievement menu to see available achievements",
+      "noLinkedMB": "No Linked MusicBrainz Account",
+      "reputation": "Reputation",
+      "revisionsApplied": "Revisions Applied",
+      "revisionsChartLabel": "Revisions",
+      "revisionsReverted": "Revisions Reverted",
+      "sendEmail": "send email",
+      "stats": "Stats",
+      "totalRevisions": "Total Revisions",
+      "unlocked": "Unlocked: {{date}}"
+    },
+    "registration": {
+      "displayNameIntro": "Firstly, please check that your display name is correct. This is the name that other editors will get to know you by.",
+      "genderIntro": "And, optionally, set a gender that will be displayed on your profile page.",
+      "genderPlaceholder": "Select gender…",
+      "heading": "Register",
+      "introText": "Great! You successfully logged in to MusicBrainz and are now just one step away from becoming a BookBrainz editor. The following form allows you to specify additional information that will let other users know a little bit more about you. When you’re done, just click the blue button at the bottom of the page.",
+      "submitButton": "Looks good, sign me up!"
+    },
+    "revisions": {
+      "headerId": "Revision ID",
+      "headerModifiedEntities": "Modified entities",
+      "headerNote": "Note",
+      "headerUser": "User",
+      "noRevisions": "No revisions to show",
+      "recentActivity": "Recent Activity",
+      "titleMerge": "Merge revision",
+      "titleNormal": "Revision"
+    },
+    "searchPage": {
+      "missingEntry": "Are we missing an entry?",
+      "noResults": "No results found",
+      "spellingWarning": "Make sure the spelling is correct, and that you have selected the correct type in the search bar."
+    },
+    "searchResults": {
+      "addToCollection": "Add to Collection",
+      "cannotAdd": "{{type}} cannot be added to a collection",
+      "clearSelected_one": "Clear 1 selected",
+      "clearSelected_other": "Clear {{count}} selected",
+      "headerAliases": "Aliases",
+      "headerType": "Type",
+      "loginRequired": "You need to be logged in",
+      "nothingSelected": "Nothing Selected",
+      "sameTypeRequired": "Selected entities should be of same type"
+    }
+  }
+}

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1,0 +1,27 @@
+{
+  "common": {
+    "about": {
+      "title": "À propos de BookBrainz",
+      "lead": "BookBrainz est une encyclopédie en ligne qui contient des informations sur la littérature publiée. Notre objectif est de collecter et stocker des données sur chaque livre, magazine, journal ou autre publication jamais écrit.",
+      "contactUs": "Contactez-nous",
+      "ourStory": "Notre histoire",
+      "accessingData": "Accéder aux données"
+    },
+    "button": {
+      "close": "Fermer"
+    },
+    "pagination": {
+      "previous": "← Page précédente",
+      "results": "Résultats {{from}} — {{to}}"
+    }
+  },
+  "entities": {},
+  "entityEditor": {
+    "aliasEditor": {
+      "helpText": "Noms variantes pour une entité tels qu'une orthographe alternative, une écriture différente, une représentation stylistique, des acronymes, etc. Consultez la page d'aide pour plus de détails et d'exemples.",
+      "title": "Éditeur d'alias"
+    }
+  },
+  "errors": {},
+  "pages": {}
+}

--- a/src/client/components/forms/registration-details.js
+++ b/src/client/components/forms/registration-details.js
@@ -98,9 +98,9 @@ class RegistrationForm extends React.Component {
 		const initialGender = this.props.gender && this.props.gender.id;
 		return (
 			<div>
-				<div className="page-header"><h1>{translate('pages:registration.heading')}</h1></div>
+				<div className="page-header"><h1>{translate('pages.registration.heading')}</h1></div>
 				<div>
-					{translate('pages:registration.introText')}
+					{translate('pages.registration.introText')}
 				</div>
 				<Row>
 					{loadingComponent}
@@ -110,16 +110,16 @@ class RegistrationForm extends React.Component {
 							onSubmit={this.handleSubmit}
 						>
 							<p>
-								{translate('pages:registration.displayNameIntro')}
+								{translate('pages.registration.displayNameIntro')}
 							</p>
 							<Form.Group className="row">
 								<Form.Label className="col-lg-4 col-form-label">
-									{translate('common:displayName')}
+									{translate('common.displayName')}
 								</Form.Label>
 								<div className="col-lg-4">
 									<Form.Control
 										defaultValue={this.props.name}
-										placeholder={translate('common:displayName')}
+										placeholder={translate('common.displayName')}
 										/* eslint-disable-next-line react/jsx-no-bind */
 										ref={(ref) => this.displayName = ref}
 										type="text"
@@ -128,10 +128,10 @@ class RegistrationForm extends React.Component {
 								</div>
 							</Form.Group>
 							<p>
-								{translate('pages:registration.genderIntro')}
+								{translate('pages.registration.genderIntro')}
 							</p>
 							<Form.Group className="row">
-								<Form.Label className="col-lg-4 col-form-label">{translate('common:gender')}</Form.Label>
+								<Form.Label className="col-lg-4 col-form-label">{translate('common.gender')}</Form.Label>
 								<div className="col-lg-4">
 									<ReactSelect
 										isClearable
@@ -139,7 +139,7 @@ class RegistrationForm extends React.Component {
 										getOptionLabel={this.getOptionLabel}
 										instanceId="gender"
 										options={this.props.genders}
-										placeholder={translate('pages:registration.genderPlaceholder')}
+										placeholder={translate('pages.registration.genderPlaceholder')}
 										ref={(ref) => this.gender = ref}
 									/>
 								</div>
@@ -153,7 +153,7 @@ class RegistrationForm extends React.Component {
 									type="submit"
 									variant="primary"
 								>
-									{translate('pages:registration.submitButton')}
+									{translate('pages.registration.submitButton')}
 								</Button>
 							</div>
 						</form>
@@ -177,4 +177,4 @@ RegistrationForm.defaultProps = {
 	name: null
 };
 
-export default withTranslation(['pages', 'common'])(RegistrationForm);
+export default withTranslation()(RegistrationForm);

--- a/src/client/components/pages/editor-revision.js
+++ b/src/client/components/pages/editor-revision.js
@@ -40,7 +40,7 @@ class EditorRevisionPage extends React.Component {
 
 	render() {
 		const {t: translate} = this.props;
-		const tableHeading = this.props.tableHeading ?? translate('revisions.recentActivity');
+		const tableHeading = this.props.tableHeading ?? translate('pages.revisions.recentActivity');
 		return (
 			<div id="pageWithPagination">
 				<RevisionsTable
@@ -87,4 +87,4 @@ EditorRevisionPage.defaultProps = {
 	tableHeading: null
 };
 
-export default withTranslation('pages')(EditorRevisionPage);
+export default withTranslation()(EditorRevisionPage);

--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -224,7 +224,7 @@ class IndexPage extends React.Component {
 						results={this.props.recent}
 						showEntities={this.props.showEntities}
 						showRevisionEditor={this.props.showRevisionEditor}
-						tableHeading={translate('pages:revisions.recentActivity')}
+						tableHeading={translate('pages.revisions.recentActivity')}
 					/>
 					<div className="text-center">
 						<Button
@@ -304,4 +304,4 @@ IndexPage.defaultProps = {
 	showRevisionEditor: true
 };
 
-export default withTranslation('pages')(IndexPage);
+export default withTranslation()(IndexPage);

--- a/src/client/components/pages/parts/call-to-action.js
+++ b/src/client/components/pages/parts/call-to-action.js
@@ -35,7 +35,7 @@ const {Button, ButtonGroup} = bootstrap;
  * the 'CallToAction' component.
  */
 function CallToAction(props) {
-	const {t: translate} = useTranslation(['pages', 'common']);
+	const {t: translate} = useTranslation();
 	const seedingParameters = new URLSearchParams({name: props.query});
 	function renderEntityLink(type) {
 		return (
@@ -45,7 +45,7 @@ function CallToAction(props) {
 					variant="secondary"
 				>
 					{genEntityIconHTMLElement(type, '3x', false)}
-					<div className="margin-top-d4">{translate(`common:entityType.${camelCase(type)}`)}</div>
+					<div className="margin-top-d4">{translate(`common.entityType.${camelCase(type)}`)}</div>
 				</Button>
 			</a>
 		);
@@ -54,12 +54,12 @@ function CallToAction(props) {
 	return (
 		<div className="text-center">
 			<p>
-				{translate('callToAction.helpText')}
+				{translate('pages.callToAction.helpText')}
 				<br/>
 				<small>
-					{translate('callToAction.notSure')}
-					<a href="/help">{translate('callToAction.helpPage')}</a>
-					{translate('callToAction.toGetStarted')}
+					{translate('pages.callToAction.notSure')}
+					<a href="/help">{translate('pages.callToAction.helpPage')}</a>
+					{translate('pages.callToAction.toGetStarted')}
 				</small>
 			</p>
 			<div>

--- a/src/client/components/pages/parts/collections-table.js
+++ b/src/client/components/pages/parts/collections-table.js
@@ -50,7 +50,7 @@ class CollectionsTable extends React.Component {
 			<DropdownButton
 				className="margin-bottom-d5"
 				id="entity-type-select"
-				title={this.props.type ? translate(`common:entityType.${_.camelCase(this.props.type)}`) : translate('common:type')}
+				title={this.props.type ? translate(`common.entityType.${_.camelCase(this.props.type)}`) : translate('common.type')}
 				variant="primary"
 				onSelect={this.handleEntitySelect}
 			>
@@ -60,7 +60,7 @@ class CollectionsTable extends React.Component {
 						key={entityType}
 					>
 						{genEntityIconHTMLElement(entityType)}
-						{translate(`common:entityType.${_.camelCase(entityType)}`)}
+						{translate(`common.entityType.${_.camelCase(entityType)}`)}
 					</Dropdown.Item>
 				))}
 				<Dropdown.Divider/>
@@ -68,7 +68,7 @@ class CollectionsTable extends React.Component {
 					eventKey={null}
 					key="allTypes"
 				>
-					{translate('pages:collections.allTypes')}
+					{translate('pages.collections.allTypes')}
 				</Dropdown.Item>
 			</DropdownButton>
 		);
@@ -86,7 +86,7 @@ class CollectionsTable extends React.Component {
 					variant="warning"
 				>
 					<FontAwesomeIcon icon={faPlus}/>
-					&nbsp;{translate('pages:collections.createButton')}
+					&nbsp;{translate('pages.collections.createButton')}
 				</Button>
 			);
 		}
@@ -103,7 +103,7 @@ class CollectionsTable extends React.Component {
 					type="button"
 					variant="success"
 				>
-					{translate('pages:collections.myCollectionsButton')}
+					{translate('pages.collections.myCollectionsButton')}
 				</Button>
 			);
 		}
@@ -131,26 +131,26 @@ class CollectionsTable extends React.Component {
 						>
 							<thead>
 								<tr>
-									<th width="16%">{translate('common:name')}</th>
-									<th width="33%">{translate('common:description')}</th>
-									<th width="16%">{translate('common:entityType')}</th>
-									<th width="16%">{translate('common:entities')}</th>
+									<th width="16%">{translate('common.name')}</th>
+									<th width="33%">{translate('common.description')}</th>
+									<th width="16%">{translate('common.entityType._self')}</th>
+									<th width="16%">{translate('common.entities')}</th>
 									{
 										showPrivacy ?
-											<th width="16%">{translate('common:privacy')}</th> : null
+											<th width="16%">{translate('common.privacy')}</th> : null
 									}
 									{
 										showIfOwnerOrCollaborator ?
-											<th width="16%">{translate('common:role')}</th> : null
+											<th width="16%">{translate('common.role')}</th> : null
 									}
 									{
 										showOwner ?
-											<th width="16%">{translate('common:owner')}</th> : null
+											<th width="16%">{translate('common.owner')}</th> : null
 
 									}
 									{
 										showLastModified ?
-											<th width="16%">{translate('common:lastModified')}</th> : null
+											<th width="16%">{translate('common.lastModified')}</th> : null
 									}
 								</tr>
 							</thead>
@@ -167,15 +167,15 @@ class CollectionsTable extends React.Component {
 												</a>
 											</td>
 											<td>{collection.description}</td>
-											<td>{translate(`common:entityType.${_.camelCase(collection.entityType)}`)}</td>
+											<td>{translate(`common.entityType.${_.camelCase(collection.entityType)}`)}</td>
 											<td>{collection.itemCount}</td>
 											{
 												showPrivacy ?
-													<td>{collection.public ? translate('common:public') : translate('common:private')}</td> : null
+													<td>{collection.public ? translate('common.public') : translate('common.private')}</td> : null
 											}
 											{
 												showIfOwnerOrCollaborator ?
-													<td>{collection.isOwner ? translate('common:owner') : translate('common:collaborator')}</td> : null
+													<td>{collection.isOwner ? translate('common.owner') : translate('common.collaborator')}</td> : null
 											}
 											{
 												showOwner ?
@@ -193,7 +193,7 @@ class CollectionsTable extends React.Component {
 						</Table> :
 
 						<div>
-							<h4> {translate('pages:collections.noCollections')}</h4>
+							<h4> {translate('pages.collections.noCollections')}</h4>
 							<hr className="wide"/>
 						</div>
 				}
@@ -233,4 +233,4 @@ CollectionsTable.defaultProps = {
 CollectionsTable.displayName = 'CollectionsTable';
 
 
-export default withTranslation(['pages', 'common'])(CollectionsTable);
+export default withTranslation()(CollectionsTable);

--- a/src/client/components/pages/parts/collections-table.js
+++ b/src/client/components/pages/parts/collections-table.js
@@ -133,7 +133,7 @@ class CollectionsTable extends React.Component {
 								<tr>
 									<th width="16%">{translate('common.name')}</th>
 									<th width="33%">{translate('common.description')}</th>
-									<th width="16%">{translate('common.entityType._self')}</th>
+									<th width="16%">{translate('common.entityTypeLabel')}</th>
 									<th width="16%">{translate('common.entities')}</th>
 									{
 										showPrivacy ?

--- a/src/client/components/pages/parts/editor-achievements.js
+++ b/src/client/components/pages/parts/editor-achievements.js
@@ -108,10 +108,10 @@ class EditorAchievementTab extends React.Component {
 					</CardDeck>
 					<span className="margin-left-1">
 						<Button type="submit" variant="success">
-							{translate('pages:achievements.updateButton')}
+							{translate('pages.achievements.updateButton')}
 						</Button>
 						<span className="margin-left-1">
-							{translate('pages:achievements.unsetInstructions')}
+							{translate('pages.achievements.unsetInstructions')}
 						</span>
 					</span>
 				</Form>
@@ -144,9 +144,9 @@ class EditorAchievementTab extends React.Component {
 								}
 							</Sticky>
 							<div style={{zIndex: 1}}>
-								<div className="h1">{translate('pages:achievements.unlockedHeading')}</div>
+								<div className="h1">{translate('pages.achievements.unlockedHeading')}</div>
 								{achievements}
-								<div className="h1">{translate('pages:achievements.lockedHeading')}</div>
+								<div className="h1">{translate('pages.achievements.lockedHeading')}</div>
 								{locked}
 							</div>
 						</StickyContainer>
@@ -174,4 +174,4 @@ EditorAchievementTab.propTypes = {
 	t: PropTypes.func.isRequired
 };
 
-export default withTranslation('pages')(EditorAchievementTab);
+export default withTranslation()(EditorAchievementTab);

--- a/src/client/components/pages/parts/editor-profile.js
+++ b/src/client/components/pages/parts/editor-profile.js
@@ -56,7 +56,7 @@ class EditorProfileTab extends React.Component {
 		const createdAtDate = formatDate(new Date(editor.createdAt), true);
 		const lastActiveDate = formatDate(new Date(editor.activeAt), true);
 
-		let musicbrainzAccount = translate('pages:profile.noLinkedMB');
+		let musicbrainzAccount = translate('pages.profile.noLinkedMB');
 		if (cachedMetabrainzName) {
 			musicbrainzAccount = (
 				<span>
@@ -69,7 +69,7 @@ class EditorProfileTab extends React.Component {
 						rel="noopener noreferrer"
 						target="_blank"
 					>
-						{translate('pages:profile.sendEmail')} <FontAwesomeIcon icon={faExternalLinkAlt}/>
+						{translate('pages.profile.sendEmail')} <FontAwesomeIcon icon={faExternalLinkAlt}/>
 					</a>)
 				</span>
 			);
@@ -79,45 +79,45 @@ class EditorProfileTab extends React.Component {
 		}
 		else if (user && editor.id === user.id) {
 			musicbrainzAccount =
-				<a href="/auth">{translate('pages:profile.linkMB')}</a>;
+				<a href="/auth">{translate('pages.profile.linkMB')}</a>;
 		}
 
 		return (
 			<div>
 				<h2>
-					{translate('pages:profile.basicInfo')}
+					{translate('pages.profile.basicInfo')}
 					{user && user.id === editor.id &&
 						<small className="float-right">
 							<Button
 								href="/editor/edit"
-								title={translate('pages:profile.editInfoTitle')}
+								title={translate('pages.profile.editInfoTitle')}
 								variant="warning"
 							>
-								<FontAwesomeIcon icon={faPencilAlt}/>{' '}{translate('pages:profile.editProfile')}
+								<FontAwesomeIcon icon={faPencilAlt}/>{' '}{translate('pages.profile.editProfile')}
 							</Button>
 						</small>
 					}
 				</h2>
 				<dl className="row editor-info">
-					<dt className="col-md-2">{translate('pages:profile.musicbrainzAccount')}</dt>
+					<dt className="col-md-2">{translate('pages.profile.musicbrainzAccount')}</dt>
 					<dd className="col-md-10">
 						{musicbrainzAccount}
 					</dd>
-					<dt className="col-md-2">{translate('common:displayName')}</dt>
+					<dt className="col-md-2">{translate('common.displayName')}</dt>
 					<dd className="col-md-10">{name}</dd>
-					<dt className="col-md-2">{translate('common:area')}</dt>
+					<dt className="col-md-2">{translate('common.area')}</dt>
 					<dd className="col-md-10">{editor.area ? editor.area.name : '?'}</dd>
-					<dt className="col-md-2">{translate('common:gender')}</dt>
+					<dt className="col-md-2">{translate('common.gender')}</dt>
 					<dd className="col-md-10">{gender ? gender.name : '?'}</dd>
-					<dt className="col-md-2">{translate('common:type')}</dt>
+					<dt className="col-md-2">{translate('common.type')}</dt>
 					<dd className="col-md-10">{editor.type.label}</dd>
-					<dt className="col-md-2">{translate('pages:profile.reputation')}</dt>
+					<dt className="col-md-2">{translate('pages.profile.reputation')}</dt>
 					<dd className="col-md-10">0</dd>
-					<dt className="col-md-2">{translate('pages:profile.joined')}</dt>
+					<dt className="col-md-2">{translate('pages.profile.joined')}</dt>
 					<dd className="col-md-10">{createdAtDate}</dd>
-					<dt className="col-md-2">{translate('pages:profile.lastLogin')}</dt>
+					<dt className="col-md-2">{translate('pages.profile.lastLogin')}</dt>
 					<dd className="col-md-10">{lastActiveDate}</dd>
-					<dt className="col-md-2">{translate('pages:profile.bio')}</dt>
+					<dt className="col-md-2">{translate('pages.profile.bio')}</dt>
 					<dd className="col-md-10">{editor.bio ? editor.bio : '-'}</dd>
 				</dl>
 			</div>
@@ -130,13 +130,13 @@ class EditorProfileTab extends React.Component {
 
 		return (
 			<div>
-				<h2>{translate('pages:profile.stats')}</h2>
+				<h2>{translate('pages.profile.stats')}</h2>
 				<dl className="row editor-info">
-					<dt className="col-md-8">{translate('pages:profile.totalRevisions')}</dt>
+					<dt className="col-md-8">{translate('pages.profile.totalRevisions')}</dt>
 					<dd className="col-md-4">{editor.totalRevisions}</dd>
-					<dt className="col-md-8">{translate('pages:profile.revisionsApplied')}</dt>
+					<dt className="col-md-8">{translate('pages.profile.revisionsApplied')}</dt>
 					<dd className="col-md-4">{editor.revisionsApplied}</dd>
-					<dt className="col-md-8">{translate('pages:profile.revisionsReverted')}</dt>
+					<dt className="col-md-8">{translate('pages.profile.revisionsReverted')}</dt>
 					<dd className="col-md-4">{editor.revisionsReverted}</dd>
 				</dl>
 			</div>
@@ -156,7 +156,7 @@ class EditorProfileTab extends React.Component {
 
 		return (
 			<div>
-				<h2>{translate('pages:profile.badges')}</h2>
+				<h2>{translate('pages.profile.badges')}</h2>
 				<Row
 					height="200px"
 					margin="0"
@@ -176,7 +176,7 @@ class EditorProfileTab extends React.Component {
 										<ListGroup.Item>{model.achievement.name}</ListGroup.Item>
 										<ListGroup.Item>{model.achievement.description}</ListGroup.Item>
 										<ListGroup.Item>
-											{translate('pages:profile.unlocked', {
+											{translate('pages.profile.unlocked', {
 												date: formatDate(new Date(model.unlockedAt), true)
 											})}
 										</ListGroup.Item>
@@ -195,7 +195,7 @@ class EditorProfileTab extends React.Component {
 									width="160px"
 								/>
 								<p className="text-center">
-									{translate('pages:profile.noBadges')}
+									{translate('pages.profile.noBadges')}
 								</p>
 							</Card>
 						</Col>
@@ -224,7 +224,7 @@ class EditorProfileTab extends React.Component {
 					hoverBackgroundColor: 'rgba(235,116,59,0.4)',
 					hoverBorderColor: 'rgba(235,116,59,1)',
 					// eslint-disable-next-line id-length
-					label: this.props.t('pages:profile.revisionsChartLabel')
+					label: this.props.t('pages.profile.revisionsChartLabel')
 				}
 			],
 			labels: months
@@ -274,4 +274,4 @@ EditorProfileTab.defaultProps = {
 	user: null
 };
 
-export default withTranslation(['pages', 'common'])(EditorProfileTab);
+export default withTranslation()(EditorProfileTab);

--- a/src/client/components/pages/parts/pager.js
+++ b/src/client/components/pages/parts/pager.js
@@ -153,13 +153,13 @@ class PagerElement extends React.Component {
 								variant="outline-primary"
 								onClick={this.handleClickPrevious}
 							>
-								{translate('pagination.previous')}
+								{translate('common.pagination.previous')}
 							</Button>
 						</Col>
 						<Col className="text-center" lg={4}>
 							<ButtonGroup>
 								<Button disabled variant="secondary">
-									{translate('pagination.results', {
+									{translate('common.pagination.results', {
 										from: this.state.from + 1,
 										to: this.state.results.length < this.state.size ?
 											this.state.from + this.state.results.length :
@@ -167,15 +167,15 @@ class PagerElement extends React.Component {
 									})}
 								</Button>
 								<DropdownButton
-									drop="up" id="bg-nested-dropdown" title={translate('pagination.perPage', {count: this.state.size})}
+									drop="up" id="bg-nested-dropdown" title={translate('common.pagination.perPage', {count: this.state.size})}
 									variant="info"
 									onSelect={this.handleResultsPerPageChange}
 								>
-									<Dropdown.Item eventKey="10">{translate('pagination.perPage', {count: 10})}</Dropdown.Item>
-									<Dropdown.Item eventKey="20">{translate('pagination.perPage', {count: 20})}</Dropdown.Item>
-									<Dropdown.Item eventKey="35">{translate('pagination.perPage', {count: 35})}</Dropdown.Item>
-									<Dropdown.Item eventKey="50">{translate('pagination.perPage', {count: 50})}</Dropdown.Item>
-									<Dropdown.Item eventKey="100">{translate('pagination.perPage', {count: 100})}</Dropdown.Item>
+									<Dropdown.Item eventKey="10">{translate('common.pagination.perPage', {count: 10})}</Dropdown.Item>
+									<Dropdown.Item eventKey="20">{translate('common.pagination.perPage', {count: 20})}</Dropdown.Item>
+									<Dropdown.Item eventKey="35">{translate('common.pagination.perPage', {count: 35})}</Dropdown.Item>
+									<Dropdown.Item eventKey="50">{translate('common.pagination.perPage', {count: 50})}</Dropdown.Item>
+									<Dropdown.Item eventKey="100">{translate('common.pagination.perPage', {count: 100})}</Dropdown.Item>
 								</DropdownButton>
 							</ButtonGroup>
 						</Col>
@@ -186,7 +186,7 @@ class PagerElement extends React.Component {
 								variant="outline-primary"
 								onClick={this.handleClickNext}
 							>
-								{translate('pagination.next')}
+								{translate('common.pagination.next')}
 							</Button>
 						</Col>
 					</Row>
@@ -217,4 +217,4 @@ PagerElement.defaultProps = {
 	size: 20
 };
 
-export default withTranslation('common')(PagerElement);
+export default withTranslation()(PagerElement);

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -31,7 +31,7 @@ const {formatDate, stringToHTMLWithLinks} = utilsHelper;
 
 function RevisionsTable(props) {
 	const {results, showEntities, showRevisionNote, showRevisionEditor, tableHeading} = props;
-	const {t: translate} = useTranslation(['pages', 'common']);
+	const {t: translate} = useTranslation();
 	return (
 		<div>
 			<div>
@@ -47,20 +47,20 @@ function RevisionsTable(props) {
 					>
 						<thead>
 							<tr>
-								<th width="16%">{translate('pages:revisions.headerId')}</th>
+								<th width="16%">{translate('pages.revisions.headerId')}</th>
 								{
 									showEntities ?
-										<th width="42%">{translate('pages:revisions.headerModifiedEntities')}</th> : null
+										<th width="42%">{translate('pages.revisions.headerModifiedEntities')}</th> : null
 								}
 								{
 									showRevisionEditor ?
-										<th width="25%">{translate('pages:revisions.headerUser')}</th> : null
+										<th width="25%">{translate('pages.revisions.headerUser')}</th> : null
 								}
 								{
 									showRevisionNote ?
-										<th width="16%">{translate('pages:revisions.headerNote')}</th> : null
+										<th width="16%">{translate('pages.revisions.headerNote')}</th> : null
 								}
-								<th width="16%">{translate('common:date')}</th>
+								<th width="16%">{translate('common.date')}</th>
 							</tr>
 						</thead>
 
@@ -71,8 +71,8 @@ function RevisionsTable(props) {
 										<td>
 											<a
 												href={`/revision/${revision.revisionId}`}
-												title={`${revision.isMerge ? translate('pages:revisions.titleMerge') :
-													translate('pages:revisions.titleNormal')} ${revision.revisionId}`}
+												title={`${revision.isMerge ? translate('pages.revisions.titleMerge') :
+													translate('pages.revisions.titleNormal')} ${revision.revisionId}`}
 											>
 												#{revision.revisionId}
 												{revision.isMerge &&
@@ -137,7 +137,7 @@ function RevisionsTable(props) {
 					</Table> :
 
 					<div>
-						<h4> {translate('pages:revisions.noRevisions')}</h4>
+						<h4> {translate('pages.revisions.noRevisions')}</h4>
 						<hr className="wide"/>
 					</div>
 			}

--- a/src/client/components/pages/parts/search-field.tsx
+++ b/src/client/components/pages/parts/search-field.tsx
@@ -114,15 +114,15 @@ class SearchField extends React.Component<SearchFieldProps, SearchFieldState> {
 		const {t: translate} = this.props;
 		const dropdownTitle = (() => {
 			if (!this.state.type || this.state.type === 'all_entities') {
-				return translate('common:allEntities');
+				return translate('common.allEntities');
 			}
 			if (this.state.type === 'editor') {
-				return translate('common:entityType.editor');
+				return translate('common.entityType.editor');
 			}
 			if (this.state.type === 'collection') {
-				return translate('common:entityType.collection');
+				return translate('common.entityType.collection');
 			}
-			return translate(`common:entityType.${_.camelCase(this.state.type)}`);
+			return translate(`common.entityType.${_.camelCase(this.state.type)}`);
 		})();
 
 		const entityTypeSelect = Array.isArray(this.props.entityTypes) ? (
@@ -139,7 +139,7 @@ class SearchField extends React.Component<SearchFieldProps, SearchFieldState> {
 						key={entityType}
 					>
 						{genEntityIconHTMLElement(entityType)}
-						{translate(`common:entityType.${_.camelCase(entityType)}`)}
+						{translate(`common.entityType.${_.camelCase(entityType)}`)}
 					</Dropdown.Item>
 				))}
 				<Dropdown.Divider/>
@@ -147,7 +147,7 @@ class SearchField extends React.Component<SearchFieldProps, SearchFieldState> {
 					eventKey="all_entities"
 					key="allEntities"
 				>
-					{translate('common:allEntities')}
+					{translate('common.allEntities')}
 				</Dropdown.Item>
 
 				<Dropdown.Divider/>
@@ -156,14 +156,14 @@ class SearchField extends React.Component<SearchFieldProps, SearchFieldState> {
 					key="editor"
 				>
 					{genEntityIconHTMLElement('Editor')}
-					{translate('common:entityType.editor')}
+					{translate('common.entityType.editor')}
 				</Dropdown.Item>
 				<Dropdown.Item
 					eventKey="collection"
 					key="collection"
 				>
 					{genEntityIconHTMLElement('Collection')}
-					{translate('common:entityType.collection')}
+					{translate('common.entityType.collection')}
 				</Dropdown.Item>
 			</DropdownButton>
 		) : '';
@@ -192,7 +192,7 @@ class SearchField extends React.Component<SearchFieldProps, SearchFieldState> {
 										type="submit"
 										variant="success"
 									>
-										<FontAwesomeIcon icon={faSearch}/>&nbsp;{translate('common:button.search')}
+										<FontAwesomeIcon icon={faSearch}/>&nbsp;{translate('common.button.search')}
 									</Button>
 								</InputGroup.Append>
 							</InputGroup>
@@ -204,5 +204,5 @@ class SearchField extends React.Component<SearchFieldProps, SearchFieldState> {
 	}
 }
 
-export default withTranslation(['pages', 'common'])(SearchField);
+export default withTranslation()(SearchField);
 

--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -76,7 +76,7 @@ class SearchResults extends React.Component {
 			const {t: translate} = this.props;
 			this.setState({
 				message: {
-					text: translate('searchResults.loginRequired'),
+					text: translate('pages.searchResults.loginRequired'),
 					type: 'danger'
 				}
 			});
@@ -127,7 +127,7 @@ class SearchResults extends React.Component {
 				else {
 					this.setState({
 						message: {
-							text: translate('searchResults.cannotAdd', {type: selectedEntities[0].type}),
+							text: translate('pages.searchResults.cannotAdd', {type: selectedEntities[0].type}),
 							type: 'danger'
 						}
 					});
@@ -136,7 +136,7 @@ class SearchResults extends React.Component {
 			else {
 				this.setState({
 					message: {
-						text: translate('searchResults.sameTypeRequired'),
+						text: translate('pages.searchResults.sameTypeRequired'),
 						type: 'danger'
 					}
 				});
@@ -145,7 +145,7 @@ class SearchResults extends React.Component {
 		else {
 			this.setState({
 				message: {
-					text: translate('searchResults.nothingSelected'),
+					text: translate('pages.searchResults.nothingSelected'),
 					type: 'danger'
 				}
 			});
@@ -163,7 +163,7 @@ class SearchResults extends React.Component {
 			}
 			const id = getId(result);
 			const name = result.defaultAlias ? result.defaultAlias.name :
-				translate('common:unnamed');
+				translate('common.unnamed');
 
 			const aliases = !this.props.condensed && result.aliasSet &&
 				Array.isArray(result.aliasSet.aliases) && result.aliasSet.aliases;
@@ -192,7 +192,7 @@ class SearchResults extends React.Component {
 										onChange={() => this.toggleRow(result)}
 									/> : null
 							}
-							{genEntityIconHTMLElement(result.type)}{translate(`common:entityType.${_camelCase(result.type)}`)}
+							{genEntityIconHTMLElement(result.type)}{translate(`common.entityType.${_camelCase(result.type)}`)}
 						</td>
 					}
 					<td>
@@ -238,7 +238,7 @@ class SearchResults extends React.Component {
 				{
 					!this.props.condensed &&
 					<h3 className="search-results-heading">
-						{translate('common:searchResults')}
+						{translate('common.searchResults')}
 					</h3>
 				}
 				<hr className="thin"/>
@@ -250,9 +250,9 @@ class SearchResults extends React.Component {
 						!this.props.condensed &&
 						<thead>
 							<tr>
-								<th width="25%">{translate('searchResults.headerType')}</th>
-								<th width="42%">{translate('common:name')}</th>
-								<th width="33%">{translate('searchResults.headerAliases')}</th>
+								<th width="25%">{translate('pages.searchResults.headerType')}</th>
+								<th width="42%">{translate('common.name')}</th>
+								<th width="33%">{translate('pages.searchResults.headerAliases')}</th>
 							</tr>
 						</thead>
 					}
@@ -281,7 +281,7 @@ class SearchResults extends React.Component {
 								onClick={this.handleAddToCollection}
 							>
 								{genEntityIconHTMLElement('Collection')}
-								{translate('searchResults.addToCollection')}
+								{translate('pages.searchResults.addToCollection')}
 							</Button>
 							<Button
 								disabled={!this.state.selected.length}
@@ -289,7 +289,7 @@ class SearchResults extends React.Component {
 								variant="warning"
 								onClick={this.handleClearSelected}
 							>
-								{translate('searchResults.clearSelected', {count: this.state.selected.length})}
+								{translate('pages.searchResults.clearSelected', {count: this.state.selected.length})}
 							</Button>
 						</ButtonGroup> : null
 				}
@@ -311,4 +311,4 @@ SearchResults.defaultProps = {
 	results: null
 };
 
-export default withTranslation(['pages', 'common'])(SearchResults);
+export default withTranslation()(SearchResults);

--- a/src/client/components/pages/revisions.js
+++ b/src/client/components/pages/revisions.js
@@ -47,7 +47,7 @@ class RevisionsPage extends React.Component {
 					results={this.state.results}
 					showEntities={this.props.showEntities}
 					showRevisionEditor={this.props.showRevisionEditor}
-					tableHeading={translate('revisions.recentActivity')}
+					tableHeading={translate('pages.revisions.recentActivity')}
 				/>
 				<PagerElement
 					from={this.props.from}
@@ -82,4 +82,4 @@ RevisionsPage.defaultProps = {
 	size: 20
 };
 
-export default withTranslation('pages')(RevisionsPage);
+export default withTranslation()(RevisionsPage);

--- a/src/client/components/pages/search.tsx
+++ b/src/client/components/pages/search.tsx
@@ -181,17 +181,17 @@ class SearchPage extends React.Component<Props, State> {
 					<div>
 						<hr className="thin"/>
 						<h2 style={{color: '#754e37'}}>
-							{translate('searchPage.noResults')}
+							{translate('pages.searchPage.noResults')}
 						</h2>
 					</div>}
 
 					<div>
 						{results.length === 0 &&
 							<small>
-								{translate('searchPage.spellingWarning')}
+								{translate('pages.searchPage.spellingWarning')}
 							</small>}
 						<hr className="wide"/>
-						<h3>{translate('searchPage.missingEntry')}</h3>
+						<h3>{translate('pages.searchPage.missingEntry')}</h3>
 						<CallToAction query={query}/>
 					</div>
 
@@ -201,5 +201,5 @@ class SearchPage extends React.Component<Props, State> {
 	}
 }
 
-export default withTranslation('pages')(SearchPage);
+export default withTranslation()(SearchPage);
 

--- a/src/client/entity-editor/alias-editor/alias-editor.js
+++ b/src/client/entity-editor/alias-editor/alias-editor.js
@@ -48,8 +48,8 @@ const AliasEditor = ({
 	onClose,
 	show
 }) => {
-	const {t: translate} = useTranslation('entityEditor');
-	const helpText = translate('aliasEditor.helpText');
+	const {t: translate} = useTranslation();
+	const helpText = translate('entityEditor.aliasEditor.helpText');
 	const helpIconElement = (
 		<OverlayTrigger
 			delay={50}
@@ -67,7 +67,7 @@ const AliasEditor = ({
 		<Modal show={show} size="lg" onHide={onClose}>
 			<Modal.Header>
 				<Modal.Title>
-					{translate('aliasEditor.title')} {helpIconElement}
+					{translate('entityEditor.aliasEditor.title')} {helpIconElement}
 				</Modal.Title>
 			</Modal.Header>
 
@@ -76,7 +76,7 @@ const AliasEditor = ({
 			</Modal.Body>
 
 			<Modal.Footer>
-				<Button variant="primary" onClick={onClose}>{translate('button.close', {ns: 'common'})}</Button>
+				<Button variant="primary" onClick={onClose}>{translate('common.button.close')}</Button>
 			</Modal.Footer>
 		</Modal>
 	);

--- a/src/client/entity-editor/annotation-section/annotation-section.js
+++ b/src/client/entity-editor/annotation-section/annotation-section.js
@@ -44,25 +44,25 @@ function AnnotationSection({
 	onAnnotationChange,
 	isUnifiedForm
 }) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const annotation = convertMapToObject(immutableAnnotation);
 	const annotationLabel = (
 		<span>
-			{translate('common:annotation')}
-			<span className="text-muted"> {translate('shared.optionalLabel')}</span>
+			{translate('common.annotation')}
+			<span className="text-muted"> {translate('entityEditor.shared.optionalLabel')}</span>
 		</span>
 	);
 
 	const tooltip = (
 		<Tooltip>
-			{translate('annotationSection.tooltip')}
+			{translate('entityEditor.annotationSection.tooltip')}
 		</Tooltip>
 	);
 	const lgCol = {offset: 3, span: 6};
 	if (isUnifiedForm) {
 		lgCol.offset = 0;
 	}
-	const heading = <h2> {translate('common:annotation')}</h2>;
+	const heading = <h2> {translate('common.annotation')}</h2>;
 	return (
 		<div>
 			{!isUnifiedForm && heading}
@@ -88,20 +88,20 @@ function AnnotationSection({
 					{
 						annotation && annotation.lastRevision &&
 						<p className="small text-muted">
-							{translate('annotationSection.lastModified', {
+							{translate('entityEditor.annotationSection.lastModified', {
 								date: formatDate(new Date(annotation.lastRevision.createdAt))
 							})}
 						</p>
 					}
 					<p className="text-muted">
-						{translate('annotationSection.helpText')}
-						<b> {translate('annotationSection.copyrightWarning')}</b>
+						{translate('entityEditor.annotationSection.helpText')}
+						<b> {translate('entityEditor.annotationSection.copyrightWarning')}</b>
 						{' '}
-						{translate('annotationSection.openLicenseNoticePre')}
+						{translate('entityEditor.annotationSection.openLicenseNoticePre')}
 						<a href="https://musicbrainz.org/doc/About/Data_License">
-							{translate('annotationSection.openLicenseNoticeLink')}
+							{translate('entityEditor.annotationSection.openLicenseNoticeLink')}
 						</a>
-						{translate('annotationSection.openLicenseNoticePost')}
+						{translate('entityEditor.annotationSection.openLicenseNoticePost')}
 					</p>
 				</Col>
 			</Row>

--- a/src/client/entity-editor/author-credit-editor/author-credit-editor.tsx
+++ b/src/client/entity-editor/author-credit-editor/author-credit-editor.tsx
@@ -55,20 +55,20 @@ const AuthorCreditEditor = ({
 	...rest
 }) => {
 	// eslint-disable-next-line id-length
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 
 	return (
 		<Modal show={showEditor} size="lg" onHide={onClose} >
 			<Modal.Header>
-				<Modal.Title>{translate('shared.authorCreditLabel')}</Modal.Title>
+				<Modal.Title>{translate('entityEditor.shared.authorCreditLabel')}</Modal.Title>
 			</Modal.Header>
 			<Modal.Body>
 				<p>
-					{translate('authorCreditEditor.introText')}
+					{translate('entityEditor.authorCreditEditor.introText')}
 				</p>
 				<hr/>
 				<dl>
-					<dt>{translate('authorCreditEditor.previewText')}</dt>
+					<dt>{translate('entityEditor.authorCreditEditor.previewText')}</dt>
 					<dd>
 						<AuthorCreditDisplay names={authorCredit}/>
 					</dd>
@@ -90,9 +90,9 @@ const AuthorCreditEditor = ({
 			<Modal.Footer>
 				<Button variant="success" onClick={onAddAuthorCreditRow}>
 					<FontAwesomeIcon icon={faPlus}/>
-					&nbsp;{translate('authorCreditEditor.addAuthor')}
+					&nbsp;{translate('entityEditor.authorCreditEditor.addAuthor')}
 				</Button>
-				<Button variant="warning" onClick={onClose}>{translate('common:button.close')}</Button>
+				<Button variant="warning" onClick={onClose}>{translate('common.button.close')}</Button>
 			</Modal.Footer>
 		</Modal>
 	);

--- a/src/client/entity-editor/author-credit-editor/author-credit-row.tsx
+++ b/src/client/entity-editor/author-credit-editor/author-credit-row.tsx
@@ -93,7 +93,7 @@ function AuthorCreditRow({
 	onRemoveButtonClick,
 	...rest
 }: Props) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const SelectWrapper = !isUnifiedForm ? EntitySearchFieldOption : SearchEntityCreate;
 	const onChangeHandler = React.useCallback((value, action) => {
 		if (['clear', 'pop-value', 'select-option'].includes(action?.action) && author?.get('__isNew__', false)) {
@@ -114,7 +114,7 @@ function AuthorCreditRow({
 					<SelectWrapper
 						instanceId={`author${index}`}
 						isUnifiedForm={isUnifiedForm}
-						label={translate('common:entityType.author')}
+						label={translate('common.entityType.author')}
 						rowId={index}
 						validationState={!author ? 'error' : null}
 						value={author}
@@ -128,7 +128,7 @@ function AuthorCreditRow({
 					<Form.Group>
 						<Form.Label>
 							<ValidationLabel empty={name.length === 0} error={!name.length}>
-								{translate('authorCreditRow.creditedAsLabel')}
+								{translate('entityEditor.authorCreditRow.creditedAsLabel')}
 							</ValidationLabel>
 						</Form.Label>
 						<Form.Control type="text" value={name} onChange={onNameChange}/>
@@ -137,7 +137,7 @@ function AuthorCreditRow({
 				</Col>
 				<Col md={{span: 3}}>
 					<Form.Group>
-						<Form.Label>{translate('authorCreditEditor.joinPhraseLabel')}</Form.Label>
+						<Form.Label>{translate('entityEditor.authorCreditEditor.joinPhraseLabel')}</Form.Label>
 						<Form.Control type="text" value={joinPhrase} onChange={onJoinPhraseChange}/>
 
 					</Form.Group>
@@ -150,7 +150,7 @@ function AuthorCreditRow({
 						onClick={handleButtonClick}
 					>
 						<FontAwesomeIcon icon={faTimes}/>
-						&nbsp;{translate('common:button.remove')}
+						&nbsp;{translate('common.button.remove')}
 					</Button>
 				</Col>
 			</Row>

--- a/src/client/entity-editor/author-credit-editor/author-credit-section.tsx
+++ b/src/client/entity-editor/author-credit-editor/author-credit-section.tsx
@@ -78,7 +78,7 @@ function AuthorCreditSection({
 	showEditor, onAuthorChange, isEditable, authorCreditEnable, toggleAuthorCreditEnable,
 	onClearHandler, isUnifiedForm, isLeftAlign, ...rest
 }: Props) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const authorCreditEditor = convertMapToObject(immutableAuthorCreditEditor);
 	let editor;
 	if (showEditor) {
@@ -100,12 +100,12 @@ function AuthorCreditSection({
 		// eslint-disable-next-line react/jsx-no-bind
 		<Button disabled={!authorCreditEnable} variant="success" onClick={function openEditor() { onEditAuthorCredit(authorCreditRows.length); }}>
 			<FontAwesomeIcon icon={faPencilAlt}/>
-			&nbsp;{translate('common:button.edit')}
+			&nbsp;{translate('common.button.edit')}
 		</Button>);
 
 	const label = (
 		<ValidationLabel empty={false} error={!isValid}>
-			{translate('common:authorCredit')}
+			{translate('common.authorCredit')}
 		</ValidationLabel>
 	);
 	const SingleValue = (props:SingleValueProps<any>) => (
@@ -118,17 +118,17 @@ function AuthorCreditSection({
 	const optionValue = authorCreditPreview.length && {label: authorCreditPreview, value: authorCreditPreview};
 	const tooltip = (
 		<Tooltip id="AC-checkbox-tooltip">
-			{translate('authorCreditSection.tooltip')}
+			{translate('entityEditor.authorCreditSection.tooltip')}
 		</Tooltip>
 	);
 	const checkboxLabel = (
 		<>
 			<FormLabel className="font-weight-normal">
-				{translate('authorCreditSection.noAuthorLabel')}
+				{translate('entityEditor.authorCreditSection.noAuthorLabel')}
 				<OverlayTrigger
 					delay={50}
 					overlay={
-						<Tooltip id="ac-enabled">{translate('authorCreditSection.noAuthorTooltip')}</Tooltip>}
+						<Tooltip id="ac-enabled">{translate('entityEditor.authorCreditSection.noAuthorTooltip')}</Tooltip>}
 				>
 					<FontAwesomeIcon
 						className="margin-left-0-5"
@@ -176,7 +176,7 @@ function AuthorCreditSection({
 								isClearable={false}
 								isDisabled={!isEditable}
 								isUnifiedForm={isUnifiedForm}
-								placeholder={translate('authorCreditSection.placeholder')}
+								placeholder={translate('entityEditor.authorCreditSection.placeholder')}
 								recentlyUsedEntityType="Author"
 								rowId="n0"
 								value={optionValue}

--- a/src/client/entity-editor/author-section/author-section-merge.tsx
+++ b/src/client/entity-editor/author-section/author-section-merge.tsx
@@ -180,8 +180,8 @@ function AuthorSectionMerge({
 
 		const ended = !_.isNil(entity.ended) && {
 			label: entity.ended ?
-				translate('common:yes') :
-				translate('common:no'),
+				translate('common.yes') :
+				translate('common.no'),
 			value: entity.ended
 		};
 		if (ended && !_.find(endedOptions, ['value', ended.value])) {
@@ -204,13 +204,13 @@ function AuthorSectionMerge({
 		<div>
 			<MergeField
 				currentValue={typeValue}
-				label={translate('common:type')}
+				label={translate('common.type')}
 				options={typeOptions}
 				onChange={onTypeChange}
 			/>
 			<MergeField
 				currentValue={genderValue}
-				label={translate('common:gender')}
+				label={translate('common.gender')}
 				options={genderOptions}
 				onChange={onGenderChange}
 			/>
@@ -305,6 +305,6 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 	};
 }
 
-export default withTranslation('entityEditor')(
+export default withTranslation()(
 	connect(mapStateToProps, mapDispatchToProps)(AuthorSectionMerge)
 );

--- a/src/client/entity-editor/author-section/author-section.tsx
+++ b/src/client/entity-editor/author-section/author-section.tsx
@@ -178,7 +178,7 @@ function AuthorSection({
 
 	const {isValid: isValidDob, errorMessage: dobError} = validateAuthorSectionBeginDate(beginDateValue);
 	const {isValid: isValidDod, errorMessage: dodError} = validateAuthorSectionEndDate(beginDateValue, endDateValue, currentAuthorType.label);
-	const heading = <h2>{translate('entityEditor:shared.entityHeading', {entity: 'Author'})}</h2>;
+	const heading = <h2>{translate('entityEditor.shared.entityHeading', {entity: 'Author'})}</h2>;
 	const lgCol = {offset: 3, span: 6};
 	if (isUnifiedForm) {
 		lgCol.offset = 0;
@@ -187,12 +187,12 @@ function AuthorSection({
 		<div>
 			{!isUnifiedForm && heading}
 			<p className="text-muted">
-				{translate('entityEditor:shared.allFieldsOptional')}
+				{translate('entityEditor.shared.allFieldsOptional')}
 			</p>
 			<Row>
 				<Col lg={lgCol}>
 					<Form.Group>
-						<Form.Label>{translate('common:type')}</Form.Label>
+						<Form.Label>{translate('common.type')}</Form.Label>
 						<Select
 							isClearable
 							classNamePrefix="react-select"
@@ -207,7 +207,7 @@ function AuthorSection({
 			<Row>
 				<Col lg={lgCol}>
 					<Form.Group className={genderShow ? null : 'd-none'}>
-						<Form.Label>{translate('common:gender')}</Form.Label>
+						<Form.Label>{translate('common.gender')}</Form.Label>
 						<Select
 							classNamePrefix="react-select"
 							instanceId="gender"
@@ -352,6 +352,6 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 	};
 }
 
-export default withTranslation('entityEditor')(
+export default withTranslation()(
 	connect(mapStateToProps, mapDispatchToProps)(AuthorSection)
 );

--- a/src/client/entity-editor/button-bar/alias-button.js
+++ b/src/client/entity-editor/button-bar/alias-button.js
@@ -40,8 +40,8 @@ function AliasButton({
 	numAliases,
 	...props
 }) {
-	const {t: translate} = useTranslation('entityEditor');
-	const text = translate('aliasButton.editAliases', {count: numAliases});
+	const {t: translate} = useTranslation();
+	const text = translate('entityEditor.aliasButton.editAliases', {count: numAliases});
 
 	const iconElement = aliasesInvalid &&
 		<FontAwesomeIcon className="margin-right-0-5 text-danger" icon={faTimes}/>;

--- a/src/client/entity-editor/button-bar/identifier-button.js
+++ b/src/client/entity-editor/button-bar/identifier-button.js
@@ -44,25 +44,25 @@ function IdentifierButton({
 	isUnifiedForm,
 	...props
 }) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const textComponent = (() => {
 		if (!isUnifiedForm) {
 			if (numIdentifiers === 0) {
-				return translate('shared.addIdentifiers');
+				return translate('entityEditor.shared.addIdentifiers');
 			}
-			return translate('identifierButton.editIdentifiers', {count: numIdentifiers});
+			return translate('entityEditor.identifierButton.editIdentifiers', {count: numIdentifiers});
 		}
 
 		if (numIdentifiers > 0) {
 			return (
 				<span>
-					{translate('identifierButton.editIdentifiersUnified')}{' '}
+					{translate('entityEditor.identifierButton.editIdentifiersUnified')}{' '}
 					<Badge className="ml-1" variant="light">{numIdentifiers}</Badge>
 				</span>
 			);
 		}
 
-		return translate('identifierButton.addIdentifiersUnified');
+		return translate('entityEditor.identifierButton.addIdentifiersUnified');
 	})();
 	const iconElement = identifiersInvalid &&
 		<FontAwesomeIcon className="margin-right-0-5 text-danger" icon={faTimes}/>;

--- a/src/client/entity-editor/common/language-field.tsx
+++ b/src/client/entity-editor/common/language-field.tsx
@@ -67,9 +67,9 @@ function LanguageField({
 	onChange,
 	...rest
 }: Props) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const label =
-		<ValidationLabel empty={empty} error={error}>{translate('languageField.label')}</ValidationLabel>
+		<ValidationLabel empty={empty} error={error}>{translate('entityEditor.languageField.label')}</ValidationLabel>
 	;
 	const MAX_DROPDOWN_OPTIONS = 20;
 	const MAX_F1_OPTIONS = 400;
@@ -95,15 +95,15 @@ function LanguageField({
 	const recentItems = RecentlyUsed.getItems('languages').filter(item => item.name !== '[Multiple languages]');
 	const defaultOptions = [
 		{
-			label: translate('languageField.recentlyUsed'),
+			label: translate('entityEditor.languageField.recentlyUsed'),
 			options: recentItems.map(item => ({label: item.name, value: item.id}))
 		},
 		{
-			label: translate('languageField.frequentlyUsed'),
+			label: translate('entityEditor.languageField.frequentlyUsed'),
 			options: f2Languages
 		},
 		{
-			label: translate('languageField.other'),
+			label: translate('entityEditor.languageField.other'),
 			options: f1Languages
 		}
 	];
@@ -140,7 +140,7 @@ function LanguageField({
 				components={{Option: OptimizedOption}}
 				defaultOptions={defaultOptions}
 				loadOptions={fetchOptions}
-				placeholder={translate('languageField.placeholder')}
+				placeholder={translate('entityEditor.languageField.placeholder')}
 				{...rest}
 				onChange={handleChange}
 			/>

--- a/src/client/entity-editor/common/name-field.tsx
+++ b/src/client/entity-editor/common/name-field.tsx
@@ -56,10 +56,10 @@ function NameField({
 	warn,
 	...rest
 }: Props) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const inputLabel = (
 		<ValidationLabel empty={empty} error={error} warn={warn}>
-			{!label ? translate('common:name') : label}
+			{!label ? translate('common.name') : label}
 		</ValidationLabel>
 	);
 

--- a/src/client/entity-editor/common/new-date-field.js
+++ b/src/client/entity-editor/common/new-date-field.js
@@ -115,7 +115,7 @@ class DateField extends React.Component {
 
 	render() {
 		const {t: translate} = this.props;
-		const warnMessage = translate('dateField.futureDateWarning');
+		const warnMessage = translate('entityEditor.dateField.futureDateWarning');
 		const labelElement = (
 			<ValidationLabel
 				empty={this.props.empty}
@@ -182,7 +182,7 @@ class DateField extends React.Component {
 								customInput={
 									<Button
 										style={{lineHeight: '1.75', padding: '0.375em 0.938em'}}
-										title={translate('dateField.datePickerTitle')}
+										title={translate('entityEditor.dateField.datePickerTitle')}
 										variant="info"
 									>
 										<FontAwesomeIcon icon={faCalendarAlt}/>
@@ -225,4 +225,4 @@ DateField.defaultProps = {
 	errorMessage: null
 };
 
-export default withTranslation('entityEditor')(DateField);
+export default withTranslation()(DateField);

--- a/src/client/entity-editor/common/sort-name-field.tsx
+++ b/src/client/entity-editor/common/sort-name-field.tsx
@@ -127,7 +127,7 @@ function SortNameField({
 	storedNameValue,
 	...rest
 }: Props) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	let input;
 
 	function handleGuessClick() {
@@ -153,21 +153,21 @@ function SortNameField({
 
 	const label = (
 		<ValidationLabel empty={empty} error={error}>
-			{translate('sortNameField.label')}
+			{translate('entityEditor.sortNameField.label')}
 		</ValidationLabel>
 	);
 
 	/* eslint-disable react/jsx-no-bind */
 	const guessButton =
-		<Button variant="primary" onClick={handleGuessClick}>{translate('common:button.guess')}</Button>;
+		<Button variant="primary" onClick={handleGuessClick}>{translate('common.button.guess')}</Button>;
 
 	const copyButton =
-		<Button className="ml-1" variant="primary" onClick={handleCopyClick}>{translate('common:button.copy')}</Button>;
+		<Button className="ml-1" variant="primary" onClick={handleCopyClick}>{translate('common.button.copy')}</Button>;
 	/* eslint-enable react/jsx-no-bind */
 
 	const tooltip = (
 		<Tooltip>
-			{translate('sortNameField.tooltip')}
+			{translate('entityEditor.sortNameField.tooltip')}
 		</Tooltip>
 	);
 

--- a/src/client/entity-editor/edition-group-section/edition-group-section-merge.tsx
+++ b/src/client/entity-editor/edition-group-section/edition-group-section-merge.tsx
@@ -67,7 +67,7 @@ function EditionGroupSectionMerge({
 	onAuthorCreditChange,
 	onTypeChange
 }: Props) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const authorCreditOptions = [];
 	const typeOptions = [];
 	const editions = [];
@@ -88,14 +88,14 @@ function EditionGroupSectionMerge({
 		<div>
 			<MergeField
 				currentValue={authorCreditValue}
-				label={translate('common:authorCredit')}
+				label={translate('common.authorCredit')}
 				options={authorCreditOptions}
 				valueRenderer={authorCreditToString}
 				onChange={onAuthorCreditChange}
 			/>
 			<MergeField
 				currentValue={typeValue}
-				label={translate('common:type')}
+				label={translate('common.type')}
 				options={typeOptions}
 				onChange={onTypeChange}
 			/>

--- a/src/client/entity-editor/edition-group-section/edition-group-section.tsx
+++ b/src/client/entity-editor/edition-group-section/edition-group-section.tsx
@@ -72,15 +72,15 @@ function EditionGroupSection({
 	isLeftAlign,
 	onTypeChange
 }: Props) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 
 	const editionGroupTypesForDisplay = editionGroupTypes.map((type) => ({
 		label: type.label,
 		value: type.id
 	}));
 	const typeOption = editionGroupTypesForDisplay.filter((el) => el.value === typeValue);
-	const tooltip = <Tooltip>{translate('editionGroupSection.typeTooltip')}</Tooltip>;
-	const heading = <h2>{translate('shared.entityHeading', {entity: 'Edition Group'})}</h2>;
+	const tooltip = <Tooltip>{translate('entityEditor.editionGroupSection.typeTooltip')}</Tooltip>;
+	const heading = <h2>{translate('entityEditor.shared.entityHeading', {entity: 'Edition Group'})}</h2>;
 	const lgCol = {offset: 3, span: 6};
 	if (isUnifiedForm) {
 		lgCol.offset = 0;
@@ -90,13 +90,13 @@ function EditionGroupSection({
 			{!isUnifiedForm && heading}
 			<AuthorCreditSection isLeftAlign={isLeftAlign} type="editionGroup"/>
 			<p className="text-muted">
-				{translate('shared.allFieldsOptional')}
+				{translate('entityEditor.shared.allFieldsOptional')}
 			</p>
 			<Row>
 				<Col lg={lgCol}>
 					<Form.Group>
 						<Form.Label>
-							{translate('common:type')}
+							{translate('common.type')}
 							<OverlayTrigger delay={50} overlay={tooltip}>
 								<FontAwesomeIcon
 									className="margin-left-0-5"

--- a/src/client/entity-editor/edition-section/edition-section-merge.tsx
+++ b/src/client/entity-editor/edition-section/edition-section-merge.tsx
@@ -156,7 +156,7 @@ function EditionSectionMerge({
 	weightValue,
 	widthValue
 }: Props) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const editionGroupOptions = [];
 	const authorCreditOptions = [];
 	const releaseDateOptions = [];
@@ -225,7 +225,7 @@ function EditionSectionMerge({
 		<div>
 			<MergeField
 				currentValue={authorCreditValue}
-				label={translate('common:authorCredit')}
+				label={translate('common.authorCredit')}
 				options={authorCreditOptions}
 				valueRenderer={authorCreditToString}
 				onChange={onAuthorCreditChange}
@@ -233,73 +233,73 @@ function EditionSectionMerge({
 			<MergeField
 				components={{Option: LinkedEntitySelect, SingleValue: EntitySelect}}
 				currentValue={editionGroupValue}
-				label={translate('common:entityType.editionGroup')}
+				label={translate('common.entityType.editionGroup')}
 				options={editionGroupOptions}
 				onChange={onEditionGroupChange}
 			/>
 			<MergeField
 				currentValue={releaseDateValue}
-				label={translate('shared.releaseDateLabel')}
+				label={translate('entityEditor.shared.releaseDateLabel')}
 				options={releaseDateOptions}
 				onChange={onReleaseDateChange}
 			/>
 			<MergeField
 				components={{Option: LinkedEntitySelect, SingleValue: EntitySelect}}
 				currentValue={publisherValue}
-				label={translate('common:entityType.publisher')}
+				label={translate('common.entityType.publisher')}
 				options={publisherOptions}
 				onChange={onPublisherChange}
 			/>
 			<MergeField
 				currentValue={formatValue}
-				label={translate('common:format')}
+				label={translate('common.format')}
 				options={formatOptions}
 				onChange={onFormatChange}
 			/>
 			<MergeField
 				currentValue={statusValue}
-				label={translate('common:status')}
+				label={translate('common.status')}
 				options={statusOptions}
 				onChange={onStatusChange}
 			/>
 			<MergeField
 				currentValue={depthValue}
-				label={translate('shared.depthLabel')}
+				label={translate('entityEditor.shared.depthLabel')}
 				options={depthOptions}
 				onChange={onDepthChange}
 			/>
 			<MergeField
 				currentValue={widthValue}
-				label={translate('shared.widthLabel')}
+				label={translate('entityEditor.shared.widthLabel')}
 				options={widthOptions}
 				onChange={onWidthChange}
 			/>
 			<MergeField
 				currentValue={heightValue}
-				label={translate('shared.heightLabel')}
+				label={translate('entityEditor.shared.heightLabel')}
 				options={heightOptions}
 				onChange={onHeightChange}
 			/>
 			<MergeField
 				currentValue={pagesValue}
-				label={translate('common:pages')}
+				label={translate('common.pages')}
 				options={pagesOptions}
 				onChange={onPagesChange}
 			/>
 			<MergeField
 				currentValue={weightValue}
-				label={translate('shared.weightLabel')}
+				label={translate('entityEditor.shared.weightLabel')}
 				options={weightOptions}
 				onChange={onWeightChange}
 			/>
 			<Form.Group>
-				<Form.Label>{translate('common:languages')}</Form.Label>
+				<Form.Label>{translate('common.languages')}</Form.Label>
 				<Select
 					isDisabled
 					isMulti
 					classNamePrefix="react-select"
 					instanceId="languages"
-					placeholder={translate('editionSectionMerge.noLanguages')}
+					placeholder={translate('entityEditor.editionSectionMerge.noLanguages')}
 					value={languageValues}
 				/>
 			</Form.Group>

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -196,7 +196,7 @@ function EditionSection({
 	widthValue,
 	...rest
 }: Props) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const languageOptionsForDisplay = languageOptions.map((language) => ({
 		frequency: language.frequency,
 		label: language.name,
@@ -230,17 +230,17 @@ function EditionSection({
 			<Col className="margin-bottom-2" lg={{offset: isUnifiedForm || showMatchingEditionGroups ? 0 : 3, span: 6}}>
 				<EntitySearchField
 					error={!validateEditionSectionEditionGroup(editionGroupValue, true)}
-					help={translate('editionSection.editionGroupHelp')}
+					help={translate('entityEditor.editionSection.editionGroupHelp')}
 					instanceId="edition-group"
 					isUnifiedForm={isUnifiedForm}
-					label={translate('common:entityType.editionGroup')}
+					label={translate('common.entityType.editionGroup')}
 					languageOptions={languageOptions}
 					recentlyUsedEntityType="EditionGroup"
 					tooltipText={
 						<>
-							{translate('editionSection.editionGroupTooltip')}
+							{translate('entityEditor.editionSection.editionGroupTooltip')}
 							<br/>
-							{translate('editionSection.editionGroupTooltipExample')}
+							{translate('entityEditor.editionSection.editionGroupTooltipExample')}
 						</>
 					}
 					type="editionGroup"
@@ -255,7 +255,7 @@ function EditionSection({
 					// eslint-disable-next-line react/jsx-no-bind
 					onClick={onToggleShowEditionGroupSection.bind(this, false)}
 				>
-					<FontAwesomeIcon icon={faClone}/>&nbsp;{translate('editionSection.autoCreateEditionGroup')}
+					<FontAwesomeIcon icon={faClone}/>&nbsp;{translate('entityEditor.editionSection.autoCreateEditionGroup')}
 				</Button>
 			</Col>
 		</React.Fragment>
@@ -263,16 +263,16 @@ function EditionSection({
 
 	const formatTooltip = (
 		<Tooltip>
-			{translate('editionSection.formatTooltip')}
+			{translate('entityEditor.editionSection.formatTooltip')}
 		</Tooltip>
 	);
 
 	const statusTooltip = (
 		<Tooltip>
-			{translate('editionSection.statusTooltip')}
+			{translate('entityEditor.editionSection.statusTooltip')}
 		</Tooltip>
 	);
-	const headingTag = !isUnifiedForm && <h2>{translate('shared.entityHeading', {entity: 'Edition'})}</h2>;
+	const headingTag = !isUnifiedForm && <h2>{translate('entityEditor.shared.entityHeading', {entity: 'Edition'})}</h2>;
 	const colSpan = {
 		offset: 3,
 		span: 6
@@ -290,7 +290,7 @@ function EditionSection({
 			{headingTag}
 			{!isUnifiedForm && <AuthorCreditSection type="edition"/>}
 			<p className="text-muted">
-				{translate('editionSection.editionGroupRequired')}
+				{translate('entityEditor.editionSection.editionGroupRequired')}
 			</p>
 
 			<Row className="margin-bottom-3">
@@ -298,7 +298,7 @@ function EditionSection({
 					showAutoCreateEditionGroupMessage ?
 						<Col lg={{offset: isUnifiedForm || showMatchingEditionGroups ? 0 : 3, span: 6}}>
 							<Alert variant="success">
-								<p>{translate('editionSection.autoCreateMessage')}</p>
+								<p>{translate('entityEditor.editionSection.autoCreateMessage')}</p>
 								<br/>
 								<Button
 									block
@@ -307,7 +307,7 @@ function EditionSection({
 									// eslint-disable-next-line react/jsx-no-bind
 									onClick={onToggleShowEditionGroupSection.bind(this, true)}
 								>
-									<FontAwesomeIcon icon={faSearch}/>&nbsp;{translate('editionSection.searchExistingEditionGroup')}
+									<FontAwesomeIcon icon={faSearch}/>&nbsp;{translate('entityEditor.editionSection.searchExistingEditionGroup')}
 								</Button>
 							</Alert>
 						</Col> :
@@ -316,18 +316,18 @@ function EditionSection({
 				{showMatchingEditionGroups &&
 					<Col lg={6}>
 						<Alert variant="warning">
-							{translate('editionSection.matchingEditionGroups', {count: matchingNameEditionGroups.length})}
+							{translate('entityEditor.editionSection.matchingEditionGroups', {count: matchingNameEditionGroups.length})}
 							<br/>
-							{translate('editionSection.reviewEditionGroups')}
+							{translate('entityEditor.editionSection.reviewEditionGroups')}
 							<br/>
 							<small>
-								{translate('editionSection.noSelectionAutoCreate')}
+								{translate('entityEditor.editionSection.noSelectionAutoCreate')}
 								<br/>
 								<Trans
 									components={{
 										icon: <FontAwesomeIcon icon={faExternalLinkAlt}/>
 									}}
-									i18nKey="entityEditor:editionSection.clickIconToOpen"
+									i18nKey="entityEditor.editionSection.clickIconToOpen"
 								/>
 							</small>
 							<ListGroup className="margin-top-1">
@@ -344,7 +344,7 @@ function EditionSection({
 
 
 			<p className="text-muted">
-				{translate('editionSection.belowFieldsOptional')}
+				{translate('entityEditor.editionSection.belowFieldsOptional')}
 			</p>
 			<Row>
 				{!isUnifiedForm &&
@@ -352,7 +352,7 @@ function EditionSection({
 					<EntitySearchFieldOption
 						isMulti
 						instanceId="publisher"
-						label={translate('common:entityType.publisher')}
+						label={translate('common.entityType.publisher')}
 						recentlyUsedEntityType="Publisher"
 						type="publisher"
 						value={publisherValue}
@@ -368,9 +368,9 @@ function EditionSection({
 						empty={isNullDate(releaseDateValue)}
 						error={!isValidReleaseDate}
 						errorMessage={dateErrorMessage}
-						label={translate('shared.releaseDateLabel')}
+						label={translate('entityEditor.shared.releaseDateLabel')}
 						placeholder="YYYY-MM-DD"
-						tooltipText={translate('editionSection.releaseDateTooltip')}
+						tooltipText={translate('entityEditor.editionSection.releaseDateTooltip')}
 						onChangeDate={onReleaseDateChange}
 					/>
 				</Col>
@@ -382,7 +382,7 @@ function EditionSection({
 						isMulti
 						instanceId="language"
 						options={languageOptionsForDisplay}
-						tooltipText={translate('editionSection.languageTooltip')}
+						tooltipText={translate('entityEditor.editionSection.languageTooltip')}
 						value={languageValues}
 						onChange={onLanguagesChange}
 					/>
@@ -392,7 +392,7 @@ function EditionSection({
 				<Col lg={shortColSpan}>
 					<Form.Group>
 						<Form.Label>
-							{translate('common:format')}
+							{translate('common.format')}
 							<OverlayTrigger delay={50} overlay={formatTooltip}>
 								<FontAwesomeIcon
 									className="margin-left-0-5"
@@ -414,7 +414,7 @@ function EditionSection({
 				<Col lg={3}>
 					<Form.Group>
 						<Form.Label>
-							{translate('common:status')}
+							{translate('common.status')}
 							<OverlayTrigger delay={50} overlay={statusTooltip}>
 								<FontAwesomeIcon
 									className="margin-left-0-5"
@@ -441,7 +441,7 @@ function EditionSection({
 						defaultValue={pagesValue}
 						empty={_.isNil(pagesValue)}
 						error={!validateEditionSectionPages(pagesValue)}
-						label={translate('common:pageCount')}
+						label={translate('common.pageCount')}
 						onChange={onPagesChange}
 					/>
 				</Col>
@@ -454,7 +454,7 @@ function EditionSection({
 						disabled={!physicalEnable}
 						empty={_.isNil(widthValue)}
 						error={!validateEditionSectionWidth(widthValue)}
-						label={translate('shared.widthLabel')}
+						label={translate('entityEditor.shared.widthLabel')}
 						onChange={onWidthChange}
 					/>
 					<NumericField
@@ -463,7 +463,7 @@ function EditionSection({
 						disabled={!physicalEnable}
 						empty={_.isNil(heightValue)}
 						error={!validateEditionSectionHeight(heightValue)}
-						label={translate('shared.heightLabel')}
+						label={translate('entityEditor.shared.heightLabel')}
 						onChange={onHeightChange}
 					/>
 				</Col>
@@ -474,7 +474,7 @@ function EditionSection({
 						disabled={!physicalEnable}
 						empty={_.isNil(weightValue)}
 						error={!validateEditionSectionWeight(weightValue)}
-						label={translate('shared.weightLabel')}
+						label={translate('entityEditor.shared.weightLabel')}
 						onChange={onWeightChange}
 					/>
 					<NumericField
@@ -483,7 +483,7 @@ function EditionSection({
 						disabled={!physicalEnable}
 						empty={_.isNil(depthValue)}
 						error={!validateEditionSectionDepth(depthValue)}
-						label={translate('shared.depthLabel')}
+						label={translate('entityEditor.shared.depthLabel')}
 						onChange={onDepthChange}
 					/>
 				</Col>

--- a/src/client/entity-editor/identifier-editor/identifier-editor.js
+++ b/src/client/entity-editor/identifier-editor/identifier-editor.js
@@ -51,8 +51,8 @@ const IdentifierEditor = ({
 	onClose,
 	show
 }) => {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
-	const helpText = translate('identifierEditor.helpText');
+	const {t: translate} = useTranslation();
+	const helpText = translate('entityEditor.identifierEditor.helpText');
 
 	const helpIconElement = (
 		<OverlayTrigger
@@ -71,7 +71,7 @@ const IdentifierEditor = ({
 		<Modal show={show} size="lg" onHide={onClose}>
 			<Modal.Header>
 				<Modal.Title>
-					{translate('identifierEditor.title')} {helpIconElement}
+					{translate('entityEditor.identifierEditor.title')} {helpIconElement}
 				</Modal.Title>
 			</Modal.Header>
 
@@ -80,7 +80,7 @@ const IdentifierEditor = ({
 			</Modal.Body>
 
 			<Modal.Footer>
-				<Button variant="primary" onClick={onClose}>{translate('button.close', {ns: 'common'})}</Button>
+				<Button variant="primary" onClick={onClose}>{translate('common.button.close')}</Button>
 			</Modal.Footer>
 		</Modal>
 	);

--- a/src/client/entity-editor/identifier-editor/identifier-modal-body.tsx
+++ b/src/client/entity-editor/identifier-editor/identifier-modal-body.tsx
@@ -23,14 +23,14 @@ type IdentifierModalBodyProps = IdentifierModalBodyOwnProps & IdentifierModalBod
 
 
 export const IdentifierModalBody = ({identifiers, onAddIdentifier, identifierTypes}:IdentifierModalBodyProps) => {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const noIdentifiersTextClass =
 		classNames('text-center', {'d-none': identifiers.size});
 
 	return (
 		<>
 			<div className={noIdentifiersTextClass}>
-				<p className="text-muted">{translate('identifierModalBody.noIdentifiers')}</p>
+				<p className="text-muted">{translate('entityEditor.identifierModalBody.noIdentifiers')}</p>
 			</div>
 			<div>
 				{
@@ -48,7 +48,7 @@ export const IdentifierModalBody = ({identifiers, onAddIdentifier, identifierTyp
 				<Col className="text-right" lg={{offset: 9, span: 3}}>
 					<Button variant="success" onClick={onAddIdentifier}>
 						<FontAwesomeIcon icon={faPlus}/>
-						<span>&nbsp;{translate('identifierModalBody.addButton')}</span>
+						<span>&nbsp;{translate('entityEditor.identifierModalBody.addButton')}</span>
 					</Button>
 				</Col>
 			</Row>

--- a/src/client/entity-editor/identifier-editor/identifier-row.tsx
+++ b/src/client/entity-editor/identifier-editor/identifier-row.tsx
@@ -88,7 +88,7 @@ function IdentifierRow({
 	onRemoveButtonClick,
 	onValueChange
 }: Props) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const identifierTypesForDisplay = typeOptions.map((type) => ({
 		label: type.label,
 		value: type.id
@@ -109,7 +109,7 @@ function IdentifierRow({
 				</Col>
 				<Col lg={4}>
 					<Form.Group>
-						<Form.Label>{translate('identifierRow.typeLabel')}</Form.Label>
+						<Form.Label>{translate('entityEditor.identifierRow.typeLabel')}</Form.Label>
 						<Select
 							classNamePrefix="react-select"
 							instanceId={`identifierType${index}`}
@@ -127,14 +127,14 @@ function IdentifierRow({
 						onClick={onRemoveButtonClick}
 					>
 						<FontAwesomeIcon icon={faTimes}/>
-						<span>&nbsp;{translate('common:button.remove')}</span>
+						<span>&nbsp;{translate('common.button.remove')}</span>
 					</Button>
 				</Col>
 			</Row>
 			{typeValue && valueValue && (
 				<Row>
 					<Col>
-						{translate('identifierRow.previewLink')}
+						{translate('entityEditor.identifierRow.previewLink')}
 						<IdentifierLink typeId={typeValue} value={valueValue}/>
 					</Col>
 				</Row>

--- a/src/client/entity-editor/identifier-editor/value-field.js
+++ b/src/client/entity-editor/identifier-editor/value-field.js
@@ -41,10 +41,10 @@ function ValueField({
 	empty,
 	...rest
 }) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const label = (
 		<ValidationLabel empty={empty} error={error}>
-			{translate('valueField.label')}
+			{translate('entityEditor.valueField.label')}
 		</ValidationLabel>
 	);
 

--- a/src/client/entity-editor/name-section/disambiguation-field.tsx
+++ b/src/client/entity-editor/name-section/disambiguation-field.tsx
@@ -47,19 +47,19 @@ function DisambiguationField({
 	required,
 	...rest
 }: Props) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const label = (
 		<ValidationLabel empty={empty} error={error}>
-			{translate('disambiguationField.label')}
+			{translate('entityEditor.disambiguationField.label')}
 			{required || null ? null :
-				<span className="text-muted"> {translate('shared.optionalLabel')}</span>
+				<span className="text-muted"> {translate('entityEditor.shared.optionalLabel')}</span>
 			}
 		</ValidationLabel>
 	);
 
 	const tooltip = (
 		<Tooltip>
-			{translate('disambiguationField.tooltip')}
+			{translate('entityEditor.disambiguationField.tooltip')}
 		</Tooltip>
 	);
 

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -143,8 +143,8 @@ class NameSection extends React.Component {
 					disambiguationDefaultValue
 				) ?
 					<Alert variant="warning">
-						{translate('nameSection.duplicateWarning', {count: exactMatches.length, entityType: _.startCase(entityType)})}
-						<br/><small className="text-muted">{translate('nameSection.clickToOpen')}</small>
+						{translate('entityEditor.nameSection.duplicateWarning', {count: exactMatches.length, entityType: _.startCase(entityType)})}
+						<br/><small className="text-muted">{translate('entityEditor.nameSection.clickToOpen')}</small>
 						<ListGroup activeKey={null} className="margin-top-1 margin-bottom-1">
 							{exactMatches.map((match) =>
 								(
@@ -159,7 +159,7 @@ class NameSection extends React.Component {
 									</ListGroup.Item>
 								))}
 						</ListGroup>
-						{translate('nameSection.fillDisambiguation')}
+						{translate('entityEditor.nameSection.fillDisambiguation')}
 					</Alert> : null
 				}
 			</Col>
@@ -201,14 +201,14 @@ class NameSection extends React.Component {
 		!_.isEmpty(searchResults) &&
 		<Row>
 			<Col lg={lgCol}>
-				{translate('nameSection.duplicateSuggestion', {entityType: _.startCase(entityType)})}
+				{translate('entityEditor.nameSection.duplicateSuggestion', {entityType: _.startCase(entityType)})}
 				<br/>
-				<small>{translate('nameSection.ctrlClick')}</small>
+				<small>{translate('entityEditor.nameSection.ctrlClick')}</small>
 				<SearchResults condensed results={searchResults}/>
 			</Col>
 		</Row>;
 		const duplicateAlert = this.renderDuplicateAlert(warnIfExists, disambiguationDefaultValue, exactMatches, entityType, lgCol);
-		const heading = <h2>{translate('nameSection.heading', {entityType: _.startCase(entityType)})}</h2>;
+		const heading = <h2>{translate('entityEditor.nameSection.heading', {entityType: _.startCase(entityType)})}</h2>;
 		return (
 			<div>
 				{!isUnifiedForm && heading}
@@ -221,7 +221,7 @@ class NameSection extends React.Component {
 							)}
 							error={!validateNameSectionName(nameValue)}
 							inputRef={this.updateNameFieldInputRef}
-							tooltipText={translate('nameSection.nameTooltip', {entityType: _.startCase(entityType)})}
+							tooltipText={translate('entityEditor.nameSection.nameTooltip', {entityType: _.startCase(entityType)})}
 							warn={(isRequiredDisambiguationEmpty(
 								warnIfExists,
 								disambiguationDefaultValue
@@ -256,7 +256,7 @@ class NameSection extends React.Component {
 							error={!validateNameSectionLanguage(languageValue)}
 							instanceId="language"
 							options={languageOptionsForDisplay}
-							tooltipText={translate('nameSection.languageTooltip')}
+							tooltipText={translate('entityEditor.nameSection.languageTooltip')}
 							value={languageOption}
 							onChange={onLanguageChange}
 						/>
@@ -375,4 +375,4 @@ function mapDispatchToProps(dispatch, {entity, entityType, copyLanguages}) {
 	};
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withTranslation('entityEditor')(NameSection));
+export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(NameSection));

--- a/src/client/entity-editor/publisher-section/publisher-section-merge.tsx
+++ b/src/client/entity-editor/publisher-section/publisher-section-merge.tsx
@@ -116,7 +116,7 @@ function PublisherSectionMerge({
 	onEndedChange,
 	onTypeChange
 }: Props) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const areaOptions = [];
 	const typeOptions = [];
 	const beginDateOptions = [];
@@ -138,8 +138,8 @@ function PublisherSectionMerge({
 		}
 		const ended = !_.isNil(entity.ended) && {
 			label: entity.ended ?
-				translate('common:yes') :
-				translate('common:no'),
+				translate('common.yes') :
+				translate('common.no'),
 			value: entity.ended
 		};
 		if (ended && !_.find(endedOptions, ['value', ended.value])) {
@@ -161,14 +161,14 @@ function PublisherSectionMerge({
 		<div>
 			<MergeField
 				currentValue={typeValue}
-				label={translate('common:type')}
+				label={translate('common.type')}
 				options={typeOptions}
 				onChange={onTypeChange}
 			/>
 			<MergeField
 				components={{Option: LinkedEntitySelect, SingleValue: EntitySelect}}
 				currentValue={areaValue}
-				label={translate('common:area')}
+				label={translate('common.area')}
 				options={areaOptions}
 				onChange={onAreaChange}
 			/>
@@ -176,13 +176,13 @@ function PublisherSectionMerge({
 				currentValue={formattedBeginDateValue}
 				error={!isValidBeginDate}
 				errorMessage={errorMessageBeginDate}
-				label={translate('publisherSection.dateFounded')}
+				label={translate('entityEditor.publisherSection.dateFounded')}
 				options={beginDateOptions}
 				onChange={onBeginDateChange}
 			/>
 			<MergeField
 				currentValue={endedChecked}
-				label={translate('shared.dissolvedLabel')}
+				label={translate('entityEditor.shared.dissolvedLabel')}
 				options={endedOptions}
 				onChange={onEndedChange}
 			/>
@@ -191,7 +191,7 @@ function PublisherSectionMerge({
 					currentValue={formattedEndDateValue}
 					error={!isValidEndDate}
 					errorMessage={errorMessageEndDate}
-					label={translate('publisherSection.dateDissolved')}
+					label={translate('entityEditor.publisherSection.dateDissolved')}
 					options={endDateOptions}
 					onChange={onEndDateChange}
 				/>

--- a/src/client/entity-editor/publisher-section/publisher-section.tsx
+++ b/src/client/entity-editor/publisher-section/publisher-section.tsx
@@ -124,7 +124,7 @@ function PublisherSection({
 	onEndedChange,
 	onTypeChange
 }: Props) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const publisherTypesForDisplay = publisherTypes.map((type) => ({
 		label: type.label,
 		value: type.id
@@ -132,7 +132,7 @@ function PublisherSection({
 	const typeOption = publisherTypesForDisplay.filter((el) => el.value === typeValue);
 	const {isValid: isValidBeginDate, errorMessage: errorMessageBeginDate} = validatePublisherSectionBeginDate(beginDateValue);
 	const {isValid: isValidEndDate, errorMessage: errorMessageEndDate} = validatePublisherSectionEndDate(beginDateValue, endDateValue, endedChecked);
-	const heading = <h2>{translate('shared.entityHeading', {entity: 'Publisher'})}</h2>;
+	const heading = <h2>{translate('entityEditor.shared.entityHeading', {entity: 'Publisher'})}</h2>;
 	const lgCol = {offset: 3, span: 6};
 	if (isUnifiedForm) {
 		lgCol.offset = 0;
@@ -141,12 +141,12 @@ function PublisherSection({
 		<div>
 			{!isUnifiedForm && heading}
 			<p className="text-muted">
-				{translate('shared.allFieldsOptional')}
+				{translate('entityEditor.shared.allFieldsOptional')}
 			</p>
 			<Row>
 				<Col lg={lgCol}>
 					<Form.Group>
-						<Form.Label>{translate('common:type')}</Form.Label>
+						<Form.Label>{translate('common.type')}</Form.Label>
 						<Select
 							isClearable
 							classNamePrefix="react-select"
@@ -162,9 +162,9 @@ function PublisherSection({
 				<Col lg={lgCol}>
 					<EntitySearchFieldOption
 						instanceId="area"
-						label={translate('common:area')}
+						label={translate('common.area')}
 						recentlyUsedEntityType="Area"
-						tooltipText={translate('publisherSection.areaTooltip')}
+						tooltipText={translate('entityEditor.publisherSection.areaTooltip')}
 						type="area"
 						value={areaValue}
 						onChange={onAreaChange}
@@ -179,7 +179,7 @@ function PublisherSection({
 						empty={isNullDate(beginDateValue)}
 						error={!isValidBeginDate}
 						errorMessage={errorMessageBeginDate}
-						label={translate('publisherSection.dateFounded')}
+						label={translate('entityEditor.publisherSection.dateFounded')}
 						placeholder="YYYY-MM-DD"
 						onChangeDate={onBeginDateChange}
 					/>
@@ -188,7 +188,7 @@ function PublisherSection({
 			<div className={`${!isUnifiedForm && 'text-center'}`}>
 				<Form.Check
 					defaultChecked={endedChecked}
-					label={translate('shared.dissolvedLabel')}
+					label={translate('entityEditor.shared.dissolvedLabel')}
 					type="checkbox"
 					onChange={onEndedChange}
 				/>
@@ -203,7 +203,7 @@ function PublisherSection({
 								empty={isNullDate(endDateValue)}
 								error={!isValidEndDate}
 								errorMessage={errorMessageEndDate}
-								label={translate('publisherSection.dateDissolved')}
+								label={translate('entityEditor.publisherSection.dateDissolved')}
 								placeholder="YYYY-MM-DD"
 								onChangeDate={onEndDateChange}
 							/>

--- a/src/client/entity-editor/relationship-editor/attributes.js
+++ b/src/client/entity-editor/relationship-editor/attributes.js
@@ -25,13 +25,13 @@ import {useTranslation} from 'react-i18next';
 export function NumberAttribute({
 	onHandleChange, value
 }) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	return (
 	    <>
-			<Form.Label>{translate('common:number')}</Form.Label>
+			<Form.Label>{translate('common.number')}</Form.Label>
 			<input
 				className="form-control"
-				placeholder={translate('relationshipAttribute.numberPlaceholder')}
+				placeholder={translate('entityEditor.relationshipAttribute.numberPlaceholder')}
 				type="text"
 				value={value || ''}
 				onChange={onHandleChange}

--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -350,7 +350,7 @@ class RelationshipModal
 		const typesForDisplay = types.map(_.startCase);
 		const lastType = _.last(typesForDisplay);
 		const otherTypes = _.join(typesForDisplay.slice(0, -1), ', ');
-		const label = translate('relationshipModal.targetLabelList', {
+		const label = translate('entityEditor.relationshipModal.targetLabelList', {
 			types: otherTypes.length ? `${otherTypes} or ${lastType}` : lastType
 		});
 
@@ -360,7 +360,7 @@ class RelationshipModal
 				disabled={!targetEntity}
 				href={link}
 				target="_blank"
-				title={translate('common:openNewTab')}
+				title={translate('common.openNewTab')}
 				variant="info"
 			>
 				<FontAwesomeIcon icon={faExternalLinkAlt}/>
@@ -428,7 +428,7 @@ class RelationshipModal
 		// We are disabling this rule because we are already sanitizing the html here
 		return (
 			<Form.Group>
-				<Form.Label>{translate('common:Relationship')}</Form.Label>
+				<Form.Label>{translate('common.Relationship')}</Form.Label>
 				<ReactSelect
 					classNamePrefix="react-select"
 					components={{Option: RelationshipSelect, SingleValue: RelationshipSelect}}
@@ -468,19 +468,19 @@ class RelationshipModal
 			return (
 				<Modal show size="lg" onHide={onClose}>
 					<Modal.Header>
-						<Modal.Title>{translate('shared.addRelationship')}</Modal.Title>
+						<Modal.Title>{translate('entityEditor.shared.addRelationship')}</Modal.Title>
 					</Modal.Header>
 					<Modal.Body>
 						<p>
 							<strong>
-								{translate('relationshipModal.noRelationshipsPossible', {
+								{translate('entityEditor.relationshipModal.noRelationshipsPossible', {
 									entityType: baseEntityTypeForDisplay
 								})}
 							</strong>
 						</p>
 					</Modal.Body>
 					<Modal.Footer>
-						<Button variant="danger" onClick={onCancel}>{translate('common:button.cancel')}</Button>
+						<Button variant="danger" onClick={onCancel}>{translate('common.button.cancel')}</Button>
 					</Modal.Footer>
 				</Modal>
 			);
@@ -489,17 +489,17 @@ class RelationshipModal
 		return (
 			<Modal show size="lg" onHide={onClose} onKeyUp={this.handleKeyPress}>
 				<Modal.Header>
-					<Modal.Title>{translate('shared.addRelationship')}</Modal.Title>
+					<Modal.Title>{translate('entityEditor.shared.addRelationship')}</Modal.Title>
 				</Modal.Header>
 				<Modal.Body>
 					<p>
 						<strong>
-							{translate('relationshipModal.introText', {
+							{translate('entityEditor.relationshipModal.introText', {
 								entityType: baseEntityTypeForDisplay
 							})}
 						</strong>
 						{' '}
-						{translate('relationshipModal.exampleText')}
+						{translate('entityEditor.relationshipModal.exampleText')}
 					</p>
 					<hr/>
 					<Row>
@@ -528,7 +528,7 @@ class RelationshipModal
 					</Container>
 					<Button variant="danger" onClick={onCancel}>
 						<FontAwesomeIcon icon={faTimes}/>
-						<span>&nbsp;{translate('common:button.cancel')}</span>
+						<span>&nbsp;{translate('common.button.cancel')}</span>
 					</Button>
 					<Button
 						disabled={submitDisabled}
@@ -536,7 +536,7 @@ class RelationshipModal
 						onClick={this.handleAdd}
 					>
 						<FontAwesomeIcon icon={faPlus}/>
-						<span>&nbsp;{translate('common:button.add')}</span>
+						<span>&nbsp;{translate('common.button.add')}</span>
 					</Button>
 				</Modal.Footer>
 			</Modal>
@@ -544,4 +544,4 @@ class RelationshipModal
 	}
 }
 
-export default withTranslation(['entityEditor', 'common'])(RelationshipModal);
+export default withTranslation()(RelationshipModal);

--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -428,7 +428,7 @@ class RelationshipModal
 		// We are disabling this rule because we are already sanitizing the html here
 		return (
 			<Form.Group>
-				<Form.Label>{translate('common.Relationship')}</Form.Label>
+				<Form.Label>{translate('common.relationship')}</Form.Label>
 				<ReactSelect
 					classNamePrefix="react-select"
 					components={{Option: RelationshipSelect, SingleValue: RelationshipSelect}}

--- a/src/client/entity-editor/relationship-editor/relationship-section.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-section.tsx
@@ -63,7 +63,7 @@ type RelationshipListProps = {
 export function RelationshipList(
 	{contextEntity, relationships, onEdit, onRemove}: RelationshipListProps
 ) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	/* eslint-disable react/jsx-no-bind */
 	const renderedRelationships = _.map(
 		relationships,
@@ -92,7 +92,7 @@ export function RelationshipList(
 									onClick={onEdit.bind(this, rowID)}
 								>
 									<FontAwesomeIcon icon={faPencilAlt}/>
-									<span>&nbsp;{translate('common:button.edit')}</span>
+									<span>&nbsp;{translate('common.button.edit')}</span>
 								</Button>
 							}
 							{onRemove &&
@@ -104,7 +104,7 @@ export function RelationshipList(
 									onClick={onRemove.bind(this, rowID)}
 								>
 									<FontAwesomeIcon icon={faTimes}/>
-									<span>&nbsp;{translate('common:button.remove')}</span>
+									<span>&nbsp;{translate('common.button.remove')}</span>
 								</Button>
 							}
 						</div>
@@ -152,7 +152,7 @@ function RelationshipSection({
 	relationshipEditorProps, relationshipTypes, onAddRelationship,
 	onEditorClose, onEditorAdd, onEdit, onRemove, onUndo, undoPossible
 }: Props) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const baseEntity = {
 		bbid: _.get(entity, 'bbid'),
 		defaultAlias: {
@@ -201,7 +201,7 @@ function RelationshipSection({
 		<div>
 			{canEdit && showEditor && editor}
 			<h2>
-				{translate('relationshipSection.heading', {
+				{translate('entityEditor.relationshipSection.heading', {
 					entityType: _.startCase(entityType)
 				})}
 			</h2>
@@ -226,7 +226,7 @@ function RelationshipSection({
 							onClick={onAddRelationship}
 						>
 							<FontAwesomeIcon icon={faPlus}/>
-							<span>&nbsp;{translate('shared.addRelationship')}</span>
+							<span>&nbsp;{translate('entityEditor.shared.addRelationship')}</span>
 						</Button>
 					</Col>
 				</Row>
@@ -241,7 +241,7 @@ function RelationshipSection({
 							onClick={onUndo}
 						>
 							<FontAwesomeIcon icon={faUndo}/>
-							<span>&nbsp;{translate('relationshipEditor.undoLastAction')}</span>
+							<span>&nbsp;{translate('entityEditor.relationshipEditor.undoLastAction')}</span>
 						</Button>
 					</Col>
 				</Row>

--- a/src/client/entity-editor/relationship-editor/relationship.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship.tsx
@@ -39,7 +39,7 @@ function getEntityObjectForDisplay(entity: _Entity, makeLink: boolean, translate
 		link,
 		text: _.get(entity, ['defaultAlias', 'name']),
 		type: entity.type,
-		unnamedText: entity.bbid ? translate('common:unnamed') : translate('entityEditor:relationship.newEntity')
+		unnamedText: entity.bbid ? translate('common.unnamed') : translate('entityEditor.relationship.newEntity')
 	};
 }
 
@@ -56,7 +56,7 @@ export {Relationship as RelationshipType};
 type RelationshipProps = Relationship & {Parent?:React.FunctionComponent<any>};
 
 function Relationship({Parent, ...props}: RelationshipProps) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const {contextEntity, link, relationshipType, sourceEntity, attributes, showAttributes, targetEntity, ...rest} = props;
 	const {depth, description, id, linkPhrase, reverseLinkPhrase} = relationshipType;
 

--- a/src/client/entity-editor/series-section/series-editor.tsx
+++ b/src/client/entity-editor/series-section/series-editor.tsx
@@ -85,7 +85,7 @@ type SeriesItemsProps = {
  */
 
 const SeriesListItem = ({value, baseEntity, handleNumberAttributeChange, onRemove, dragHandler, isUnifiedForm}) => {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	return (
 		<Row className={`margin-top-d5 ${isUnifiedForm ? 'w-100 align-items-center' : ''}`} key={value.rowID}>
 			{(!isUnifiedForm || dragHandler) &&
@@ -95,7 +95,7 @@ const SeriesListItem = ({value, baseEntity, handleNumberAttributeChange, onRemov
 			<Col lg={2}>
 				<input
 					className="form-control"
-					placeholder={translate('seriesEditor.placeholder')}
+					placeholder={translate('entityEditor.seriesEditor.placeholder')}
 					type="text"
 					value={_.find(value.attributes, {attributeType: 2})?.value.textValue || ''}
 					onChange={handleNumberAttributeChange.bind(this, value.rowID)}
@@ -117,7 +117,7 @@ const SeriesListItem = ({value, baseEntity, handleNumberAttributeChange, onRemov
 					onClick={onRemove.bind(this, value.rowID)}
 				>
 					<FontAwesomeIcon icon={faTimes}/>
-					<span>&nbsp;{translate('common:button.remove')}</span>
+					<span>&nbsp;{translate('common.button.remove')}</span>
 				</Button>
 			</Col>
 		</Row>
@@ -149,7 +149,7 @@ const SortableList = SortableContainer(({children}) => <div>{children}</div>);
 function SeriesEditor({baseEntity, relationshipTypes, seriesType, orderType, onRemove, hideItemSelect,
 	onAdd, onEdit, onSort, seriesItemsArray, isUnifiedForm}:SeriesItemsProps) {
 	const [seriesItem, setSeriesItem] = useState(null);
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const [targetEntity, setTargetEntity] = useState(null);
 
 	const handleEntityChange = (value: EntitySearchResult) => {
@@ -202,7 +202,7 @@ function SeriesEditor({baseEntity, relationshipTypes, seriesType, orderType, onR
 		onEdit(attributeNumber, rowID);
 		onSort({newIndex: null, oldIndex: null});
 	};
-	const heading = <h2>{translate('seriesEditor.heading', {seriesType: `${seriesType}s`})}</h2>;
+	const heading = <h2>{translate('entityEditor.seriesEditor.heading', {seriesType: `${seriesType}s`})}</h2>;
 	const alignText = isUnifiedForm ? 'text-left' : 'text-right';
 	return (
 		<div>
@@ -218,8 +218,8 @@ function SeriesEditor({baseEntity, relationshipTypes, seriesType, orderType, onR
 									handleNumberAttributeChange={handleNumberAttributeChange}
 									isUnifiedForm={isUnifiedForm}
 									key={value.rowID}
-									placeholder={translate('seriesEditor.placeholder')}
-									removeButtonText={translate('common:button.remove')}
+									placeholder={translate('entityEditor.seriesEditor.placeholder')}
+									removeButtonText={translate('common.button.remove')}
 									value={value}
 									onRemove={onRemove}
 								/>
@@ -234,8 +234,8 @@ function SeriesEditor({baseEntity, relationshipTypes, seriesType, orderType, onR
 									index={index}
 									isUnifiedForm={isUnifiedForm}
 									key={value.rowID}
-									placeholder={translate('seriesEditor.placeholder')}
-									removeButtonText={translate('common:button.remove')}
+									placeholder={translate('entityEditor.seriesEditor.placeholder')}
+									removeButtonText={translate('common.button.remove')}
 									value={value}
 									onRemove={onRemove}
 								/>
@@ -247,7 +247,7 @@ function SeriesEditor({baseEntity, relationshipTypes, seriesType, orderType, onR
 			{!hideItemSelect &&
 			<Row className="margin-top-d8">
 				<Col className={alignText} lg={isUnifiedForm ? 7 : 3}>
-					<p className="margin-top-d5">{translate('seriesEditor.addEntityPrompt')}</p>
+					<p className="margin-top-d5">{translate('entityEditor.seriesEditor.addEntityPrompt')}</p>
 				</Col>
 				<Col lg={isUnifiedForm ? 6 : 7} style={{marginTop: -22}}>
 					<EntitySearchFieldOption
@@ -263,7 +263,7 @@ function SeriesEditor({baseEntity, relationshipTypes, seriesType, orderType, onR
 				<Col lg={isUnifiedForm ? 7 : 2}>
 					<Button variant="success" onClick={handleAdd}>
 						<FontAwesomeIcon icon={faPlus}/>
-						<span>&nbsp;{translate('seriesEditor.addButton', {seriesType})}</span>
+						<span>&nbsp;{translate('entityEditor.seriesEditor.addButton', {seriesType})}</span>
 					</Button>
 				</Col>
 			</Row>

--- a/src/client/entity-editor/series-section/series-section-merge.tsx
+++ b/src/client/entity-editor/series-section/series-section-merge.tsx
@@ -68,7 +68,7 @@ function SeriesSectionMerge({
 	onOrderTypeChange,
 	onSeriesTypeChange
 }: Props) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const seriesOrderingTypeOptions = [];
 	const seriesTypeOptions = [];
 	const relationships = [];
@@ -108,13 +108,13 @@ function SeriesSectionMerge({
 		<div>
 			<MergeField
 				currentValue={orderTypeValue}
-				label={translate('seriesSection.orderingTypeLabel')}
+				label={translate('entityEditor.seriesSection.orderingTypeLabel')}
 				options={seriesOrderingTypeOptions}
 				onChange={onOrderTypeChange}
 			/>
 			<MergeField
 				currentValue={seriesTypeValue}
-				label={translate('seriesSection.seriesTypeLabel')}
+				label={translate('entityEditor.seriesSection.seriesTypeLabel')}
 				options={seriesTypeOptions}
 				onChange={onSeriesTypeChange}
 			/>

--- a/src/client/entity-editor/series-section/series-section.tsx
+++ b/src/client/entity-editor/series-section/series-section.tsx
@@ -116,7 +116,7 @@ function SeriesSection({
 	isUnifiedForm,
 	seriesTypeValue
 }: Props) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 
 	const baseEntity = {
 		bbid: _.get(entity, 'bbid'),
@@ -164,15 +164,15 @@ function SeriesSection({
 	const seriesTypeOption = seriesTypesForDisplay.filter((el) => el.value === seriesTypeValue);
 	const orderingTooltip = (
 		<Tooltip>
-			{translate('seriesSection.orderingTypeTooltip')}
+			{translate('entityEditor.seriesSection.orderingTypeTooltip')}
 		</Tooltip>
 	);
 	const seriesTypeTooltip = (
 		<Tooltip>
-			{translate('seriesSection.seriesTypeTooltip')}
+			{translate('entityEditor.seriesSection.seriesTypeTooltip')}
 		</Tooltip>
 	);
-	const heading = <h2>{translate('shared.entityHeading', {entity: 'Series'})}</h2>;
+	const heading = <h2>{translate('entityEditor.shared.entityHeading', {entity: 'Series'})}</h2>;
 	const lgCol = {offset: 3, span: 6};
 	if (isUnifiedForm) {
 		lgCol.offset = 0;
@@ -182,13 +182,13 @@ function SeriesSection({
 			{!isUnifiedForm && heading}
 			{!hideItemSelect &&
 			<p className="text-muted">
-				{translate('seriesSection.allFieldsMandatory')}
+				{translate('entityEditor.seriesSection.allFieldsMandatory')}
 			</p>}
 			<Row>
 				<Col lg={lgCol}>
 					<Form.Group>
 						<Form.Label>
-							{translate('seriesSection.orderingTypeLabel')}
+							{translate('entityEditor.seriesSection.orderingTypeLabel')}
 							<OverlayTrigger delay={50} overlay={orderingTooltip}>
 								<FontAwesomeIcon
 									className="margin-left-0-5"
@@ -209,7 +209,7 @@ function SeriesSection({
 					{!isUnifiedForm &&
 					<Form.Group>
 						<Form.Label>
-							{translate('seriesSection.seriesTypeLabel')}
+							{translate('entityEditor.seriesSection.seriesTypeLabel')}
 							<OverlayTrigger delay={50} overlay={seriesTypeTooltip}>
 								<FontAwesomeIcon
 									className="margin-left-0-5"

--- a/src/client/entity-editor/submission-section/submission-section.js
+++ b/src/client/entity-editor/submission-section/submission-section.js
@@ -51,27 +51,27 @@ function SubmissionSection({
 	onNoteChange,
 	submitted
 }) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const errorAlertClass =
 		classNames('text-center', 'margin-top-1', {'d-none': !errorText});
 
 	const editNoteLabel = (
 		<span>
-			{translate('submissionSection.editNoteLabel')}
-			<span className="text-muted"> {translate('shared.optionalLabel')}</span>
+			{translate('entityEditor.submissionSection.editNoteLabel')}
+			<span className="text-muted"> {translate('entityEditor.shared.optionalLabel')}</span>
 		</span>
 	);
 
 	const tooltip = (
 		<Tooltip>
-			{translate('submissionSection.editNoteTooltip')}
+			{translate('entityEditor.submissionSection.editNoteTooltip')}
 		</Tooltip>
 	);
 
 	return (
 		<div>
 			<h2>
-				{translate('submissionSection.heading')}
+				{translate('entityEditor.submissionSection.heading')}
 			</h2>
 			<Row>
 				<Col lg={{offset: 3, span: 6}}>
@@ -88,7 +88,7 @@ function SubmissionSection({
 						<Form.Control as="textarea" defaultValue={note} rows="6" onChange={onNoteChange}/>
 					</Form.Group>
 					<p className="text-muted">
-						{translate('submissionSection.editNoteHelp')}
+						{translate('entityEditor.submissionSection.editNoteHelp')}
 					</p>
 				</Col>
 			</Row>
@@ -106,11 +106,11 @@ function SubmissionSection({
 						role="status"
 						size="sm"
 					/>}
-					 {submitted ? ` ${translate('submissionSection.submitButton')}` : translate('submissionSection.submitButton')}
+					 {submitted ? ` ${translate('entityEditor.submissionSection.submitButton')}` : translate('entityEditor.submissionSection.submitButton')}
 				</Button>
 			</div>
 			<div className={errorAlertClass}>
-				<Alert variant="danger">{translate('submissionSection.submissionError', {errorText})}</Alert>
+				<Alert variant="danger">{translate('entityEditor.submissionSection.submissionError', {errorText})}</Alert>
 			</div>
 		</div>
 	);

--- a/src/client/entity-editor/work-section/work-section-merge.tsx
+++ b/src/client/entity-editor/work-section/work-section-merge.tsx
@@ -75,7 +75,7 @@ function WorkSectionMerge({
 	typeValue,
 	onTypeChange
 }: Props) {
-	const {t: translate} = useTranslation(['entityEditor', 'common']);
+	const {t: translate} = useTranslation();
 	const typeOptions = [];
 
 	mergingEntities.forEach(entity => {
@@ -89,12 +89,12 @@ function WorkSectionMerge({
 		<div>
 			<MergeField
 				currentValue={typeValue}
-				label={translate('common:type')}
+				label={translate('common.type')}
 				options={typeOptions}
 				onChange={onTypeChange}
 			/>
 			<Form.Group>
-				<Form.Label>{translate('common:languages')}</Form.Label>
+				<Form.Label>{translate('common.languages')}</Form.Label>
 				<Select
 					isDisabled
 					isMulti

--- a/src/client/entity-editor/work-section/work-section.tsx
+++ b/src/client/entity-editor/work-section/work-section.tsx
@@ -148,7 +148,7 @@ function WorkSection({
 	onLanguagesChange,
 	onTypeChange
 }: Props) {
-	const {t: translate} = useTranslation('entityEditor');
+	const {t: translate} = useTranslation();
 	const languageOptionsForDisplay = languageOptions.map((language) => ({
 		frequency: language.frequency,
 		label: language.name,
@@ -160,10 +160,10 @@ function WorkSection({
 	const selectedTypeOption:WorkType = workTypesForDisplay.find((el) => el.id === typeValue);
 	const tooltip = (
 		<Tooltip id="work-type-tooltip">
-			{translate('workSection.typeTooltip')}
+			{translate('entityEditor.workSection.typeTooltip')}
 		</Tooltip>
 	);
-	const heading = <h2>{translate('shared.entityHeading', {entity: 'Work'})}</h2>;
+	const heading = <h2>{translate('entityEditor.shared.entityHeading', {entity: 'Work'})}</h2>;
 	const lgCol = {offset: 3, span: 6};
 	if (isUnifiedForm) {
 		lgCol.offset = 0;
@@ -172,13 +172,13 @@ function WorkSection({
 		<div>
 			{!isUnifiedForm && heading}
 			<p className="text-muted">
-				{translate('shared.allFieldsOptional')}
+				{translate('entityEditor.shared.allFieldsOptional')}
 			</p>
 			<Row>
 				<Col lg={lgCol}>
 					<Form.Group>
 						<Form.Label>
-							{translate('common:type')}
+							{translate('common.type')}
 							<OverlayTrigger delay={50} overlay={tooltip}>
 								<FontAwesomeIcon
 									className="margin-left-0-5"
@@ -213,7 +213,7 @@ function WorkSection({
 						isMulti
 						instanceId="language"
 						options={languageOptionsForDisplay}
-						tooltipText={translate('workSection.languageTooltip')}
+						tooltipText={translate('entityEditor.workSection.languageTooltip')}
 						value={languageValues}
 						onChange={onLanguagesChange}
 					/>

--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -70,20 +70,20 @@ export function labelsForAuthor(isGroup: boolean, translate?: any) {
 	if (translate) {
 		return {
 			beginAreaLabel: isGroup ?
-				translate('entityEditor:authorSection.beginAreaLabel.group') :
-				translate('entityEditor:authorSection.beginAreaLabel.person'),
+				translate('entityEditor.authorSection.beginAreaLabel.group') :
+				translate('entityEditor.authorSection.beginAreaLabel.person'),
 			beginDateLabel: isGroup ?
-				translate('entityEditor:authorSection.beginDateLabel.group') :
-				translate('entityEditor:authorSection.beginDateLabel.person'),
+				translate('entityEditor.authorSection.beginDateLabel.group') :
+				translate('entityEditor.authorSection.beginDateLabel.person'),
 			endAreaLabel: isGroup ?
-				translate('entityEditor:authorSection.endAreaLabel.group') :
-				translate('entityEditor:authorSection.endAreaLabel.person'),
+				translate('entityEditor.authorSection.endAreaLabel.group') :
+				translate('entityEditor.authorSection.endAreaLabel.person'),
 			endDateLabel: isGroup ?
-				translate('entityEditor:authorSection.endDateLabel.group') :
-				translate('entityEditor:authorSection.endDateLabel.person'),
+				translate('entityEditor.authorSection.endDateLabel.group') :
+				translate('entityEditor.authorSection.endDateLabel.person'),
 			endedLabel: isGroup ?
-				translate('entityEditor:shared.dissolvedLabel') :
-				translate('entityEditor:authorSection.endedLabel.person')
+				translate('entityEditor.shared.dissolvedLabel') :
+				translate('entityEditor.authorSection.endedLabel.person')
 		};
 	}
 	return {

--- a/src/client/unified-form/unified-form.tsx
+++ b/src/client/unified-form/unified-form.tsx
@@ -26,7 +26,7 @@ const {Tabs, Tab} = Boostrap;
 export function UnifiedForm(props:UnifiedFormProps) {
 	const {allIdentifierTypes, validator, onSubmit, formValid,
 		languageOptions, contentTabEmpty, coverTabValid, coverTabEmpty, detailTabValid, detailTabEmpty} = props;
-	const rest = omit(props, ['contentTabEmpty', 'coverTabValid', 'coverTabEmpty', 'detailTabValid', 'formValid', 'detailTabEmpty']);
+	const rest = omit(props, ['contentTabEmpty', 'coverTabValid', 'coverTabEmpty', 'detailTabValid', 'formValid', 'detailTabEmpty', 'i18n']);
 	React.useMemo(() => {
 		// without this check, it would cause undefined behaviour
 		if (!freezeObjects.filterOptions) {

--- a/src/common/i18n/i18n.ts
+++ b/src/common/i18n/i18n.ts
@@ -38,11 +38,14 @@ export function createI18n(locale = 'en', resources?) {
 	}
 
 	instance.init({
+		defaultNS: 'translation',
 		fallbackLng: 'en',
 		initAsync: false,
+		keySeparator: '.',
 		lng: locale,
-		ns: ['common', 'entityEditor', 'pages', 'entities', 'errors'],
-		...hasResources ? {resources} : {backend: {loadPath: '/locales/{{lng}}/{{ns}}.json'}}
+		ns: ['translation'],
+		nsSeparator: false,
+		...hasResources ? {resources} : {backend: {loadPath: '/locales/{{lng}}/translation.json'}}
 	});
 
 	return instance;

--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -475,10 +475,10 @@ export async function i18nMiddleware(req: $Request, res: $Response, next: NextFu
 	const preferred = cookieLang ?? headerLang;
 	const locale = availableLocales.includes(preferred) ? preferred : 'en';
 
-	async function load(loc: string, ns: string) {
+	async function load(loc: string) {
 		try {
 			return JSON.parse(await fs.promises.readFile(
-				path.join(process.cwd(), 'public', 'locales', loc, `${ns}.json`), 'utf8'
+				path.join(process.cwd(), 'public', 'locales', loc, 'translation.json'), 'utf8'
 			));
 		}
 		catch {
@@ -486,22 +486,16 @@ export async function i18nMiddleware(req: $Request, res: $Response, next: NextFu
 		}
 	}
 
-	async function loadAllNamespaces(loc: string) {
-		return {
-			common: await load(loc, 'common'),
-			entities: await load(loc, 'entities'),
-			entityEditor: await load(loc, 'entityEditor'),
-			errors: await load(loc, 'errors'),
-			pages: await load(loc, 'pages')
-		};
-	}
-
 	const resources: Record<string, any> = {
-		[locale]: await loadAllNamespaces(locale)
+		[locale]: {
+			translation: await load(locale)
+		}
 	};
 
 	if (locale !== 'en') {
-		resources.en = await loadAllNamespaces('en');
+		resources.en = {
+			translation: await load('en')
+		};
 	}
 
 	res.locals.locale = locale;

--- a/test/src/common/i18n.js
+++ b/test/src/common/i18n.js
@@ -27,24 +27,24 @@ const {expect} = chai;
 describe('createI18n', () => {
 	it('should default to English when no locale is provided', () => {
 		// eslint-disable-next-line no-undefined
-		const i18n = createI18n(undefined, {en: {common: {}}});
+		const i18n = createI18n(undefined, {en: {translation: {}}});
 		expect(i18n.language).to.equal('en');
 	});
 
 	it('should use the specified locale', () => {
-		const i18n = createI18n('fr', {fr: {common: {'test.key': 'Bonjour'}}});
+		const i18n = createI18n('fr', {fr: {translation: {common: {test: {key: 'Bonjour'}}}}});
 		expect(i18n.language).to.equal('fr');
 	});
 
 	it('should use pre-loaded resources for translation', () => {
-		const resources = {en: {common: {'button.submit': 'Submit'}}};
+		const resources = {en: {translation: {common: {button: {submit: 'Submit'}}}}};
 		const i18n = createI18n('en', resources);
-		expect(i18n.t('button.submit', {ns: 'common'})).to.equal('Submit');
+		expect(i18n.t('common.button.submit')).to.equal('Submit');
 	});
 
 	it('should return the key when translation is missing', () => {
-		const i18n = createI18n('en', {en: {common: {}}});
-		expect(i18n.t('nonexistent.key', {ns: 'common'})).to.equal('nonexistent.key');
+		const i18n = createI18n('en', {en: {translation: {}}});
+		expect(i18n.t('common.nonexistent.key')).to.equal('common.nonexistent.key');
 	});
 
 	it('should initialize synchronously for SSR compatibility', () => {
@@ -53,7 +53,7 @@ describe('createI18n', () => {
 				// No-op (needed by i18next backend interface)
 			},
 			read: (lng, ns, callback) => {
-				callback(null, {'sync.test': 'Works'});
+				callback(null, {common: {sync: {test: 'Works'}}});
 			},
 			type: 'backend'
 		};
@@ -65,9 +65,9 @@ describe('createI18n', () => {
 		asyncInstance.init({
 			initAsync: true,
 			lng: 'en',
-			ns: ['common']
+			ns: ['translation']
 		});
-		expect(asyncInstance.t('sync.test', {ns: 'common'})).to.equal('sync.test');
+		expect(asyncInstance.t('common.sync.test')).to.equal('common.sync.test');
 
 		// When initAsync is false, translations load synchronously and are immediately available
 		const syncInstance = createInstance();
@@ -75,12 +75,12 @@ describe('createI18n', () => {
 		syncInstance.init({
 			initAsync: false,
 			lng: 'en',
-			ns: ['common']
+			ns: ['translation']
 		});
-		expect(syncInstance.t('sync.test', {ns: 'common'})).to.equal('Works');
+		expect(syncInstance.t('common.sync.test')).to.equal('Works');
 
 		// Verify our createI18n behaves synchronously
-		const i18n = createI18n('en', {en: {common: {'sync.test': 'Works'}}});
-		expect(i18n.t('sync.test', {ns: 'common'})).to.equal('Works');
+		const i18n = createI18n('en', {en: {translation: {common: {sync: {test: 'Works'}}}}});
+		expect(i18n.t('common.sync.test')).to.equal('Works');
 	});
 });


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to BooknBrainz. We appreciate
    your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/bookbrainz-site/blob/master/CONTRIBUTING.md
    
    Dont skip our AI usage policy if you plan on using AI tooling.
-->

# Problem

Merge the  5 separate translation files (`common.json`, `entityEditor.json`, `pages.json`, `entities.json`, `errors.json`) in one combined translation.json.
 
# Solution

1. **Merged Translation Files**:
   * Consolidated all flat localization files into a single nested `translation.json` structure per locale (`en` and `fr`).
   * Cleaned up the old flat namespace JSON files.

2. **Configuration Updates**:
   * Updated `i18next.config.js` to target `translation.json` with `keySeparator: '.'` and `nsSeparator: false`.
   * Updated runtime config in `src/common/i18n/i18n.ts` and node middleware in `src/server/helpers/middleware.ts` to load the unified translations.

3. **Codebase Migration**:
   * Replaced all occurrences of `useTranslation('namespace')` and `withTranslation('namespace')` with parameterless `useTranslation()` / `withTranslation()` across ~50 component files.
   * Migrated all flat translation keys to the new nested dot-path notation (e.g. `t('button.submit')` to `t('common.button.submit')`).
   * Updated `test/src/common/i18n.js` to reflect the new nested JSON structure and dot-path lookups.


* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

 
# Action

*None.*